### PR TITLE
Remove note about Bicep user defined types being preview

### DIFF
--- a/docs/content/specs/bicep/_index.md
+++ b/docs/content/specs/bicep/_index.md
@@ -56,7 +56,7 @@ To simplify the consumption experience for module consumers when interacting wit
 
 {{< hint type=tip >}}
 
-User-Defined Types are GA in Bicep as of version v0.21.1, please ensure you have this version installed as a minimum. 
+User-Defined Types are GA in Bicep as of version v0.21.1, please ensure you have this version installed as a minimum.
 
 {{< /hint >}}
 

--- a/docs/content/specs/bicep/_index.md
+++ b/docs/content/specs/bicep/_index.md
@@ -54,6 +54,12 @@ Review the [Bicep Contribution Guide's 'RBAC Role Definition Name Mapping' secti
 
 To simplify the consumption experience for module consumers when interacting with complex data types input parameters, mainly objects and arrays, the Bicep feature of [User-Defined Types](https://learn.microsoft.com/azure/azure-resource-manager/bicep/user-defined-data-types) **MUST** be used and declared.
 
+{{< hint type=tip >}}
+
+User-Defined Types are GA in Bicep as of version v0.21.1, please ensure you have this version installed as a minimum. 
+
+{{< /hint >}}
+
 [User-Defined Types](https://learn.microsoft.com/azure/azure-resource-manager/bicep/user-defined-data-types) allow intellisense support in supported IDEs (e.g. Visual Studio Code) for complex input parameters using arrays and objects.
 
 {{< hint type=important title="CARML Migration Exemption" >}}

--- a/docs/content/specs/bicep/_index.md
+++ b/docs/content/specs/bicep/_index.md
@@ -54,14 +54,6 @@ Review the [Bicep Contribution Guide's 'RBAC Role Definition Name Mapping' secti
 
 To simplify the consumption experience for module consumers when interacting with complex data types input parameters, mainly objects and arrays, the Bicep feature of [User-Defined Types](https://learn.microsoft.com/azure/azure-resource-manager/bicep/user-defined-data-types) **MUST** be used and declared.
 
-{{< hint type=note >}}
-
-The AVM team are aware that to use [User-Defined Types](https://learn.microsoft.com/azure/azure-resource-manager/bicep/user-defined-data-types) at this time, August 2023, you must [enable the preview feature via the `bicepconfig.json`](https://learn.microsoft.com/azure/azure-resource-manager/bicep/user-defined-data-types#enable-the-preview-feature).
-
-This is only planned to be temporary and will be made part of the default features enabled in a upcoming release of Bicep very soon.
-
-{{< /hint >}}
-
 [User-Defined Types](https://learn.microsoft.com/azure/azure-resource-manager/bicep/user-defined-data-types) allow intellisense support in supported IDEs (e.g. Visual Studio Code) for complex input parameters using arrays and objects.
 
 {{< hint type=important title="CARML Migration Exemption" >}}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Bicep user defined types are [GA since v0.21](https://github.com/Azure/bicep/releases/tag/v0.21.1) 🥳 

## This PR fixes/adds/changes/removes

1. Remove outdated note from Bicep specs

### Breaking Changes

N/A

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
