### PR TITLE
add module statistics to indexes

### DIFF
--- a/docs/content/indexes/_index.md
+++ b/docs/content/indexes/_index.md
@@ -13,3 +13,13 @@ This section lists all Azure Verified Modules that are available or planned in *
 - [Terraform](/Azure-Verified-Modules/indexes/terraform)
   - [Resource Modules](/Azure-Verified-Modules/indexes/terraform/tf-resource-modules)
   - [Pattern Modules](/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules)
+
+
+
+---
+
+<br>
+
+The following table shows the number of all available, orphaned and planned **AVM Modules**.
+
+{{< moduleStats language="All" moduleType="All" showLanguage=true showClassification=true >}}

--- a/docs/content/indexes/bicep/_index.md
+++ b/docs/content/indexes/bicep/_index.md
@@ -9,3 +9,11 @@ This section lists all Azure Verified Modules that are available in or planned f
 
 - [Resource Modules](/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules)
 - [Pattern Modules](/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules)
+
+---
+
+<br>
+
+The following table shows the number of all available, orphaned and planned **Bicep Modules**.
+
+{{< moduleStats language="Bicep" moduleType="All" showLanguage=false showClassification=true >}}

--- a/docs/content/indexes/bicep/bicep-pattern-modules.md
+++ b/docs/content/indexes/bicep/bicep-pattern-modules.md
@@ -31,6 +31,10 @@ This page contains various views of the module index (catalog) for **Bicep Patte
 Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use. For planned modules, see the [Planned modules](#planned-modules) section below.
 {{< /hint >}}
 
+The following table shows the number of all available, orphaned and planned **Bicep Pattern Modules**.
+
+{{< moduleStats language="Bicep" moduleType="Pattern" showLanguage=false showClassification=false >}}
+
 ### Available modules
 
 {{< expand "➕ Available Modules - Module names, status and owners" "expand/collapse" "open" >}}

--- a/docs/content/indexes/bicep/bicep-resource-modules.md
+++ b/docs/content/indexes/bicep/bicep-resource-modules.md
@@ -31,6 +31,10 @@ This page contains various views of the module index (catalog) for **Bicep Resou
 Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use. For planned modules, see the [Planned modules](#planned-modules) section below.
 {{< /hint >}}
 
+The following table shows the number of all available, orphaned and planned **Bicep Resource Modules**.
+
+{{< moduleStats language="Bicep" moduleType="Resource" showLanguage=false showClassification=false >}}
+
 <br>
 
 ### Available modules

--- a/docs/content/indexes/terraform/_index.md
+++ b/docs/content/indexes/terraform/_index.md
@@ -9,3 +9,11 @@ This section lists all Azure Verified Modules that are available in or planned f
 
 - [Resource Modules](/Azure-Verified-Modules/indexes/terraform/tf-resource-modules)
 - [Pattern Modules](/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules)
+
+---
+
+<br>
+
+The following table shows the number of all available, orphaned and planned **Terraform Modules**.
+
+{{< moduleStats language="Terraform" moduleType="All" showLanguage=false showClassification=true >}}

--- a/docs/content/indexes/terraform/tf-pattern-modules.md
+++ b/docs/content/indexes/terraform/tf-pattern-modules.md
@@ -31,6 +31,10 @@ This page contains various views of the module index (catalog) for **Terraform P
 Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use. For planned modules, see the [Planned modules](#planned-modules) section below.
 {{< /hint >}}
 
+The following table shows the number of all available, orphaned and planned **Terraform Pattern Modules**.
+
+{{< moduleStats language="Terraform" moduleType="Pattern" showLanguage=false showClassification=false >}}
+
 <br>
 
 ### Available modules

--- a/docs/content/indexes/terraform/tf-resource-modules.md
+++ b/docs/content/indexes/terraform/tf-resource-modules.md
@@ -31,6 +31,10 @@ This page contains various views of the module index (catalog) for **Terraform R
 Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use. For planned modules, see the [Planned modules](#planned-modules) section below.
 {{< /hint >}}
 
+The following table shows the number of all available, orphaned and planned **Terraform Resource Modules**.
+
+{{< moduleStats language="Terraform" moduleType="Resource" showLanguage=false showClassification=false >}}
+
 <br>
 
 ### Available modules

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -6,56 +6,56 @@
 {{ $language := .Get "language" }}
 {{ $moduleType := .Get "moduleType" }}
 {{ $exclude := .Get "exclude" }}
-{{ $ProviderNamespace := 0 }}
-{{ $ResourceType := 0 }}
-{{ $ModuleDisplayName := 0 }}
-{{ $ModuleName := 0 }}
-{{ $ModuleStatus := 0 }}
-{{ $RepoURL := 0 }}
-{{ $PublicRegistryReference := 0 }}
-{{ $TelemetryIdPrefix := 0 }}
-{{ $PrimaryModuleOwnerGHHandle := 0 }}
-{{ $PrimaryModuleOwnerDisplayName := 0 }}
-{{ $SecondaryModuleOwnerGHHandle := 0 }}
-{{ $SecondaryModuleOwnerDisplayName := 0 }}
-{{ $ModuleOwnersGHTeam := 0 }}
-{{ $ModuleContributorsGHTeam := 0 }}
-{{ $Description := 0 }}
-{{ $Comments := 0 }}
+{{ $ProviderNamespaceColumnId := 0 }}
+{{ $ResourceTypeColumnId := 0 }}
+{{ $ModuleDisplayNameColumnId := 0 }}
+{{ $ModuleNameColumnId := 0 }}
+{{ $ModuleStatusColumnId := 0 }}
+{{ $RepoURLColumnId := 0 }}
+{{ $PublicRegistryReferenceColumnId := 0 }}
+{{ $TelemetryIdPrefixColumnId := 0 }}
+{{ $PrimaryModuleOwnerGHHandleColumnId := 0 }}
+{{ $PrimaryModuleOwnerDisplayNameColumnId := 0 }}
+{{ $SecondaryModuleOwnerGHHandleColumnId := 0 }}
+{{ $SecondaryModuleOwnerDisplayNameColumnId := 0 }}
+{{ $ModuleOwnersGHTeamColumnId := 0 }}
+{{ $ModuleContributorsGHTeamColumnId := 0 }}
+{{ $DescriptionColumnId := 0 }}
+{{ $CommentsColumnId := 0 }}
 {{ $hasModulesAvailable := false }}
 
 {{ if eq $moduleType "resource" }}
-  {{ $ProviderNamespace = 0 }}
-  {{ $ResourceType = 1 }}
-  {{ $ModuleDisplayName = 2 }}
-  {{ $ModuleName = 3 }}
-  {{ $ModuleStatus = 4 }}
-  {{ $RepoURL = 5 }}
-  {{ $PublicRegistryReference = 6 }}
-  {{ $TelemetryIdPrefix = 7 }}
-  {{ $PrimaryModuleOwnerGHHandle = 8 }}
-  {{ $PrimaryModuleOwnerDisplayName = 9 }}
-  {{ $SecondaryModuleOwnerGHHandle = 10 }}
-  {{ $SecondaryModuleOwnerDisplayName = 11 }}
-  {{ $ModuleOwnersGHTeam = 12 }}
-  {{ $ModuleContributorsGHTeam = 13 }}
-  {{ $Description = 14 }}
-  {{ $Comments = 15 }}
+  {{ $ProviderNamespaceColumnId = 0 }}
+  {{ $ResourceTypeColumnId = 1 }}
+  {{ $ModuleDisplayNameColumnId = 2 }}
+  {{ $ModuleNameColumnId = 3 }}
+  {{ $ModuleStatusColumnId = 4 }}
+  {{ $RepoURLColumnId = 5 }}
+  {{ $PublicRegistryReferenceColumnId = 6 }}
+  {{ $TelemetryIdPrefixColumnId = 7 }}
+  {{ $PrimaryModuleOwnerGHHandleColumnId = 8 }}
+  {{ $PrimaryModuleOwnerDisplayNameColumnId = 9 }}
+  {{ $SecondaryModuleOwnerGHHandleColumnId = 10 }}
+  {{ $SecondaryModuleOwnerDisplayNameColumnId = 11 }}
+  {{ $ModuleOwnersGHTeamColumnId = 12 }}
+  {{ $ModuleContributorsGHTeamColumnId = 13 }}
+  {{ $DescriptionColumnId = 14 }}
+  {{ $CommentsColumnId = 15 }}
 {{ else if eq $moduleType "pattern" }}
-  {{ $ModuleDisplayName = 0 }}
-  {{ $ModuleName = 1 }}
-  {{ $ModuleStatus = 2 }}
-  {{ $RepoURL = 3 }}
-  {{ $PublicRegistryReference = 4 }}
-  {{ $TelemetryIdPrefix = 5 }}
-  {{ $PrimaryModuleOwnerGHHandle = 6 }}
-  {{ $PrimaryModuleOwnerDisplayName = 7 }}
-  {{ $SecondaryModuleOwnerGHHandle = 8 }}
-  {{ $SecondaryModuleOwnerDisplayName = 9 }}
-  {{ $ModuleOwnersGHTeam = 10 }}
-  {{ $ModuleContributorsGHTeam = 11 }}
-  {{ $Description = 12 }}
-  {{ $Comments = 13 }}
+  {{ $ModuleDisplayNameColumnId = 0 }}
+  {{ $ModuleNameColumnId = 1 }}
+  {{ $ModuleStatusColumnId = 2 }}
+  {{ $RepoURLColumnId = 3 }}
+  {{ $PublicRegistryReferenceColumnId = 4 }}
+  {{ $TelemetryIdPrefixColumnId = 5 }}
+  {{ $PrimaryModuleOwnerGHHandleColumnId = 6 }}
+  {{ $PrimaryModuleOwnerDisplayNameColumnId = 7 }}
+  {{ $SecondaryModuleOwnerGHHandleColumnId = 8 }}
+  {{ $SecondaryModuleOwnerDisplayNameColumnId = 9 }}
+  {{ $ModuleOwnersGHTeamColumnId = 10 }}
+  {{ $ModuleContributorsGHTeamColumnId = 11 }}
+  {{ $DescriptionColumnId = 12 }}
+  {{ $CommentsColumnId = 13 }}
 {{ else }}
   {{ errorf "The %q shortcode requires a moduleType parameter to bet set to either 'resource' or 'pattern'. See %s" .Name .Position }}
 {{ end }}
@@ -75,12 +75,12 @@
   </thead>
   {{ end }}
   {{ range $row, $rows }}
-  {{ if not ( in $exclude (index $row $ModuleStatus) ) }}
+  {{ if not ( in $exclude (index $row $ModuleStatusColumnId) ) }}
   <tr>
-    <td>{{ if $useLinks }} {{ if or (eq (index $row $ModuleStatus) "Module Available :green_circle:") (eq (index $row $ModuleStatus) "Module Orphaned :eyes:") }} <a href="{{ index $row $RepoURL }}">{{ index $row $ModuleName }}</a> {{ else }} {{ index $row $ModuleName }} {{ end }} {{else}} {{ index $row $ModuleName }} {{ end }} </td>
-    <td>{{ index $row $ModuleDisplayName }}</td>
-    <td>{{ emojify (index $row $ModuleStatus) }}</td>
-    <td>{{ if ne (index $row $PrimaryModuleOwnerGHHandle) ""}}<a href="https://github.com/{{ index $row $PrimaryModuleOwnerGHHandle }}">{{ index $row $PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne (index $row $PrimaryModuleOwnerGHHandle) "") (ne (index $row $PrimaryModuleOwnerDisplayName) "") }} <br> ({{ index $row $PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
+    <td>{{ if $useLinks }} {{ if or (eq (index $row $ModuleStatusColumnId) "Module Available :green_circle:") (eq (index $row $ModuleStatusColumnId) "Module Orphaned :eyes:") }} <a href="{{ index $row $RepoURLColumnId }}">{{ index $row $ModuleNameColumnId }}</a> {{ else }} {{ index $row $ModuleNameColumnId }} {{ end }} {{else}} {{ index $row $ModuleNameColumnId }} {{ end }} </td>
+    <td>{{ index $row $ModuleDisplayNameColumnId }}</td>
+    <td>{{ emojify (index $row $ModuleStatusColumnId) }}</td>
+    <td>{{ if ne (index $row $PrimaryModuleOwnerGHHandleColumnId) ""}}<a href="https://github.com/{{ index $row $PrimaryModuleOwnerGHHandleColumnId }}">{{ index $row $PrimaryModuleOwnerGHHandleColumnId }}</a> {{ if and (ne (index $row $PrimaryModuleOwnerGHHandleColumnId) "") (ne (index $row $PrimaryModuleOwnerDisplayNameColumnId) "") }} <br> ({{ index $row $PrimaryModuleOwnerDisplayNameColumnId }}) {{ end }} {{ end}}</td>
   </tr>
   {{ $hasModulesAvailable = true }}
   {{ end }}
@@ -110,13 +110,13 @@
   </thead>
   {{ end }}
   {{ range $row, $rows }}
-  {{ if not ( in $exclude (index $row $ModuleStatus) ) }}
+  {{ if not ( in $exclude (index $row $ModuleStatusColumnId) ) }}
   <tr>
-    <td>{{ if $useLinks }} {{ if or (eq (index $row $ModuleStatus) "Module Available :green_circle:") (eq (index $row $ModuleStatus) "Module Orphaned :eyes:") }} <a href="{{ index $row $PublicRegistryReference }}">{{ index $row $ModuleName }}</a> {{ else }} {{ index $row $ModuleName }} {{ end }} {{else}} {{ index $row $ModuleName }} {{ end }} </td>
-    <td>{{ if $useLinks }} {{ if or (eq (index $row $ModuleStatus) "Module Available :green_circle:") (eq (index $row $ModuleStatus) "Module Orphaned :eyes:") }} <a href="{{ index $row $RepoURL }}">📄</a> {{ else }} {{ "n/a" }} {{ end }} {{else}} {{ "n/a" }} {{ end }} </td>
-    <td>{{ index $row $ModuleDisplayName }}</td>
-    <td>{{ emojify (index $row $ModuleStatus) }}</td>
-    <td>{{ if ne (index $row $PrimaryModuleOwnerGHHandle) ""}}<a href="https://github.com/{{ index $row $PrimaryModuleOwnerGHHandle }}">{{ index $row $PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne (index $row $PrimaryModuleOwnerGHHandle) "") (ne (index $row $PrimaryModuleOwnerDisplayName) "") }} <br> ({{ index $row $PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
+    <td>{{ if $useLinks }} {{ if or (eq (index $row $ModuleStatusColumnId) "Module Available :green_circle:") (eq (index $row $ModuleStatusColumnId) "Module Orphaned :eyes:") }} <a href="{{ index $row $PublicRegistryReferenceColumnId }}">{{ index $row $ModuleNameColumnId }}</a> {{ else }} {{ index $row $ModuleNameColumnId }} {{ end }} {{else}} {{ index $row $ModuleNameColumnId }} {{ end }} </td>
+    <td>{{ if $useLinks }} {{ if or (eq (index $row $ModuleStatusColumnId) "Module Available :green_circle:") (eq (index $row $ModuleStatusColumnId) "Module Orphaned :eyes:") }} <a href="{{ index $row $RepoURLColumnId }}">📄</a> {{ else }} {{ "n/a" }} {{ end }} {{else}} {{ "n/a" }} {{ end }} </td>
+    <td>{{ index $row $ModuleDisplayNameColumnId }}</td>
+    <td>{{ emojify (index $row $ModuleStatusColumnId) }}</td>
+    <td>{{ if ne (index $row $PrimaryModuleOwnerGHHandleColumnId) ""}}<a href="https://github.com/{{ index $row $PrimaryModuleOwnerGHHandleColumnId }}">{{ index $row $PrimaryModuleOwnerGHHandleColumnId }}</a> {{ if and (ne (index $row $PrimaryModuleOwnerGHHandleColumnId) "") (ne (index $row $PrimaryModuleOwnerDisplayNameColumnId) "") }} <br> ({{ index $row $PrimaryModuleOwnerDisplayNameColumnId }}) {{ end }} {{ end}}</td>
   </tr>
   {{ $hasModulesAvailable = true }}
   {{ end }}

--- a/docs/layouts/shortcodes/moduleNameTelemetryGHTeams.html
+++ b/docs/layouts/shortcodes/moduleNameTelemetryGHTeams.html
@@ -5,56 +5,56 @@
 {{ $useLinks := .Get "useLinks" | default true }}
 {{ $language := .Get "language" }}
 {{ $moduleType := .Get "moduleType" }}
-{{ $ProviderNamespace := 0 }}
-{{ $ResourceType := 0 }}
-{{ $ModuleDisplayName := 0 }}
-{{ $ModuleName := 0 }}
-{{ $ModuleStatus := 0 }}
-{{ $RepoURL := 0 }}
-{{ $PublicRegistryReference := 0 }}
-{{ $TelemetryIdPrefix := 0 }}
-{{ $PrimaryModuleOwnerGHHandle := 0 }}
-{{ $PrimaryModuleOwnerDisplayName := 0 }}
-{{ $SecondaryModuleOwnerGHHandle := 0 }}
-{{ $SecondaryModuleOwnerDisplayName := 0 }}
-{{ $ModuleOwnersGHTeam := 0 }}
-{{ $ModuleContributorsGHTeam := 0 }}
-{{ $Description := 0 }}
-{{ $Comments := 0 }}
+{{ $ProviderNamespaceColumnId := 0 }}
+{{ $ResourceTypeColumnId := 0 }}
+{{ $ModuleDisplayNameColumnId := 0 }}
+{{ $ModuleNameColumnId := 0 }}
+{{ $ModuleStatusColumnId := 0 }}
+{{ $RepoURLColumnId := 0 }}
+{{ $PublicRegistryReferenceColumnId := 0 }}
+{{ $TelemetryIdPrefixColumnId := 0 }}
+{{ $PrimaryModuleOwnerGHHandleColumnId := 0 }}
+{{ $PrimaryModuleOwnerDisplayNameColumnId := 0 }}
+{{ $SecondaryModuleOwnerGHHandleColumnId := 0 }}
+{{ $SecondaryModuleOwnerDisplayNameColumnId := 0 }}
+{{ $ModuleOwnersGHTeamColumnId := 0 }}
+{{ $ModuleContributorsGHTeamColumnId := 0 }}
+{{ $DescriptionColumnId := 0 }}
+{{ $CommentsColumnId := 0 }}
 {{ $hasModulesAvailable := false }}
 
 {{ if eq $moduleType "resource" }}
-  {{ $ProviderNamespace = 0 }}
-  {{ $ResourceType = 1 }}
-  {{ $ModuleDisplayName = 2 }}
-  {{ $ModuleName = 3 }}
-  {{ $ModuleStatus = 4 }}
-  {{ $RepoURL = 5 }}
-  {{ $PublicRegistryReference = 6 }}
-  {{ $TelemetryIdPrefix = 7 }}
-  {{ $PrimaryModuleOwnerGHHandle = 8 }}
-  {{ $PrimaryModuleOwnerDisplayName = 9 }}
-  {{ $SecondaryModuleOwnerGHHandle = 10 }}
-  {{ $SecondaryModuleOwnerDisplayName = 11 }}
-  {{ $ModuleOwnersGHTeam = 12 }}
-  {{ $ModuleContributorsGHTeam = 13 }}
-  {{ $Description = 14 }}
-  {{ $Comments = 15 }}
+  {{ $ProviderNamespaceColumnId = 0 }}
+  {{ $ResourceTypeColumnId = 1 }}
+  {{ $ModuleDisplayNameColumnId = 2 }}
+  {{ $ModuleNameColumnId = 3 }}
+  {{ $ModuleStatusColumnId = 4 }}
+  {{ $RepoURLColumnId = 5 }}
+  {{ $PublicRegistryReferenceColumnId = 6 }}
+  {{ $TelemetryIdPrefixColumnId = 7 }}
+  {{ $PrimaryModuleOwnerGHHandleColumnId = 8 }}
+  {{ $PrimaryModuleOwnerDisplayNameColumnId = 9 }}
+  {{ $SecondaryModuleOwnerGHHandleColumnId = 10 }}
+  {{ $SecondaryModuleOwnerDisplayNameColumnId = 11 }}
+  {{ $ModuleOwnersGHTeamColumnId = 12 }}
+  {{ $ModuleContributorsGHTeamColumnId = 13 }}
+  {{ $DescriptionColumnId = 14 }}
+  {{ $CommentsColumnId = 15 }}
 {{ else if eq $moduleType "pattern" }}
-  {{ $ModuleDisplayName = 0 }}
-  {{ $ModuleName = 1 }}
-  {{ $ModuleStatus = 2 }}
-  {{ $RepoURL = 3 }}
-  {{ $PublicRegistryReference = 4 }}
-  {{ $TelemetryIdPrefix = 5 }}
-  {{ $PrimaryModuleOwnerGHHandle = 6 }}
-  {{ $PrimaryModuleOwnerDisplayName = 7 }}
-  {{ $SecondaryModuleOwnerGHHandle = 8 }}
-  {{ $SecondaryModuleOwnerDisplayName = 9 }}
-  {{ $ModuleOwnersGHTeam = 10 }}
-  {{ $ModuleContributorsGHTeam = 11 }}
-  {{ $Description = 12 }}
-  {{ $Comments = 13 }}
+  {{ $ModuleDisplayNameColumnId = 0 }}
+  {{ $ModuleNameColumnId = 1 }}
+  {{ $ModuleStatusColumnId = 2 }}
+  {{ $RepoURLColumnId = 3 }}
+  {{ $PublicRegistryReferenceColumnId = 4 }}
+  {{ $TelemetryIdPrefixColumnId = 5 }}
+  {{ $PrimaryModuleOwnerGHHandleColumnId = 6 }}
+  {{ $PrimaryModuleOwnerDisplayNameColumnId = 7 }}
+  {{ $SecondaryModuleOwnerGHHandleColumnId = 8 }}
+  {{ $SecondaryModuleOwnerDisplayNameColumnId = 9 }}
+  {{ $ModuleOwnersGHTeamColumnId = 10 }}
+  {{ $ModuleContributorsGHTeamColumnId = 11 }}
+  {{ $DescriptionColumnId = 12 }}
+  {{ $CommentsColumnId = 13 }}
 {{ else }}
 {{ errorf "The %q shortcode requires a moduleType parameter to bet set to either 'resource' or 'pattern'. See %s" .Name .Position }}
 {{ end }}
@@ -73,12 +73,12 @@
   {{ end }}
   {{ range $row, $rows }}
   <tr>
-    <td>{{ if $useLinks }} {{ if or (eq (index $row $ModuleStatus) "Module Available :green_circle:") (eq (index $row $ModuleStatus) "Module Orphaned :eyes:") }} <a href="{{ index $row $RepoURL }}">{{ index $row $ModuleName }}</a> {{ else }} {{ index $row $ModuleName }} {{ end }} {{else}} {{ index $row $ModuleName }} {{ end }} </td>
-    <td><code>{{ index $row $TelemetryIdPrefix }}</code></td>
+    <td>{{ if $useLinks }} {{ if or (eq (index $row $ModuleStatusColumnId) "Module Available :green_circle:") (eq (index $row $ModuleStatusColumnId) "Module Orphaned :eyes:") }} <a href="{{ index $row $RepoURLColumnId }}">{{ index $row $ModuleNameColumnId }}</a> {{ else }} {{ index $row $ModuleNameColumnId }} {{ end }} {{else}} {{ index $row $ModuleNameColumnId }} {{ end }} </td>
+    <td><code>{{ index $row $TelemetryIdPrefixColumnId }}</code></td>
     <td>
-      <code>{{ index $row $ModuleOwnersGHTeam }}</code>
+      <code>{{ index $row $ModuleOwnersGHTeamColumnId }}</code>
       <br>
-      <code>{{ index $row $ModuleContributorsGHTeam }}</code>
+      <code>{{ index $row $ModuleContributorsGHTeamColumnId }}</code>
     </td>
     <td></td>
   </tr>
@@ -99,12 +99,12 @@
   {{ end }}
   {{ range $row, $rows }}
   <tr>
-    <td>{{ if $useLinks }} {{ if or (eq (index $row $ModuleStatus) "Module Available :green_circle:") (eq (index $row $ModuleStatus) "Module Orphaned :eyes:") }} <a href="{{ index $row $PublicRegistryReference }}">{{ index $row $ModuleName }}</a> {{ else }} {{ index $row $ModuleName }} {{ end }} {{else}} {{ index $row $ModuleName }} {{ end }} </td>
-    <td><code>{{ index $row $TelemetryIdPrefix }}</code></td>
+    <td>{{ if $useLinks }} {{ if or (eq (index $row $ModuleStatusColumnId) "Module Available :green_circle:") (eq (index $row $ModuleStatusColumnId) "Module Orphaned :eyes:") }} <a href="{{ index $row $PublicRegistryReferenceColumnId }}">{{ index $row $ModuleNameColumnId }}</a> {{ else }} {{ index $row $ModuleNameColumnId }} {{ end }} {{else}} {{ index $row $ModuleNameColumnId }} {{ end }} </td>
+    <td><code>{{ index $row $TelemetryIdPrefixColumnId }}</code></td>
     <td>
-      <code>{{ index $row $ModuleOwnersGHTeam }}</code>
+      <code>{{ index $row $ModuleOwnersGHTeamColumnId }}</code>
       <br>
-      <code>{{ index $row $ModuleContributorsGHTeam }}</code>
+      <code>{{ index $row $ModuleContributorsGHTeamColumnId }}</code>
     </td>
     <td></td>
   </tr>

--- a/docs/layouts/shortcodes/moduleStats.html
+++ b/docs/layouts/shortcodes/moduleStats.html
@@ -37,12 +37,12 @@
   <tr>
     {{ if $showLanguage }}<th>Language</th>{{ end }}
     {{ if $showClassification }}<th>Classification</th>{{ end }}
-    <th>{{ emojify ("Available :green_circle:") }}</th>
-    <th>{{ emojify ("Orphaned :eyes:") }}</th>
-    {{ if in (slice "Bicep" "All") $language }}<th>{{ emojify ("Migrate From CARML :rocket:") }}</th>{{ end }}
-    {{ if in (slice "Terraform" "All") $language }}<th>{{ emojify ("Migrate From TFVM :rocket:") }}</th>{{ end }}
-    <th>{{ emojify ("New Module :new:") }}</th>
-    <th>SUM</th>
+    <th align="right">{{ emojify ("Available :green_circle:") }}</th>
+    <th align="right">{{ emojify ("Orphaned :eyes:") }}</th>
+    {{ if in (slice "Bicep" "All") $language }}<th align="right">{{ emojify ("Migrate From CARML :rocket:") }}</th>{{ end }}
+    {{ if in (slice "Terraform" "All") $language }}<th align="right">{{ emojify ("Migrate From TFVM :rocket:") }}</th>{{ end }}
+    <th align="right">{{ emojify ("New Module :new:") }}</th>
+    <th align="right">SUM</th>
   </tr>
 </thead>
 {{ if in (slice "Bicep" "All") $language }}
@@ -51,12 +51,12 @@
 <tr>
   {{ if $showLanguage }}<td>Bicep</td>{{ end }}
   {{ if $showClassification }}<td>Resource</td>{{ end }}
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Module Available :green_circle:") }}</td>
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Module Orphaned :eyes:") }}</td>
-  {{ if in (slice "Bicep" "All") $language }}<td align="center"> {{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Migrate From CARML :rocket:") }}</td>{{ end }}
-  {{ if in (slice "Terraform" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Migrate From TFVM :rocket:") }}</td>{{ end }}
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "New Module :new:") }}</td>
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "All") }}</td>
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Module Available :green_circle:") }}</td>
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Module Orphaned :eyes:") }}</td>
+  {{ if in (slice "Bicep" "All") $language }}<td align="right"> {{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Migrate From CARML :rocket:") }}</td>{{ end }}
+  {{ if in (slice "Terraform" "All") $language }}<td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Migrate From TFVM :rocket:") }}</td>{{ end }}
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "New Module :new:") }}</td>
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "All") }}</td>
 </tr>
 {{ end }}
 {{ if in (slice "Pattern" "All") $moduleType }}
@@ -64,12 +64,12 @@
 <tr>
   {{ if $showLanguage }}<td>Bicep</td>{{ end }}
   {{ if $showClassification }}<td>Pattern</td>{{ end }}
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Module Available :green_circle:") }}</td>
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Module Orphaned :eyes:") }}</td>
-  {{ if in (slice "Bicep" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Migrate From CARML :rocket:") }}</td>{{ end }}
-  {{ if in (slice "Terraform" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Migrate From TFVM :rocket:") }}</td>{{ end }}
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "New Module :new:") }}</td>
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "All") }}</td>
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Module Available :green_circle:") }}</td>
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Module Orphaned :eyes:") }}</td>
+  {{ if in (slice "Bicep" "All") $language }}<td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Migrate From CARML :rocket:") }}</td>{{ end }}
+  {{ if in (slice "Terraform" "All") $language }}<td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Migrate From TFVM :rocket:") }}</td>{{ end }}
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "New Module :new:") }}</td>
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "All") }}</td>
 </tr>
 {{ end }}
 {{ end }}
@@ -79,12 +79,12 @@
 <tr>
   {{ if $showLanguage }}<td>Terraform</td>{{ end }}
   {{ if $showClassification }}<td>Resource</td>{{ end }}
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Module Available :green_circle:") }}</td>
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Module Orphaned :eyes:") }}</td>
-  {{ if in (slice "Bicep" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Migrate From CARML :rocket:") }}</td>{{ end }}
-  {{ if in (slice "Terraform" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Migrate From TFVM :rocket:") }}</td>{{ end }}
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "New Module :new:") }}</td>
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "All") }}</td>
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Module Available :green_circle:") }}</td>
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Module Orphaned :eyes:") }}</td>
+  {{ if in (slice "Bicep" "All") $language }}<td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Migrate From CARML :rocket:") }}</td>{{ end }}
+  {{ if in (slice "Terraform" "All") $language }}<td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Migrate From TFVM :rocket:") }}</td>{{ end }}
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "New Module :new:") }}</td>
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "All") }}</td>
 </tr>
 {{ end }}
 {{ if in (slice "Pattern" "All") $moduleType }}
@@ -92,12 +92,12 @@
 <tr>
   {{ if $showLanguage }}<td>Terraform</td>{{ end }}
   {{ if $showClassification }}<td>Pattern</td>{{ end }}
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Module Available :green_circle:") }}</td>
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Module Orphaned :eyes:") }}</td>
-  {{ if in (slice "Bicep" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Migrate From CARML :rocket:") }}</td>{{ end }}
-  {{ if in (slice "Terraform" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Migrate From TFVM :rocket:") }}</td>{{ end }}
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "New Module :new:") }}</td>
-  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "All") }}</td>
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Module Available :green_circle:") }}</td>
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Module Orphaned :eyes:") }}</td>
+  {{ if in (slice "Bicep" "All") $language }}<td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Migrate From CARML :rocket:") }}</td>{{ end }}
+  {{ if in (slice "Terraform" "All") $language }}<td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Migrate From TFVM :rocket:") }}</td>{{ end }}
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "New Module :new:") }}</td>
+  <td align="right">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "All") }}</td>
 </tr>
 {{ end }}
 {{ end }}

--- a/docs/layouts/shortcodes/moduleStats.html
+++ b/docs/layouts/shortcodes/moduleStats.html
@@ -1,0 +1,104 @@
+{{ $showLanguage := .Get "showLanguage" | default true }}
+{{ $showClassification := .Get "showClassification" | default true }}
+{{ $language := .Get "language" | default "All" }}
+{{ $moduleType := .Get "moduleType" | default "All" }}
+
+{{ $bicepResFile := readFile "/static/module-indexes/BicepResourceModules.csv" }}
+{{ $bicepResRows := $bicepResFile | transform.Unmarshal (dict "delimiter" ",") }}
+{{ $bicepPtnFile := readFile "/static/module-indexes/BicepPatternModules.csv" }}
+{{ $bicepPtnRows := $bicepPtnFile | transform.Unmarshal (dict "delimiter" ",") }}
+{{ $tfResFile := readFile "/static/module-indexes/TerraformResourceModules.csv" }}
+{{ $tfResRows := $tfResFile | transform.Unmarshal (dict "delimiter" ",") }}
+{{ $tfPtnFile := readFile "/static/module-indexes/TerraformPatternModules.csv" }}
+{{ $tfPtnRows := $tfPtnFile | transform.Unmarshal (dict "delimiter" ",") }}
+
+
+{{ $ModuleStatusColumnId := 0 }}
+
+{{ define "countModules" }}
+  {{ $params := . }}
+  {{ $ModuleStatusColumnId := index $params 0 }}
+  {{ $rows := index $params 1 }}
+  {{ $moduleStatusToCount := index $params 2 }}
+  {{ $moduleCount := 0 }}
+  {{ if eq $moduleStatusToCount "All" }}
+    {{ $moduleCount = sub (len $rows) 1 }}
+  {{ end }}
+  {{ range $row, $rows }}
+    {{ if eq (index $row $ModuleStatusColumnId) $moduleStatusToCount }}
+      {{ $moduleCount = add $moduleCount 1 }}
+    {{ end }}
+  {{ end }}
+  {{ printf "%d" $moduleCount }}
+{{ end }}
+
+<table>
+<thead>
+  <tr>
+    {{ if $showLanguage }}<th>Language</th>{{ end }}
+    {{ if $showClassification }}<th>Classification</th>{{ end }}
+    <th>{{ emojify ("Available :green_circle:") }}</th>
+    <th>{{ emojify ("Orphaned :eyes:") }}</th>
+    {{ if in (slice "Bicep" "All") $language }}<th>{{ emojify ("Migrate From CARML :rocket:") }}</th>{{ end }}
+    {{ if in (slice "Terraform" "All") $language }}<th>{{ emojify ("Migrate From TFVM :rocket:") }}</th>{{ end }}
+    <th>{{ emojify ("New Module :new:") }}</th>
+    <th>SUM</th>
+  </tr>
+</thead>
+{{ if in (slice "Bicep" "All") $language }}
+{{ if in (slice "Resource" "All") $moduleType }}
+{{ $ModuleStatusColumnId = 4 }}
+<tr>
+  {{ if $showLanguage }}<td>Bicep</td>{{ end }}
+  {{ if $showClassification }}<td>Resource</td>{{ end }}
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Module Available :green_circle:") }}</td>
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Module Orphaned :eyes:") }}</td>
+  {{ if in (slice "Bicep" "All") $language }}<td align="center"> {{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Migrate From CARML :rocket:") }}</td>{{ end }}
+  {{ if in (slice "Terraform" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Migrate From TFVM :rocket:") }}</td>{{ end }}
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "New Module :new:") }}</td>
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "All") }}</td>
+</tr>
+{{ end }}
+{{ if in (slice "Pattern" "All") $moduleType }}
+{{ $ModuleStatusColumnId = 2 }}
+<tr>
+  {{ if $showLanguage }}<td>Bicep</td>{{ end }}
+  {{ if $showClassification }}<td>Pattern</td>{{ end }}
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Module Available :green_circle:") }}</td>
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Module Orphaned :eyes:") }}</td>
+  {{ if in (slice "Bicep" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Migrate From CARML :rocket:") }}</td>{{ end }}
+  {{ if in (slice "Terraform" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Migrate From TFVM :rocket:") }}</td>{{ end }}
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "New Module :new:") }}</td>
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "All") }}</td>
+</tr>
+{{ end }}
+{{ end }}
+{{ if in (slice "Terraform" "All") $language }}
+{{ if in (slice "Resource" "All") $moduleType }}
+  {{ $ModuleStatusColumnId = 4 }}
+<tr>
+  {{ if $showLanguage }}<td>Terraform</td>{{ end }}
+  {{ if $showClassification }}<td>Resource</td>{{ end }}
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Module Available :green_circle:") }}</td>
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Module Orphaned :eyes:") }}</td>
+  {{ if in (slice "Bicep" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Migrate From CARML :rocket:") }}</td>{{ end }}
+  {{ if in (slice "Terraform" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Migrate From TFVM :rocket:") }}</td>{{ end }}
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "New Module :new:") }}</td>
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "All") }}</td>
+</tr>
+{{ end }}
+{{ if in (slice "Pattern" "All") $moduleType }}
+{{ $ModuleStatusColumnId = 2 }}
+<tr>
+  {{ if $showLanguage }}<td>Terraform</td>{{ end }}
+  {{ if $showClassification }}<td>Pattern</td>{{ end }}
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Module Available :green_circle:") }}</td>
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Module Orphaned :eyes:") }}</td>
+  {{ if in (slice "Bicep" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Migrate From CARML :rocket:") }}</td>{{ end }}
+  {{ if in (slice "Terraform" "All") $language }}<td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Migrate From TFVM :rocket:") }}</td>{{ end }}
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "New Module :new:") }}</td>
+  <td align="center">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "All") }}</td>
+</tr>
+{{ end }}
+{{ end }}
+</table>


### PR DESCRIPTION
# Overview/Summary

Adding a feature to count the number of all available, orphaned and planned modules on ALL module index pages (and their TOCs).

<img width="507" alt="image" src="https://github.com/Azure/Azure-Verified-Modules/assets/22733424/233e0bb2-28ca-4b83-94cc-480873d6ac84">

## This PR fixes/adds/changes/removes

see above

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
