### PR TITLE
remove mandatory name output

### DIFF
--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -892,7 +892,6 @@ Module owners **MUST** output the following outputs as a minimum in their module
 
 | Output                                                                 | Bicep Output Name             | Terraform Output Name             |
 |------------------------------------------------------------------------|-------------------------------|-----------------------------------|
-| Resource Name                                                          | `name`                        | `name`                            |
 | Resource ID                                                            | `resourceId`                  | `resource_id`                     |
 | System Assigned Managed Identity Principal ID (if supported by module) | `systemAssignedMIPrincipalId` | `system_assigned_mi_prinicpal_id` |
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Outputting the name in a resource module has no value as the name parameter is an input.

The name parameter is never transformed within the module, therefore the caller already knows this information as they provided it as an input.

## This PR fixes/adds/changes/removes

1. removes mandatory name output

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
