### PR TITLE
[bug]: Fixing Function Name in AVM Team Linter

### DIFF
--- a/utilities/pipelines/sharedScripts/teamLinter/Get-AvmCsvData.ps1
+++ b/utilities/pipelines/sharedScripts/teamLinter/Get-AvmCsvData.ps1
@@ -1,4 +1,4 @@
-Function Get-AvmCsv {
+Function Get-AvmCsvData {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/utilities/pipelines/sharedScripts/teamLinter/Invoke-AvmGitHubTeamLinter.ps1
+++ b/utilities/pipelines/sharedScripts/teamLinter/Invoke-AvmGitHubTeamLinter.ps1
@@ -78,7 +78,7 @@ Function Invoke-AvmGitHubTeamLinter {
   }
 
     # Retrieve the CSV file
-    $sourceData = Get-AvmCsv -ModuleIndex $ModuleIndex
+    $sourceData = Get-AvmCsvData -ModuleIndex $ModuleIndex
     $gitHubTeamsData = Get-AvmGitHubTeamsData -TeamFilter $TeamFilter
     $unmatchedTeams = @()
     # Iterate through each object in $csv


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixing function name as issue found in test run: 
![image](https://github.com/Azure/Azure-Verified-Modules/assets/48600046/69535de5-0098-459c-adb4-d0dea9d8eafb)


Run with Fix:
[![Github Team - Check Existance](https://github.com/Azure/Azure-Verified-Modules/actions/workflows/github-teams-check-existance.yml/badge.svg)](https://github.com/Azure/Azure-Verified-Modules/actions/workflows/github-teams-check-existance.yml)

## This PR fixes/adds/changes/removes

### Breaking Changes

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
