### PR TITLE
GH Policy Service - fixing language dependent labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/module_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/module_proposal.yml
@@ -27,7 +27,7 @@ body:
         - label: I have checked for that this module doesn't already exist in the module indexes; or I'm proposing the module to be migrated from CARML/TFVM.
           required: true
   - type: dropdown
-    id: tf-bicep
+    id: language
     attributes:
       label: Bicep or Terraform?
       description: What language are you proposing the module for? (Please create a separate proposal for each language!)

--- a/.github/ISSUE_TEMPLATE/module_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/module_proposal.yml
@@ -29,7 +29,7 @@ body:
   - type: dropdown
     id: tf-bicep
     attributes:
-      label: Terraform or Bicep?
+      label: Bicep or Terraform?
       description: What language are you proposing the module for? (Please create a separate proposal for each language!)
       options:
         - Bicep

--- a/.github/ISSUE_TEMPLATE/orphaned_module.yml
+++ b/.github/ISSUE_TEMPLATE/orphaned_module.yml
@@ -11,7 +11,7 @@ body:
 
         Please ensure you have checked the [AVM Module Classification Definitions](https://azure.github.io/Azure-Verified-Modules/specs/shared/module-classifications/) & the [AVM Shared Specification](https://azure.github.io/Azure-Verified-Modules/specs/shared/)
   - type: dropdown
-    id: tf-bicep
+    id: language
     attributes:
       label: Bicep or Terraform?
       description: What language is the orphaned module written in? (Please create a separate "Orphaned AVM Module" issue for each language!)

--- a/.github/ISSUE_TEMPLATE/orphaned_module.yml
+++ b/.github/ISSUE_TEMPLATE/orphaned_module.yml
@@ -13,7 +13,7 @@ body:
   - type: dropdown
     id: tf-bicep
     attributes:
-      label: Terraform or Bicep?
+      label: Bicep or Terraform?
       description: What language is the orphaned module written in? (Please create a separate "Orphaned AVM Module" issue for each language!)
       options:
         - Bicep

--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -102,7 +102,7 @@ configuration:
             - isAction:
                 action: Opened
             - bodyContains:
-                pattern: '/### Terraform or Bicep\?\n\n\s+Bicep/'
+                pattern: '/### Bicep or Terraform\?\n\s+Bicep/'
                 isRegex: true
         then:
           - addLabel:
@@ -115,7 +115,7 @@ configuration:
             - isAction:
                 action: Opened
             - bodyContains:
-                pattern: '/### Terraform or Bicep\?\n\n\s+Terraform/'
+                pattern: '/### Bicep or Terraform\?\n\s+Terraform/'
                 isRegex: true
         then:
           - addLabel:


### PR DESCRIPTION
# Overview/Summary

Small fix to the regex expression used in the GH poilcy service that automatically picks up the language of the proposed module and applies label accordingly.

## This PR fixes/adds/changes/removes

see above

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
