### PR TITLE
render links in module indexes

### DIFF
--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -18,7 +18,7 @@
   {{ end }}
   {{ range $row, $rows }}
   <tr>
-    <td>{{ if $useLinks }} {{ if eq (index $row 4) "Done" }} <a href="{{ index $row 5 }}">{{ index $row 3 }}</a> {{ else }} {{ index $row 3 }} {{ end }} {{else}} {{ index $row 3 }} {{ end }} </td>
+    <td>{{ if $useLinks }} {{ if or (eq (index $row 4) "Module Available :green_circle:") (eq (index $row 4) "Module Orphaned :eyes:") }} <a href="{{ index $row 5 }}">{{ index $row 3 }}</a> {{ else }} {{ index $row 3 }} {{ end }} {{else}} {{ index $row 3 }} {{ end }} </td>
     <td>{{ index $row 2 }}</td>
     <td>{{ emojify (index $row 4) }}</td>
     <td>{{ index $row 8 }} {{ if and (ne (index $row 8) "") (ne (index $row 9) "") }} ({{ index $row 9 }}){{ end }}</td>

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -2,6 +2,7 @@
 {{ $csv := .Get "csv" }}
 {{ $file := readFile $csv }}
 {{ $rows := $file | transform.Unmarshal (dict "delimiter" ",") }}
+{{ $useLinks := .Get "useLinks" | default true }}
 <table>
   {{ if $useHeaderRow }}
   {{ $headerRow := index $rows 0 }}
@@ -17,7 +18,7 @@
   {{ end }}
   {{ range $row, $rows }}
   <tr>
-    <td>{{ index $row 3 }}</td>
+    <td>{{ if $useLinks }} {{ if eq (index $row 4) "Done" }} <a href="{{ index $row 5 }}">{{ index $row 3 }}</a> {{ else }} {{ index $row 3 }} {{ end }} {{else}} {{ index $row 3 }} {{ end }} </td>
     <td>{{ index $row 2 }}</td>
     <td>{{ emojify (index $row 4) }}</td>
     <td>{{ index $row 8 }} {{ if and (ne (index $row 8) "") (ne (index $row 9) "") }} ({{ index $row 9 }}){{ end }}</td>

--- a/docs/static/governance/avm-standard-github-labels.csv
+++ b/docs/static/governance/avm-standard-github-labels.csv
@@ -18,6 +18,7 @@ Status: Wont Fix :-1:,This will not be worked on,ffffff
 Status: Migrate from CARML :articulated_lorry:,This item is related to a module migration from CARML,00796F
 Status: Migrate from TFVM :articulated_lorry:,This item is related to a module migration from TFVM,00796F
 Status: Owners Identified :metal:,This module has its owners identified,FBEF2A
+Status: Module Available :green_circle:,The module is published,7ED321
 Status: Module Orphaned :eyes:,The module has no owner and is therefore orphaned at this time,f4a460
 Type: Bug :bug:,Something isn't working,d73a4a
 Type: Documentation :page_facing_up:,Improvements or additions to documentation,0075ca


### PR DESCRIPTION
# Overview/Summary

Adding functionality to module indexes that renders the links to those modules that are marked as done in the module index CSV files.

## This PR fixes/adds/changes/removes

see above

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
