### PR TITLE
Documentation and module triage updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/module_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/module_proposal.yml
@@ -89,3 +89,10 @@ body:
       description: Please provide the secondary module owner's GitHub username, leave blank if unknown!
     validations:
       required: false
+  - type: markdown
+    attributes:
+      value: |
+        > **NOTE**:
+        >
+        > - This Module Proposal issue **MUST remain open** until the module is fully developed, tested and published to the relevant registry. **Do NOT close** the issue before the successful publication is confirmed!
+        > - Once the module is fully developed, tested and published to the relevant registry, and the Module Proposal issue was closed, it **MUST remain closed**.

--- a/.github/ISSUE_TEMPLATE/orphaned_module.yml
+++ b/.github/ISSUE_TEMPLATE/orphaned_module.yml
@@ -73,3 +73,10 @@ body:
       description: Please provide the secondary module owner's GitHub username, leave blank if unknown!
     validations:
       required: false
+  - type: markdown
+    attributes:
+      value: |
+        > **NOTE**:
+        >
+        > - This Orphaned Module issue **MUST remain open** until the ownership is fully confirmed!
+        > - Once the Orphaned Module issue was closed, it **MUST remain closed**. If the module will subsequently become orphaned again, a new Orphaned Module issue must be opened.

--- a/docs/content/help-support/issue-triage/avm-issue-triage.md
+++ b/docs/content/help-support/issue-triage/avm-issue-triage.md
@@ -98,14 +98,13 @@ You **MUST** still confirm that the requestor is a Microsoft FTE and that they u
 
 {{< hint type=important >}}
 
-Although, it's not directly part of the module proposal triage process, to begin development, module owners and contributors will need additional help from the AVM core team, such as:
+Although, it's not directly part of the module proposal triage process, to begin development, module owners and contributors might need additional help from the AVM core team, such as:
 
 1. Update any Azure RBAC permissions for test tenants/subscription, if needed.
 2. In case of **Bicep modules** only:
     - Look for the module owners confirmation on the related `[Module Proposal]` issue that they have created the required `-module-owners-` and `-module-contributors-` GitHub teams.
-    - Grant the necessary permissions to the `-module-owners-` and `-module-contributors-` teams on the [BRM repo](https://aka.ms/BRM) as described [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#grant-permissions---bicep).
-    - Update [`CODEOWNERS`](https://github.com/Azure/bicep-registry-modules/blob/main/.github/CODEOWNERS) file in the [BRM repo](https://aka.ms/BRM).
-    - When ready, on the related issue, confirm that you have granted the necessary permissions to the GitHub teams and updated the `CODEOWNERS` file.
+    - Ensure the `-module-owners-` and `-module-contributors-` GitHub teams have been assigned to their respective parent teams as outlined [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#grant-permissions---bicep).
+    - Ensure the [`CODEOWNERS`](https://github.com/Azure/bicep-registry-modules/blob/main/.github/CODEOWNERS) file in the [BRM repo](https://aka.ms/BRM) has been updated.
 
 {{< /hint >}}
 

--- a/docs/content/help-support/issue-triage/avm-issue-triage.md
+++ b/docs/content/help-support/issue-triage/avm-issue-triage.md
@@ -102,8 +102,8 @@ Although, it's not directly part of the module proposal triage process, to begin
 
 1. Update any Azure RBAC permissions for test tenants/subscription, if needed.
 2. In case of **Bicep modules** only:
-    - Look for the module owners confirmation on the related `[Module Proposal]` issue that they have created the required `-module-owners-` and `-module-owners-` GitHub teams.
-    - Grant the necessary permissions to the `-module-owners-` and `-module-owners-` teams on the [BRM repo](https://aka.ms/BRM) as described [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#grant-permissions---bicep).
+    - Look for the module owners confirmation on the related `[Module Proposal]` issue that they have created the required `-module-owners-` and `-module-contributors-` GitHub teams.
+    - Grant the necessary permissions to the `-module-owners-` and `-module-contributors-` teams on the [BRM repo](https://aka.ms/BRM) as described [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#grant-permissions---bicep).
     - Update [`CODEOWNERS`](https://github.com/Azure/bicep-registry-modules/blob/main/.github/CODEOWNERS) file in the [BRM repo](https://aka.ms/BRM).
     - When ready, on the related issue, confirm that you have granted the necessary permissions to the GitHub teams and updated the `CODEOWNERS` file.
 

--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -443,6 +443,18 @@ Each module **MUST** have separate GitHub teams assigned for module owners **AND
 
 There **MUST NOT** be any GitHub repository permissions assigned to individual users.
 
+{{< hint type=note >}}
+The names for the GitHub teams for each approved module are already defined in the respective [Module Indexes](/Azure-Verified-Modules/indexes/). These teams **MUST** be created (and used) for each module.
+
+- [Bicep Resource Modules](/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+- [Bicep Pattern Modules](/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+- [Terraform Resource Modules](/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+- [Terraform Pattern Modules](/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+
+The `@Azure` prefix in the last column of the tables linked above represents the "Azure" GitHub organization all AVM-related repositories exist in. **DO NOT** include this segment in the team's name!
+
+{{< /hint >}}
+
 <br>
 
 ##### Naming Convention
@@ -468,18 +480,6 @@ Examples:
 
 - `avm-res-compute-virtualmachine-module-owners-bicep`
 - `avm-res-compute-virtualmachine-module-contributors-tf`
-
-{{< hint type=note >}}
-The names for the GitHub teams for each approved module are already defined in the respective [Module Indexes](/Azure-Verified-Modules/indexes/). These teams **MUST** be created (and used) for each module.
-
-- [Bicep Resource Modules](/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
-- [Bicep Pattern Modules](/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
-- [Terraform Resource Modules](/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
-- [Terraform Pattern Modules](/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
-
-The `@Azure` prefix in the last column of the tables linked above represents the "Azure" GitHub organization all AVM-related repositories exist in. **DO NOT** include this segment in the team's name!
-
-{{< /hint >}}
 
 <br>
 

--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -437,18 +437,6 @@ The names for the GitHub teams for each approved module are already defined in t
 
 #### ID: SNFR20 - Category: Contribution/Support - GitHub Teams Only
 
-{{< hint type=note >}}
-The names for the GitHub teams for each approved module are already defined in the respective [Module Indexes](/Azure-Verified-Modules/indexes/). These teams **MUST** be created (and used) for each module.
-
-- [Bicep Resource Modules](/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
-- [Bicep Pattern Modules](/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
-- [Terraform Resource Modules](/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
-- [Terraform Pattern Modules](/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
-
-The `@Azure` prefix in the last column of the tables linked above represents the "Azure" GitHub organization all AVM-related repositories exist in. **DO NOT** include this segment in the team's name.
-
-{{< /hint >}}
-
 All GitHub repositories that AVM module are published from and hosted within **MUST** only assign GitHub repository permissions to GitHub teams only.
 
 Each module **MUST** have separate GitHub teams assigned for module owners **AND** module contributors respectively. These GitHub teams **MUST** be created in the [Azure organization](https://github.com/orgs/Azure/teams) in GitHub.
@@ -464,6 +452,10 @@ The naming convention for the GitHub teams **MUST** follow the below pattern:
 - `<hyphenated module name>-module-owners-<bicep/tf>` - to be assigned as the GitHub repository's `Module Owners` team
 - `<hyphenated module name>-module-contributors-<bicep/tf>` - to be assigned as the GitHub repository's `Module Contributors` team
 
+{{< hint type=note >}}
+The naming convention for Bicep modules is slightly different than the naming convention for their respective GitHub teams.
+{{< /hint >}}
+
 Segments:
 
 - `<hyphenated module name>` == the AVM Module's name, with each segment separated by dashes, i.e., `avm-res-<resource provider>-<ARM resource type>`
@@ -476,6 +468,18 @@ Examples:
 
 - `avm-res-compute-virtualmachine-module-owners-bicep`
 - `avm-res-compute-virtualmachine-module-contributors-tf`
+
+{{< hint type=note >}}
+The names for the GitHub teams for each approved module are already defined in the respective [Module Indexes](/Azure-Verified-Modules/indexes/). These teams **MUST** be created (and used) for each module.
+
+- [Bicep Resource Modules](/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+- [Bicep Pattern Modules](/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+- [Terraform Resource Modules](/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+- [Terraform Pattern Modules](/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+
+The `@Azure` prefix in the last column of the tables linked above represents the "Azure" GitHub organization all AVM-related repositories exist in. **DO NOT** include this segment in the team's name!
+
+{{< /hint >}}
 
 <br>
 
@@ -491,33 +495,52 @@ Unless explicitly requested and agreed, members of the AVM core team or any PG t
 
 ##### Grant Permissions - Bicep
 
+##### Team memberships
+
 {{< hint type=note >}}
 
-Only the AVM core team can grant permissions to the [BRM](https://aka.ms/BRM) repository (the repo of the Bicep Registry) and modify the `CODEOWNERS` file.
+In case of Bicep modules, permissions to the [BRM](https://aka.ms/BRM) repository (the repo of the Bicep Registry) are granted via assigning the `-module-owners-` and `-module-contributors-` teams to parent teams that already have the required level access configured. Whilst it't the module owner's responsibility to initiate the addition of their teams to the respective parents, only the AVM core team **CAN** approve this parent-child relationship.
 
 {{< /hint >}}
 
-Module owners **MUST** notify the AVM core team, when the `-module-owners-` and `-module-owners-` teams are created, so the AVM core team can grant permissions to the BRM repo and make the necessary changes to the `CODEOWNERS` file.
+Module owners **MUST** create their `-module-owners-` and `-module-contributors-` teams and as part of the provisioning process, they **MUST** request the addition of these teams to their respective parent teams (see the table below for details).
 
-| GitHub Team Name                                            | Description                                                                  | Permissions | Permissions granted through                                           | Where to work?          |
-|-------------------------------------------------------------|------------------------------------------------------------------------------|-------------|-----------------------------------------------------------------------|-------------------------|
-| `<hyphenated module name>-module-owners-bicep`       | Module Owners of the <module name> AVM Bicep <resource/pattern> module       | **Write**   | Assignment to the `avm-technical-reviewers-bicep` parent team. | Need to work in a fork. |
-| `<hyphenated module name>-module-contributors-bicep` | Module Contributors of the <module name> AVM Bicep <resource/pattern> module | **Triage**  | `avm-module-contributors-bicep` parent team.                   | Need to work in a fork. |
+| GitHub Team Name                                     | Description                                                                  | Permissions | Permissions granted through                                        | Where to work?          |
+|------------------------------------------------------|------------------------------------------------------------------------------|-------------|--------------------------------------------------------------------|-------------------------|
+| `<hyphenated module name>-module-owners-bicep`       | Module Owners of the <module name> AVM Bicep <resource/pattern> module       | **Write**   | Assignment to the **`avm-technical-reviewers-bicep`** parent team. | Need to work in a fork. |
+| `<hyphenated module name>-module-contributors-bicep` | Module Contributors of the <module name> AVM Bicep <resource/pattern> module | **Triage**  | **`avm-module-contributors-bicep`** parent team.                   | Need to work in a fork. |
 
-{{< hint type=important >}}
+Examples - GitHub teams required for the Bicep resource module of Azure Virtual Network (`avm/res/network/virtual-network`):
 
-The `CODEOWNERS` file **MUST** be updated for every module to be onboarded: the `-module-owners-`team **MUST** be added **to the path of the module**.
+- `avm-res-network-virtualnetwork-module-owners-bicep` --> assign to the `avm-technical-reviewers-bicep` parent team.
+- `avm-res-network-virtualnetwork-module-contributors-bicep` --> assign to the `avm-module-contributors-bicep` parent team.
 
+##### CODEOWNERS file
+
+As part of the "initial Pull Request" (that publishes the first version of the module), module owners **MUST** add an entry to the `CODEOWNERS` file in the BRM repository ([here](https://github.com/Azure/bicep-registry-modules/blob/main/.github/CODEOWNERS)).
+
+{{< hint type=note >}}
+Through this approach, the AVM core team will grant review permission to module owners as part of the standard PR review process.
 {{< /hint >}}
+
+Every `CODEOWNERS` entry (line) **MUST** include the following segments separated by a single whitespace character:
+
+- Path of the module, relative to the repo's root, e.g.: `/avm/res/network/virtual-network/`
+- The `-module-owners-`team, with the `@Azure/` prefix, e.g., `@Azure/avm-res-network-virtualnetwork-module-owners-bicep`
+- The GitHub team of the AVM core team, with the `@Azure/` prefix, i.e., `@Azure/avm-core-team-technical-bicep`
+
+Example - `CODEOWNERS` entry for the Bicep resource module of Azure Virtual Network (`avm/res/network/virtual-network`):
+
+- `/avm/res/network/virtual-network/ @Azure/avm-res-network-virtualnetwork-module-owners-bicep @Azure/avm-core-team-technical-bicep`
 
 <br>
 
 ##### Grant Permissions - Terraform
 
-Module owners **MUST** assign the `-module-owners-`and `-module-owners-` teams the necessary permissions on their Terraform module repository and edit the `CODEOWNERS` file as per the guidance below.
+Module owners **MUST** assign the `-module-owners-`and `-module-contributors-` teams the necessary permissions on their Terraform module repository and edit the `CODEOWNERS` file as per the guidance below.
 
-| GitHub Team Name                              | Description                                                                      | Permissions | Permissions granted through | Where to work?                                                                                |
-|-----------------------------------------------|----------------------------------------------------------------------------------|-------------|-----------------------------|-----------------------------------------------------------------------------------------------|
+| GitHub Team Name                       | Description                                                                      | Permissions | Permissions granted through | Where to work?                                                                                |
+|----------------------------------------|----------------------------------------------------------------------------------|-------------|-----------------------------|-----------------------------------------------------------------------------------------------|
 | `<module name>-module-owners-tf`       | Module Owners of the <module name> AVM Terraform <resource/pattern> module       | **Admin**   | Direct assignment to repo   | Module owner can decide whether they want to work in a branch local to the repo or in a fork. |
 | `<module name>-module-contributors-tf` | Module Contributors of the <module name> AVM Terraform <resource/pattern> module | **Write**   | Direct assignment to repo   | Need to work in a fork.                                                                       |
 

--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -425,7 +425,7 @@ Today this is only Microsoft FTEs, but everyone is welcome to contribute. The mo
 
 {{< hint type=note >}}
 
-The names for the GitHub Teams for each approved module are already defined in the respective [Module Indexes](/Azure-Verified-Modules/indexes/). These teams **MUST** be created (and used) for each module.
+The names for the GitHub teams for each approved module are already defined in the respective [Module Indexes](/Azure-Verified-Modules/indexes/). These teams **MUST** be created (and used) for each module.
 
 {{< /hint >}}
 
@@ -438,14 +438,20 @@ The names for the GitHub Teams for each approved module are already defined in t
 #### ID: SNFR20 - Category: Contribution/Support - GitHub Teams Only
 
 {{< hint type=note >}}
+The names for the GitHub teams for each approved module are already defined in the respective [Module Indexes](/Azure-Verified-Modules/indexes/). These teams **MUST** be created (and used) for each module.
 
-The names for the GitHub Teams for each approved module are already defined in the respective [Module Indexes](/Azure-Verified-Modules/indexes/). These teams **MUST** be created (and used) for each module.
+- [Bicep Resource Modules](/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+- [Bicep Pattern Modules](/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+- [Terraform Resource Modules](/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+- [Terraform Pattern Modules](/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+
+The `@Azure` prefix in the last column of the tables linked above represents the "Azure" GitHub organization all AVM-related repositories exist in. **DO NOT** include this segment in the team's name.
 
 {{< /hint >}}
 
 All GitHub repositories that AVM module are published from and hosted within **MUST** only assign GitHub repository permissions to GitHub teams only.
 
-Each module **MUST** have separate GitHub Teams assigned for module owners **AND** module contributors respectively.
+Each module **MUST** have separate GitHub teams assigned for module owners **AND** module contributors respectively. These GitHub teams **MUST** be created in the [Azure organization](https://github.com/orgs/Azure/teams) in GitHub.
 
 There **MUST NOT** be any GitHub repository permissions assigned to individual users.
 
@@ -453,14 +459,13 @@ There **MUST NOT** be any GitHub repository permissions assigned to individual u
 
 ##### Naming Convention
 
-The naming convention for the GitHub Teams **MUST** follow the below pattern:
+The naming convention for the GitHub teams **MUST** follow the below pattern:
 
-- `@Azure/<hyphenated module name>-module-owners-<bicep/tf>` - to be assigned as the GitHub repository's `Module Owners` team
-- `@Azure/<hyphenated module name>-module-contributors-<bicep/tf>` - to be assigned as the GitHub repository's `Module Contributors` team
+- `<hyphenated module name>-module-owners-<bicep/tf>` - to be assigned as the GitHub repository's `Module Owners` team
+- `<hyphenated module name>-module-contributors-<bicep/tf>` - to be assigned as the GitHub repository's `Module Contributors` team
 
 Segments:
 
-- `@Azure` == the GitHub organization the AVM repository exists in. **NOTE**: **DO NOT** include this segment in the team's name.
 - `<hyphenated module name>` == the AVM Module's name, with each segment separated by dashes, i.e., `avm-res-<resource provider>-<ARM resource type>`
   - See [RMNFR1](#id-rmnfr1---category-naming---module-naming) for AVM Resource Module Naming
   - See [PMNFR1](#id-pmnfr1---category-naming---module-naming) for AVM Pattern Module Naming
@@ -469,8 +474,8 @@ Segments:
 
 Examples:
 
-- `@Azure/avm-res-compute-virtualmachine-module-owners-bicep`
-- `@Azure/avm-res-compute-virtualmachine-module-contributors-tf`
+- `avm-res-compute-virtualmachine-module-owners-bicep`
+- `avm-res-compute-virtualmachine-module-contributors-tf`
 
 <br>
 
@@ -496,8 +501,8 @@ Module owners **MUST** notify the AVM core team, when the `-module-owners-` and 
 
 | GitHub Team Name                                            | Description                                                                  | Permissions | Permissions granted through                                           | Where to work?          |
 |-------------------------------------------------------------|------------------------------------------------------------------------------|-------------|-----------------------------------------------------------------------|-------------------------|
-| `@Azure/<hyphenated module name>-module-owners-bicep`       | Module Owners of the <module name> AVM Bicep <resource/pattern> module       | **Write**   | Assignment to the `@Azure/avm-technical-reviewers-bicep` parent team. | Need to work in a fork. |
-| `@Azure/<hyphenated module name>-module-contributors-bicep` | Module Contributors of the <module name> AVM Bicep <resource/pattern> module | **Triage**  | `@Azure/avm-module-contributors-bicep` parent team.                   | Need to work in a fork. |
+| `<hyphenated module name>-module-owners-bicep`       | Module Owners of the <module name> AVM Bicep <resource/pattern> module       | **Write**   | Assignment to the `avm-technical-reviewers-bicep` parent team. | Need to work in a fork. |
+| `<hyphenated module name>-module-contributors-bicep` | Module Contributors of the <module name> AVM Bicep <resource/pattern> module | **Triage**  | `avm-module-contributors-bicep` parent team.                   | Need to work in a fork. |
 
 {{< hint type=important >}}
 
@@ -513,8 +518,8 @@ Module owners **MUST** assign the `-module-owners-`and `-module-owners-` teams t
 
 | GitHub Team Name                              | Description                                                                      | Permissions | Permissions granted through | Where to work?                                                                                |
 |-----------------------------------------------|----------------------------------------------------------------------------------|-------------|-----------------------------|-----------------------------------------------------------------------------------------------|
-| `@Azure/<module name>-module-owners-tf`       | Module Owners of the <module name> AVM Terraform <resource/pattern> module       | **Admin**   | Direct assignment to repo   | Module owner can decide whether they want to work in a branch local to the repo or in a fork. |
-| `@Azure/<module name>-module-contributors-tf` | Module Contributors of the <module name> AVM Terraform <resource/pattern> module | **Write**   | Direct assignment to repo   | Need to work in a fork.                                                                       |
+| `<module name>-module-owners-tf`       | Module Owners of the <module name> AVM Terraform <resource/pattern> module       | **Admin**   | Direct assignment to repo   | Module owner can decide whether they want to work in a branch local to the repo or in a fork. |
+| `<module name>-module-contributors-tf` | Module Contributors of the <module name> AVM Terraform <resource/pattern> module | **Write**   | Direct assignment to repo   | Need to work in a fork.                                                                       |
 
 {{< hint type=important >}}
 
@@ -532,7 +537,7 @@ For more details on how to modify the `CODEOWNERS` file, please see the [documen
 
 #### ID: SNFR9 - Category: Contribution/Support - AVM & PG Teams GitHub Repo Permissions
 
-A module owner **MUST** make the following GitHub Teams in the Azure GitHub organization admins on the GitHub repo of the module in question:
+A module owner **MUST** make the following GitHub teams in the Azure GitHub organization admins on the GitHub repo of the module in question:
 
 ##### Bicep
 
@@ -540,7 +545,7 @@ A module owner **MUST** make the following GitHub Teams in the Azure GitHub orga
 - [`@Azure/bicep-admins`](https://github.com/orgs/Azure/teams/bicep-admins) = Bicep PG team
 
 {{< hint type=note >}}
-These required GitHub Teams are already associated to the [BRM](https://aka.ms/BRM) repository and have the required permissions.
+These required GitHub teams are already associated to the [BRM](https://aka.ms/BRM) repository and have the required permissions.
 {{< /hint >}}
 
 ##### Terraform
@@ -549,7 +554,7 @@ These required GitHub Teams are already associated to the [BRM](https://aka.ms/B
 - [`@Azure/terraform-azure`](https://github.com/orgs/Azure/teams/terraform-azure) = Terraform PG
 
 {{< hint type=important >}}
-Module owners **MUST** assign these GitHub Teams as admins on the GitHub repo of the module in question.
+Module owners **MUST** assign these GitHub teams as admins on the GitHub repo of the module in question.
 
 For detailed steps, please follow this [guidance](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-teams-and-people-with-access-to-your-repository#inviting-a-team-or-person).
 {{< /hint >}}

--- a/docs/static/includes/msg-final-conf-new-orph-mod-owners.md
+++ b/docs/static/includes/msg-final-conf-new-orph-mod-owners.md
@@ -17,11 +17,4 @@ Any further questions or clarifications needed, let us know!
 Thanks,
 
 The AVM Core Team
-
-<br>
-
-> **NOTE**:
->
-> - This Orphaned Module issue **MUST remain open** until the ownership is fully confirmed!
-> - Once the Orphaned Module issue was closed, it **MUST remain closed**. If the module will subsequently become orphaned again, a new Orphaned Module issue must be opened.
 <!-- markdownlint-restore -->

--- a/docs/static/includes/msg-final-conf-new-orph-mod-owners.md
+++ b/docs/static/includes/msg-final-conf-new-orph-mod-owners.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable -->
-Hi @{requestor/proposed owner's GitHub alias},
+Hi @{module_owner},
 
 Thanks for confirming that you wish to own this AVM module and understand the related requirements and responsibilities!
 

--- a/docs/static/includes/msg-final-conf-new-orph-mod-owners.md
+++ b/docs/static/includes/msg-final-conf-new-orph-mod-owners.md
@@ -7,7 +7,7 @@ We just want to ask you to double check a few important things.
 
 **Please use the following values explicitly as provided in the [module index](https://azure.github.io/Azure-Verified-Modules/indexes/) page**:
 
-- You must be the owner of the GitHub teams defined in the `ModuleOwnersGHTeam` and `ModuleContributorsGHTeam` columns
+- You must be the owner of the GitHub teams as outlined [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-snfr20---category-contributionsupport---github-teams-only).
 - Please check that your name has been updated in the module index page (this should happen shortly after you confirmed ownership).
 
 You can now take ownership of this module and start improving it as needed! ✅ Happy coding! 🎉

--- a/docs/static/includes/msg-final-conf-new-prop-mod-owners.md
+++ b/docs/static/includes/msg-final-conf-new-prop-mod-owners.md
@@ -1,37 +1,27 @@
 <!-- markdownlint-disable -->
-Hi @{requestor/proposed owner's GitHub alias},
+Hi @{module_owner},
 
 Thanks for confirming that you wish to own this AVM module and understand the related requirements and responsibilities!
 
-We just want to ask you to double check a few important things and take the next steps before you start the development.
+Before starting development, please ensure ALL the following requirements are met.
 
 **Please use the following values explicitly as provided in the [module index](https://azure.github.io/Azure-Verified-Modules/indexes/) page**:
 
 - For your module:
-  - `ModuleName` - to name your module
-  - `TelemetryIdPrefix` - to be used in your module's [telemetry](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-sfr3---category-telemetry---deploymentusage-telemetry)
+  - `ModuleName` - for naming your module
+  - `TelemetryIdPrefix` - for your module's [telemetry](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-sfr3---category-telemetry---deploymentusage-telemetry)
 - For your module's repository:
-  - Repository name and folder path are defined in `RepoURL`
-  - Create the GitHub teams defined in the `ModuleOwnersGHTeam` and `ModuleContributorsGHTeam` columns and grant them permissions as described [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-snfr20---category-contributionsupport---github-teams-only).
-    - In case of a Bicep module, **please let the AVM core team know** when you created these teams, and we'll help you with assigning the necessary permissions as described [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#grant-permissions---bicep).
-    - In case of a Terraform module, follow the instructions [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#grant-permissions---terraform) and assign the necessary permissions.
-
-Grant the right level of permissions for  the AVM core team and PG teams on your GitHub repo as described [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-snfr9---category-contributionsupport---avm--pg-teams-github-repo-permissions).
+  - Repo name and folder path are defined in `RepoURL`
+  - Create GitHub teams for module owners and contributors and grant them permissions as outlined [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-snfr20---category-contributionsupport---github-teams-only).
+  - Grant permissions for the AVM core team and PG teams on your GitHub repo as described [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-snfr9---category-contributionsupport---avm--pg-teams-github-repo-permissions).
 
 You can now start the development of this module! ✅ Happy coding! 🎉
 
-**Please respond to this comment and request a review from the AVM core team once your module is ready to be published!** Please include a link pointing to your PR if available. 🙏
+**Please respond to this comment and request a review from the AVM core team once your module is ready to be published! Please include a link pointing to your PR, once available. 🙏**
 
 Any further questions or clarifications needed, let us know!
 
 Thanks,
 
 The AVM Core Team
-
-<br>
-
-> **NOTE**:
->
-> - This Module Proposal issue **MUST remain open** until the module is fully developed, tested and published to the relevant registry. **Do NOT close** the issue before the successful publication is confirmed!
-> - Once the module is fully developed, tested and published to the relevant registry, and the Module Proposal issue was closed, it **MUST remain closed**.
 <!-- markdownlint-restore -->

--- a/docs/static/includes/msg-final-conf-new-prop-mod-owners.md
+++ b/docs/static/includes/msg-final-conf-new-prop-mod-owners.md
@@ -15,6 +15,8 @@ Before starting development, please ensure ALL the following requirements are me
   - Create GitHub teams for module owners and contributors and grant them permissions as outlined [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-snfr20---category-contributionsupport---github-teams-only).
   - Grant permissions for the AVM core team and PG teams on your GitHub repo as described [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-snfr9---category-contributionsupport---avm--pg-teams-github-repo-permissions).
 
+Check if this module exists in the other IaC language. If so, collaborate with the other owner for consistency. 👍
+
 You can now start the development of this module! ✅ Happy coding! 🎉
 
 **Please respond to this comment and request a review from the AVM core team once your module is ready to be published! Please include a link pointing to your PR, once available. 🙏**

--- a/docs/static/includes/msg-std-reply-new-orph-mod-owners.md
+++ b/docs/static/includes/msg-std-reply-new-orph-mod-owners.md
@@ -20,11 +20,4 @@ Thanks,
 The AVM Core Team
 
 #RR
-
-<br>
-
-> **NOTE**:
->
-> - This Orphaned Module issue **MUST remain open** until the ownership is fully confirmed!
-> - Once the Orphaned Module issue was closed, it **MUST remain closed**. If the module will subsequently become orphaned again, a new Orphaned Module issue must be opened.
 <!-- markdownlint-restore -->

--- a/docs/static/includes/msg-std-reply-new-orph-mod-owners.md
+++ b/docs/static/includes/msg-std-reply-new-orph-mod-owners.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable -->
-Hi @{requestor/proposed owner's GitHub alias},
+Hi @{module_owner},
 
 Thanks for requesting/proposing to be an AVM module owner!
 

--- a/docs/static/includes/msg-std-reply-new-prop-mod-owners.md
+++ b/docs/static/includes/msg-std-reply-new-prop-mod-owners.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable -->
-Hi @{requestor/proposed owner's GitHub alias},
+Hi @{module_owner},
 
 Thanks for requesting/proposing to be an AVM module owner!
 

--- a/docs/static/includes/msg-std-reply-new-prop-mod-owners.md
+++ b/docs/static/includes/msg-std-reply-new-prop-mod-owners.md
@@ -20,11 +20,4 @@ Thanks,
 The AVM Core Team
 
 #RR
-
-<br>
-
-> **NOTE**:
->
-> - This Module Proposal issue **MUST remain open** until the module is fully developed, tested and published to the relevant registry. **Do NOT close** the issue before the successful publication is confirmed!
-> - Once the module is fully developed, tested and published to the relevant registry, and the Module Proposal issue was closed, it **MUST remain closed**.
 <!-- markdownlint-restore -->


### PR DESCRIPTION
# Overview/Summary

Documentation and module triage updates

## This PR fixes/adds/changes/removes

- clarifying GH team naming conventions
- clarifying SNFR20 module owner tasks
- moving "issue must remain open" notice from standard messages to module proposal and orphaned module issue templates
- shortening standard messages

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
