### PR TITLE
fix GH policy service bug; add saved issue queries; clarify non-FTE permissions in SNFR20

### DIFF
--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -133,7 +133,21 @@ configuration:
               label: 'Status: Owners Identified :metal:'
         triggerOnOwnActions: true
 
-      - description: 'ITA17 - If the issue author says they want to be the module owner, assign the issue to the author and respond to them.'
+      - description: 'ITA17A - If the issue author says they want to be the module owner, assign the issue to the author and respond to them.'
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: |
+                ### Do you want to be the owner of this module?
+
+                Yes
+        then:
+          - assignTo:
+              author: true
+
+      - description: 'ITA17B - If the issue author says they want to be the module owner, assign the issue to the author and respond to them.'
         if:
           - payloadType: Issues
           - isAction:
@@ -151,8 +165,6 @@ configuration:
                 **Please don't start the development just yet!**
 
                 The AVM core team will review this module proposal and respond to you first. Thank you!
-          - assignTo:
-              author: true
 
       - description: 'ITA18 - Send automatic response to the issue author if they don''t want to be module owner and don''t have any candidate in mind. Assign the "Needs: Module Owner :mega:" label.'
         if:

--- a/docs/content/help-support/issue-triage/avm-issue-triage.md
+++ b/docs/content/help-support/issue-triage/avm-issue-triage.md
@@ -19,8 +19,18 @@ Every module needs a module proposal to be created in the AVM repository. This a
 {{< /hint >}}
 
 {{< hint type=tip >}}
-- To look for items that **need triaging**, click on the following link to use this saved query ➡️ <a href="https://aka.ms/AVM/NeedsTriage"><mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark></a> ⬅️.
-- To look for items that **need attention**, click on the following link to use this saved query ➡️ <a href="https://aka.ms/AVM/NeedsAttention"><mark style="background-color:#E99695;color:white;">Needs: Attention 👋</mark></a> ⬅️.
+During the triage process, the AVM Core Team should also check the status of following queries:
+
+- Open items that **need triaging**: <a href="https://aka.ms/AVM/NeedsTriage"><mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark></a>
+  - Bicep items (that need triaging): <a href="https://aka.ms/AVM/NeedsTriageBicep"><mark style="background-color:#1D73B3;color:white;">Language: Bicep 💪</mark> & <mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark></a>
+  - Terraform items (that need triaging): <a href="https://aka.ms/AVM/NeedsTriageTerraform"><mark style="background-color:#7740B6;color:white;">Language: Terraform 🌐</mark> & <mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark></a>
+- Open items that **need attention**: <a href="https://aka.ms/AVM/NeedsAttention"><mark style="background-color:#E99695;">Needs: Attention 👋</mark></a>
+- Open items that **need owners**: <a href="https://aka.ms/AVM/NeedsModuleOwner"><mark style="background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark></a>
+- Open items with **no recent activity**: <a href="https://aka.ms/AVM/NoRecentActivity"><mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark></a>
+- Open **question/feedback** items: <a href="https://aka.ms/AVM/QuestionsFeedback"><mark style="background-color:#CB6BA2;color:white;">Type: Question/Feedback 🙋‍♀️</mark></a>
+- Open items with **long term** status: <a href="https://aka.ms/AVM/StatusLongTerm"><mark style="background-color:#B60205;color:white;">Status: long-term ⏳</mark></a>
+- Open items that are <a href="https://aka.ms/AVM/NotInAProject">**not in a project**</a>.
+
 {{< /hint >}}
 
 <br>

--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -455,6 +455,10 @@ The `@Azure` prefix in the last column of the tables linked above represents the
 
 {{< /hint >}}
 
+{{< hint type=important >}}
+Non-FTE / external contributors (subject matter experts that aren't Microsoft employees) can't be members of the teams described in this chapter, hence, they won't gain any extra permissions on AVM repositories, therefore, they need to work in forks.
+{{< /hint >}}
+
 <br>
 
 ##### Naming Convention


### PR DESCRIPTION
# Overview/Summary

This PR has multiple minor improvements related to the triage process and SNFR20.

## This PR fixes/adds/changes/removes

- fix GH policy service bug
- add saved issue queries
- clarify non-FTE permissions in SNFR20

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
