### PR TITLE
RP Collaboration: internal wiki URL added

### DIFF
--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -755,7 +755,7 @@ A module **SHOULD** use the following standard inputs:
 
 Module owners (Microsoft FTEs) **SHOULD** reach out to the respective Resource Provider teams to build a partnership and collaboration on the modules creation, existence and long term maintenance.
 
-Review this [wiki page (TBC)](/Azure-Verified-Modules/specs/shared/#id-rmnfr3---category-composition---rp-collaboration) for more information.
+Review this [wiki page (Microsoft Internal)](https://dev.azure.com/CSUSolEng/Azure%20Verified%20Modules/_wiki/wikis/AVM%20Internal%20Wiki/276/RP-Collaboration) for more information.
 
 <br>
 


### PR DESCRIPTION
# Overview/Summary

Added internal wiki URL for the RP Collaboration specs.

## This PR fixes/adds/changes/removes

see above

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
