### PR TITLE
Fixed PE interface telemetry usage

### DIFF
--- a/docs/static/includes/interfaces/int.pe.udt.schema.bicep
+++ b/docs/static/includes/interfaces/int.pe.udt.schema.bicep
@@ -66,7 +66,7 @@ module exampleResourcePrivateEndpoint 'br/public:avm-res-network-privateendpoint
     name: privateEndpoint.?name ?? 'pe-${last(split(exampleResource.id, '/'))}-${privateEndpoint.service}-${index}'
     serviceResourceId: exampleResource.id
     subnetResourceId: privateEndpoint.subnetResourceId
-    enableTelemetry: enableTelemetry
+    enableTelemetry: privateEndpoint.?enableTelemetry ?? enableTelemetry
     location: privateEndpoint.?location ?? reference(split(privateEndpoint.subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location
     lock: privateEndpoint.?lock ?? lock
     privateDnsZoneResourceIds: privateEndpoint.?privateDnsZoneResourceIds ?? []

--- a/docs/static/includes/interfaces/int.pe.udt.schema.bicep
+++ b/docs/static/includes/interfaces/int.pe.udt.schema.bicep
@@ -47,8 +47,8 @@ type privateEndpointType = {
   @description('Optional. Manual PrivateLink Service Connections.')
   manualPrivateLinkServiceConnections: array?
 
-  @description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
-  enableDefaultTelemetry: bool?
+  @description('Optional. Enable/Disable usage telemetry for module.')
+  enableTelemetry: bool?
 }[]?
 
 @description('Optional. Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible.')
@@ -66,7 +66,7 @@ module exampleResourcePrivateEndpoint 'br/public:avm-res-network-privateendpoint
     name: privateEndpoint.?name ?? 'pe-${last(split(exampleResource.id, '/'))}-${privateEndpoint.service}-${index}'
     serviceResourceId: exampleResource.id
     subnetResourceId: privateEndpoint.subnetResourceId
-    enableDefaultTelemetry: enableReferencedModulesTelemetry
+    enableTelemetry: enableTelemetry
     location: privateEndpoint.?location ?? reference(split(privateEndpoint.subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location
     lock: privateEndpoint.?lock ?? lock
     privateDnsZoneResourceIds: privateEndpoint.?privateDnsZoneResourceIds ?? []


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

- Fixed PE interface telemetry usage: We should use the correct naming and further pass the value of the telemtry through instead of simply disabling it for any remote-referenced module

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
