### PR TITLE
chore: include existing repo advice in q and a section

### DIFF
--- a/docs/content/contributing/q-and-a.md
+++ b/docs/content/contributing/q-and-a.md
@@ -171,6 +171,14 @@ To read more about how to start, navigate to [Terraform AVM contribution guide.]
 
 ---
 
+### I get the error 'The repository ********** already exists on this account' when I try to create a new repository, what should I do?
+
+If you get this error, it means that the repository already exists in the Azure GitHub Organization. This can happen if someone has already created a repository with the same name in the past and then archived it.
+
+To determine if this is the case you'll need to navigate to the [Microsoft Open Source Management Portal](https://repos.opensource.microsoft.com/orgs/Azure/repos?q=), then search for the repository name you are trying to create. Click on the repository and you will find the owner. Reach out the owner to ask them to transfer the repo to you or delete it. You'll want them to delete it if it was not created from the template.
+
+---
+
 ### Where can I test my module during development?
 
 During initial module development module owners/developers need to use your own environment (Azure subscriptions) to test module. In later phase, during publishing process, we will conduct automated test that will use AVM dedicated environment.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

If a repository has been created and then archived as a private repository it is possible to get a naming collision and that is not visible from the public GitHub UI. This PR adds a section to the Q and A to explain what steps to take in this scenario.

## This PR fixes/adds/changes/removes

N/A

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
