### PR TITLE
GH Team naming convention AB#29903

### DIFF
--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -169,7 +169,7 @@ Today this is only Microsoft FTEs, but everyone is welcome to contribute. The mo
 
 All GitHub repositories that AVM module are published from and hosted within **MUST** only assign GitHub repository permissions to GitHub teams only.
 
-Each module **MUST** have a separate GitHub Teams assigned for module owners **AND** module contributors respectively. 
+Each module **MUST** have separate GitHub Teams assigned for module owners **AND** module contributors respectively. 
 
 There **MUST NOT** be any GitHub repository permissions assigned to individual users.
 

--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -167,9 +167,29 @@ Today this is only Microsoft FTEs, but everyone is welcome to contribute. The mo
 
 #### ID: SNFR20 - Category: Contribution/Support - GitHub Teams Only
 
-All GitHub repositories that AVM module are published from and hosted withing **MUST** only assign GitHub repository permissions to GitHub teams only.
+All GitHub repositories that AVM module are published from and hosted within **MUST** only assign GitHub repository permissions to GitHub teams only.
 
-They **MUST NOT** assign any GitHub repository permissions to individual users.
+Each module **MUST** have a separate GitHub Teams assigned for module owners **AND** module contributors respectively. 
+
+There **MUST NOT** be any GitHub repository permissions assigned to individual users.
+
+The naming convention for the GitHub Teams **MUST** follow the below pattern:
+- `@azure/<module name>-module-owners-<bicep/tf>` - to be assigned as the GitHub repository's `Module Owners` team
+- `@azure/<module name>-module-contributors-<bicep/tf>` - to be assigned as the GitHub repository's `Module Contributors` team
+
+Segments:
+
+- `@azure` == the GitHub organization the AVM repository exists in
+- `<module name>` == the AVM Module's name
+  - See [RMNFR1](#id-rmnfr1---category-naming---module-naming) for AVM Resource Module Naming
+  - See [PMNFR1](#id-pmnfr1---category-naming---module-naming) for AVM Pattern Module Naming
+- `module-owners` or `module-contributors` == the role the GitHub Team is assigned to
+- `<bicep/tf>` == the language the module is written in
+
+Examples:
+
+- `@azure/avm-res-compute-virtualmachine-module-owners-bicep`
+- `@azure/avm-res-compute-virtualmachine-module-contributors-tf`
 
 #### ID: SNFR9 - Category: Contribution/Support - AVM & PG Teams GitHub Repo Permissions
 

--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -169,7 +169,7 @@ Today this is only Microsoft FTEs, but everyone is welcome to contribute. The mo
 
 All GitHub repositories that AVM module are published from and hosted within **MUST** only assign GitHub repository permissions to GitHub teams only.
 
-Each module **MUST** have separate GitHub Teams assigned for module owners **AND** module contributors respectively. 
+Each module **MUST** have separate GitHub Teams assigned for module owners **AND** module contributors respectively.
 
 There **MUST NOT** be any GitHub repository permissions assigned to individual users.
 


### PR DESCRIPTION

# Overview/Summary

Added naming convention for GH teams representing module owners and contributors.

## This PR fixes/adds/changes/removes

see above

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
