### PR TITLE
Users/alsehr/diagnostic changes

### DIFF
--- a/docs/static/includes/interfaces/int.diag.input.bicep
+++ b/docs/static/includes/interfaces/int.diag.input.bicep
@@ -1,6 +1,5 @@
 diagnosticSettings: [
   {
-    retentionInDays: 30
     logCategoriesAndGroups: ['allLogs']
     metricCategories: ['AllMetrics']
     logAnalyticsDestinationType: 'Dedicated'

--- a/docs/static/includes/interfaces/int.diag.input.tf
+++ b/docs/static/includes/interfaces/int.diag.input.tf
@@ -1,6 +1,5 @@
 diagnostic_settings = {
   diag_setting_1 = {
-    retention_in_days = 30
     log_categories_and_groups = ["allLogs"]
     metric_categories = ["AllMetrics"]
     log_analytics_destination_type = "Dedicated"

--- a/docs/static/includes/interfaces/int.diag.schema.bicep.json
+++ b/docs/static/includes/interfaces/int.diag.schema.bicep.json
@@ -5,10 +5,6 @@
   "items": {
     "type": "object",
     "properties": {
-      "retentionInDays": {
-        "type": "integer",
-        "default": 30
-      },
       "logCategoriesAndGroups": {
         "type": "array",
         "items": {

--- a/docs/static/includes/interfaces/int.diag.schema.tf.json
+++ b/docs/static/includes/interfaces/int.diag.schema.tf.json
@@ -5,10 +5,6 @@
   "additionalProperties": {
     "type": "object",
     "properties": {
-      "retention_in_days": {
-        "type": "integer",
-        "default": 30
-      },
       "log_categories_and_groups": {
         "type": "array",
         "items": {


### PR DESCRIPTION
## Description

Removed `retentionInDays` from Diagnostic Interface to account for [breaking changes](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/migrate-to-azure-storage-lifecycle-policy) on the Azure-side. @jtracey93 this may also affect [Terraform](https://github.com/hashicorp/terraform-provider-azurerm/issues/23051).

On the CARML-side we already removed any reference of the RetentionPolicy from our modules.

## This PR fixes/adds/changes/removes

- Removed `retentionInDays` from Diagnostic interface for BICEP.

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
