### PR TITLE
Readability improvements for module indexes and GH landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h2> 📄📄 Please note that all of our documentation is published over at <a href="https://aka.ms/AVM">aka.ms/AVM</a>. Please visit this site for more information and guidance! 📄📄 </h2>
 
-> **NOTE**: This repository is used for proposing new modules, tracking issues and feature requests as well as hosting documentation for the Azure Verified Modules (AVM) project. If you are looking for the AVM code repositories, please visit the Bicep and Terraform [module indexes](https://azure.github.io/Azure-Verified-Modules/indexes/) on the AVM portal for references.
+> **NOTE**: This repository is used for proposing and tracking the state of modules, tracking issues and feature requests as well as hosting documentation for the Azure Verified Modules (AVM) project. If you are looking for the AVM code repositories, please visit the Bicep and Terraform [module indexes](https://azure.github.io/Azure-Verified-Modules/indexes/) on the AVM portal for references.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
-# Azure Verified Modules (AVM)
+## 📄📄 Please note that all of our documentation is published over at [aka.ms/AVM](https://aka.ms/AVM) please visit this site for more information and guidance 📄📄
 
+> **NOTE**: This repository is used for proposing new modules, tracking issues and feature requests as well as hosting documentation for the Azure Verified Modules (AVM) project. If you are looking for the AVM code repositories, please visit the Bicep and Terraform [module indexes](https://azure.github.io/Azure-Verified-Modules/indexes/) on the AVM portal for references.
+
+<br>
+
+# Azure Verified Modules (AVM)
 <!-- [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/azure/azure-verified-modules.svg)](http://isitmaintained.com/project/azure/azure-verified-modules "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/azure/azure-verified-modules.svg)](http://isitmaintained.com/project/azure/azure-verified-modules "Percentage of issues still open") -->
 
-![AVM Logo](docs/static/img/avm_logo.png)
+<table style="width:100%">
+  <tr>
+    <td style="width:70%">
+Welcome to the Azure Verified Modules (AVM) repository!
 
-> 📄📄 Please note that all of our documentation is published over at [aka.ms/AVM](https://aka.ms/AVM) please visit this site for more information and guidance 📄📄
-
-Welcome to the Azure Verified Modules (AVM) repo.
+<br>
 
 Azure Verified Modules (AVM), as "One Microsoft", we want to provide and define the single definition of what a good IaC module is;
 
@@ -15,7 +21,12 @@ Azure Verified Modules (AVM), as "One Microsoft", we want to provide and define 
   - Enforcing consistency and testing where possible
 - How they are to be consumed
 - What they deliver for consumers in terms of resources deployed and configured
-- And where appropriate aligned across IaC languages (e.g. Bicep, Terraform, etc.)
+- And where appropriate aligned across IaC languages (e.g. Bicep, Terraform, etc.)</td>
+    <td style="width:30%"><img src="docs/static/img/avm_logo.png" width=100%></td>
+  </tr>
+</table>
+
+For more information on AVM, **please visit the [AVM portal (https://aka.ms/AVM)](https://aka.ms/AVM)**.
 
 ## AVM Mission Statement
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <!-- [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/azure/azure-verified-modules.svg)](http://isitmaintained.com/project/azure/azure-verified-modules "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/azure/azure-verified-modules.svg)](http://isitmaintained.com/project/azure/azure-verified-modules "Percentage of issues still open") -->
 
-<table style="width:100%">
+<table style="width:100%" border="0">
   <tr>
     <td style="width:70%">
 Welcome to the Azure Verified Modules (AVM) repository!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <!-- markdownlint-disable -->
-> 📄 **Please note** that our documentation is published over at [aka.ms/AVM](https://aka.ms/avm). Please visit this site for more information and guidance! 📄
-> 
+> 📄 **Please note** that our documentation is published over at [aka.ms/AVM](https://aka.ms/avm). Please visit this site for more information and guidance! 📄 <br><br>
 >  This repository is used for proposing and tracking the state of modules, tracking issues and feature requests as well as hosting documentation for the Azure Verified Modules (AVM) project. If you are looking for the AVM code repositories, please visit the Bicep and Terraform [module indexes](https://azure.github.io/Azure-Verified-Modules/indexes/) on the AVM portal for references.
 <!-- markdownlint-restore -->
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <!-- [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/azure/azure-verified-modules.svg)](http://isitmaintained.com/project/azure/azure-verified-modules "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/azure/azure-verified-modules.svg)](http://isitmaintained.com/project/azure/azure-verified-modules "Percentage of issues still open") -->
 
-<img src="docs/static/img/avm_logo.png" width=15% align="right">
+<img src="docs/static/img/avm_logo.png" width=20% align=right>
 
 Welcome to the Azure Verified Modules (AVM) repository!
 <br>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 <img src="docs/static/img/avm_logo.png" width=20% align=right>
 
-Welcome to the Azure Verified Modules (AVM) repository!
+**Welcome to the Azure Verified Modules (AVM) repository!**
+
 <br>
 
 Azure Verified Modules (AVM), as "One Microsoft", we want to provide and define the single definition of what a good IaC module is;

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<h2> 📄📄 Please note that all of our documentation is published over at <a href="https://aka.ms/AVM">aka.ms/AVM</a>. Please visit this site for more information and guidance! 📄📄 </h2>
-
-> **NOTE**: This repository is used for proposing and tracking the state of modules, tracking issues and feature requests as well as hosting documentation for the Azure Verified Modules (AVM) project. If you are looking for the AVM code repositories, please visit the Bicep and Terraform [module indexes](https://azure.github.io/Azure-Verified-Modules/indexes/) on the AVM portal for references.
-
-<br>
+<!-- markdownlint-disable -->
+> 📄 **Please note** that our documentation is published over at [aka.ms/AVM](https://aka.ms/avm). Please visit this site for more information and guidance! 📄
+> 
+>  This repository is used for proposing and tracking the state of modules, tracking issues and feature requests as well as hosting documentation for the Azure Verified Modules (AVM) project. If you are looking for the AVM code repositories, please visit the Bicep and Terraform [module indexes](https://azure.github.io/Azure-Verified-Modules/indexes/) on the AVM portal for references.
+<!-- markdownlint-restore -->
 
 # Azure Verified Modules (AVM)
 <!-- [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/azure/azure-verified-modules.svg)](http://isitmaintained.com/project/azure/azure-verified-modules "Average time to resolve an issue")

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## 📄📄 Please note that all of our documentation is published over at [aka.ms/AVM](https://aka.ms/AVM) please visit this site for more information and guidance 📄📄
+## 📄📄 Please note that all of our documentation is published over at [aka.ms/AVM](https://aka.ms/AVM). Please visit this site for more information and guidance! 📄📄
 
 > **NOTE**: This repository is used for proposing new modules, tracking issues and feature requests as well as hosting documentation for the Azure Verified Modules (AVM) project. If you are looking for the AVM code repositories, please visit the Bicep and Terraform [module indexes](https://azure.github.io/Azure-Verified-Modules/indexes/) on the AVM portal for references.
 
@@ -8,11 +8,9 @@
 <!-- [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/azure/azure-verified-modules.svg)](http://isitmaintained.com/project/azure/azure-verified-modules "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/azure/azure-verified-modules.svg)](http://isitmaintained.com/project/azure/azure-verified-modules "Percentage of issues still open") -->
 
-<table style="width:100%" border="0">
-  <tr>
-    <td style="width:70%" style='border:none;'>
-Welcome to the Azure Verified Modules (AVM) repository!
+<img src="docs/static/img/avm_logo.png" width=15% align="right">
 
+Welcome to the Azure Verified Modules (AVM) repository!
 <br>
 
 Azure Verified Modules (AVM), as "One Microsoft", we want to provide and define the single definition of what a good IaC module is;
@@ -22,9 +20,6 @@ Azure Verified Modules (AVM), as "One Microsoft", we want to provide and define 
 - How they are to be consumed
 - What they deliver for consumers in terms of resources deployed and configured
 - And where appropriate aligned across IaC languages (e.g. Bicep, Terraform, etc.)</td>
-    <td style="width:30%" style='border:none;'><img src="docs/static/img/avm_logo.png" width=100%></td>
-  </tr>
-</table>
 
 For more information on AVM, **please visit the [AVM portal (https://aka.ms/AVM)](https://aka.ms/AVM)**.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <table style="width:100%" border="0">
   <tr>
-    <td style="width:70%">
+    <td style="width:70%" style='border:none;'>
 Welcome to the Azure Verified Modules (AVM) repository!
 
 <br>
@@ -22,7 +22,7 @@ Azure Verified Modules (AVM), as "One Microsoft", we want to provide and define 
 - How they are to be consumed
 - What they deliver for consumers in terms of resources deployed and configured
 - And where appropriate aligned across IaC languages (e.g. Bicep, Terraform, etc.)</td>
-    <td style="width:30%"><img src="docs/static/img/avm_logo.png" width=100%></td>
+    <td style="width:30%" style='border:none;'><img src="docs/static/img/avm_logo.png" width=100%></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
 
 **Welcome to the Azure Verified Modules (AVM) repository!**
 
-<br>
-
 Azure Verified Modules (AVM), as "One Microsoft", we want to provide and define the single definition of what a good IaC module is;
 
 - How they should be constructed and built

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 📄📄 Please note that all of our documentation is published over at [aka.ms/AVM](https://aka.ms/AVM). Please visit this site for more information and guidance! 📄📄
+<h2> 📄📄 Please note that all of our documentation is published over at <a href="https://aka.ms/AVM">aka.ms/AVM</a>. Please visit this site for more information and guidance! 📄📄 </h2>
 
 > **NOTE**: This repository is used for proposing new modules, tracking issues and feature requests as well as hosting documentation for the Azure Verified Modules (AVM) project. If you are looking for the AVM code repositories, please visit the Bicep and Terraform [module indexes](https://azure.github.io/Azure-Verified-Modules/indexes/) on the AVM portal for references.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## 📄📄 Please note that all of our documentation is published over at [aka.ms/AVM](https://aka.ms/AVM). Please visit this site for more information and guidance! 📄📄
+# 📄📄 Please note that all of our documentation is published over at [aka.ms/AVM](https://aka.ms/AVM). Please visit this site for more information and guidance! 📄📄
 
 > **NOTE**: This repository is used for proposing new modules, tracking issues and feature requests as well as hosting documentation for the Azure Verified Modules (AVM) project. If you are looking for the AVM code repositories, please visit the Bicep and Terraform [module indexes](https://azure.github.io/Azure-Verified-Modules/indexes/) on the AVM portal for references.
 

--- a/docs/content/indexes/bicep/bicep-pattern-modules.md
+++ b/docs/content/indexes/bicep/bicep-pattern-modules.md
@@ -19,7 +19,7 @@ geekdocAnchor: true
 
 {{< hint type=note >}}
 
-This page contains various views of the module index (catalog) for **Bicep Pattern Modules**. To see these views, **click on the expandable sections** below.
+This page contains various views of the module index (catalog) for **Bicep Pattern Modules**. To see these views, **click on the expandable sections** with the "➕" sign below.
 
 - {{< icon "gdoc_github" >}} To see the **full, unfiltered module index** on GitHub, click [here](https://github.com/Azure/Azure-Verified-Modules/blob/main/docs/static/module-indexes/BicepPatternModules.csv).
 
@@ -27,8 +27,15 @@ This page contains various views of the module index (catalog) for **Bicep Patte
 
 {{< /hint >}}
 
+{{< hint type=important >}}
+Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use.
+{{< /hint >}}
+
+<br>
+
 ## Module names, status and owners
-{{< expand "Module names, status and owners" "expand/collapse" >}}
+
+{{< expand "➕ Module names, status and owners" "expand/collapse" >}}
 
 {{< moduleNameStatusOwners header=true csv="/static/module-indexes/BicepPatternModules.csv" >}}
 
@@ -37,7 +44,8 @@ This page contains various views of the module index (catalog) for **Bicep Patte
 <br>
 
 ## Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors
-{{< expand "Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" "expand/collapse" >}}
+
+{{< expand "➕ Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" "expand/collapse" >}}
 
 {{< moduleNameTelemetryGHTeams header=true csv="/static/module-indexes/BicepPatternModules.csv" >}}
 

--- a/docs/content/indexes/bicep/bicep-resource-modules.md
+++ b/docs/content/indexes/bicep/bicep-resource-modules.md
@@ -13,7 +13,7 @@ geekdocAnchor: true
 
 {{< hint type=note >}}
 
-This page contains various views of the module index (catalog) for **Bicep Resource Modules**. To see these views, **click on the expandable sections** below.
+This page contains various views of the module index (catalog) for **Bicep Resource Modules**. To see these views, **click on the expandable sections** with the "➕" sign below.
 
 - {{< icon "gdoc_github" >}} To see the **full, unfiltered module index** on GitHub, click [here](https://github.com/Azure/Azure-Verified-Modules/blob/main/docs/static/module-indexes/BicepResourceModules.csv).
 
@@ -21,8 +21,15 @@ This page contains various views of the module index (catalog) for **Bicep Resou
 
 {{< /hint >}}
 
+{{< hint type=important >}}
+Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use.
+{{< /hint >}}
+
+<br>
+
 ## Module names, status and owners
-{{< expand "Module names, status and owners" "expand/collapse" >}}
+
+{{< expand "➕ Module names, status and owners" "expand/collapse" >}}
 
 {{< moduleNameStatusOwners header=true csv="/static/module-indexes/BicepResourceModules.csv" >}}
 
@@ -31,7 +38,8 @@ This page contains various views of the module index (catalog) for **Bicep Resou
 <br>
 
 ## Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors
-{{< expand "Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" "expand/collapse" >}}
+
+{{< expand "➕ Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" "expand/collapse" >}}
 
 {{< moduleNameTelemetryGHTeams header=true csv="/static/module-indexes/BicepResourceModules.csv" >}}
 

--- a/docs/content/indexes/terraform/tf-pattern-modules.md
+++ b/docs/content/indexes/terraform/tf-pattern-modules.md
@@ -19,7 +19,7 @@ geekdocAnchor: true
 
 {{< hint type=note >}}
 
-This page contains various views of the module index (catalog) for **Terraform Pattern Modules**. To see these views, **click on the expandable sections** below.
+This page contains various views of the module index (catalog) for **Terraform Pattern Modules**. To see these views, **click on the expandable sections** with the "➕" sign below.
 
 - {{< icon "gdoc_github" >}} To see the **full, unfiltered module index** on GitHub, click [here](https://github.com/Azure/Azure-Verified-Modules/blob/main/docs/static/module-indexes/TerraformPatternModules.csv).
 
@@ -27,8 +27,15 @@ This page contains various views of the module index (catalog) for **Terraform P
 
 {{< /hint >}}
 
+{{< hint type=important >}}
+Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use.
+{{< /hint >}}
+
+<br>
+
 ## Module names, status and owners
-{{< expand "Module names, status and owners" "expand/collapse" >}}
+
+{{< expand "➕ Module names, status and owners" "expand/collapse" >}}
 
 {{< moduleNameStatusOwners header=true csv="/static/module-indexes/TerraformPatternModules.csv" >}}
 
@@ -37,7 +44,8 @@ This page contains various views of the module index (catalog) for **Terraform P
 <br>
 
 ## Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors
-{{< expand "Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" "expand/collapse" >}}
+
+{{< expand "➕ Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" "expand/collapse" >}}
 
 {{< moduleNameTelemetryGHTeams header=true csv="/static/module-indexes/TerraformPatternModules.csv" >}}
 

--- a/docs/content/indexes/terraform/tf-resource-modules.md
+++ b/docs/content/indexes/terraform/tf-resource-modules.md
@@ -13,7 +13,7 @@ geekdocAnchor: true
 
 {{< hint type=note >}}
 
-This page contains various views of the module index (catalog) for **Terraform Resource Modules**. To see these views, **click on the expandable sections** below.
+This page contains various views of the module index (catalog) for **Terraform Resource Modules**. To see these views, **click on the expandable sections** with the "➕" sign below.
 
 - {{< icon "gdoc_github" >}} To see the **full, unfiltered module index** on GitHub, click [here](https://github.com/Azure/Azure-Verified-Modules/blob/main/docs/static/module-indexes/TerraformResourceModules.csv).
 
@@ -21,8 +21,15 @@ This page contains various views of the module index (catalog) for **Terraform R
 
 {{< /hint >}}
 
+{{< hint type=important >}}
+Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use.
+{{< /hint >}}
+
+<br>
+
 ## Module names, status and owners
-{{< expand "Module names, status and owners" "expand/collapse" >}}
+
+{{< expand "➕ Module names, status and owners" "expand/collapse" >}}
 
 {{< moduleNameStatusOwners header=true csv="/static/module-indexes/TerraformResourceModules.csv" >}}
 
@@ -31,7 +38,8 @@ This page contains various views of the module index (catalog) for **Terraform R
 <br>
 
 ## Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors
-{{< expand "Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" "expand/collapse" >}}
+
+{{< expand "➕ Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" "expand/collapse" >}}
 
 {{< moduleNameTelemetryGHTeams header=true csv="/static/module-indexes/TerraformResourceModules.csv" >}}
 


### PR DESCRIPTION
# Overview/Summary

Readability improvements for module indexes (recently received feedback incorporated)

## This PR fixes/adds/changes/removes

1. Updated main GitHub landing page to make it clearer that customers are supposed to read the documentation on the [AVM portal](https://aka.ms/AVM)
2. Updated the module index pages to make it more obvious that people are supposed to click on the expandable sections to see the content.

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
