### PR TITLE
Fixed link to diagnostic dependencies file

### DIFF
--- a/docs/content/contributing/bicep/_index.md
+++ b/docs/content/contributing/bicep/_index.md
@@ -279,7 +279,7 @@ To test the numerous diagnostic settings targets (Log Analytics Workspace, Stora
 
 {{< hint type=note >}}
 
-Also note there are a number of additional scripts and utilities available [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utilities/e2e-template-assets/diagnostic.dependencies.bicep) that may be of use to module owners/contributors.
+Also note there are a number of additional scripts and utilities available [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utilities/e2e-template-assets/templates/diagnostic.dependencies.bicep) that may be of use to module owners/contributors.
 
 {{< /hint >}}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Updated the `diagnostic.dependencies.bicep` to its actual location in the Public Bicep Registry repository