### PR TITLE
Add nullable = false to prevent precondition to fail

### DIFF
--- a/docs/static/includes/interfaces/int.diag.schema.tf
+++ b/docs/static/includes/interfaces/int.diag.schema.tf
@@ -10,7 +10,8 @@ variable "diagnostic_settings" {
     event_hub_name                           = optional(string, null)
     marketplace_partner_resource_id          = optional(string, null)
   }))
-  default = {}
+  default  = {}
+  nullable = false
 
   validation {
     condition     = alltrue([for _, v in var.diagnostic_settings : contains(["Dedicated", "AzureDiagnostics"], v.log_analytics_destination_type)])


### PR DESCRIPTION
Line 17 var.diagnostic_settings could be null and the condition would fail. nullable = false would force the default value to be set to "{}" if null is sent

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. Add a condition in the variable template to prevent the variable to be null and default it to the default value


### Breaking Changes

1. no

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
