### PR TITLE
[bug]: Adding Publishing Logic to determine branch

### DIFF
--- a/.github/workflows/github-teams-check-existance.yml
+++ b/.github/workflows/github-teams-check-existance.yml
@@ -63,7 +63,7 @@ jobs:
           if ($branchName -eq "main"){
               $functionInput['CreateIssues'] = $true
           }
-          Write-Verbose 'Ref: $($env:branchName)' -Verbose
+          Write-Verbose "Ref: $($env:branchName)" -Verbose
           Write-Verbose 'Invoke task with' -Verbose
           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 

--- a/.github/workflows/github-teams-check-existance.yml
+++ b/.github/workflows/github-teams-check-existance.yml
@@ -59,7 +59,7 @@ jobs:
           }
 
 
-          $branchName = $env:GITHUB_REF -replace 'refs/heads/', ''
+          $branchName = $env:GITHUB_REF_NAME -replace 'refs/heads/', ''
           if ($branchName -eq "main"){
               $functionInput['CreateIssues'] = $true
           }

--- a/.github/workflows/github-teams-check-existance.yml
+++ b/.github/workflows/github-teams-check-existance.yml
@@ -88,8 +88,10 @@ jobs:
             ValidateBicepParentConfiguration  = $true
           }
 
-          if ($env.GITHUB_REF_NAME -eq "main"){
-            $functionInput['CreateIssues'] = $true
+          $branch = git branch --show-current
+          $branchName = $branch.split('/')[-1]
+          if ($branchName -eq "main"){
+              $functionInput['CreateIssues'] = $true
           }
 
           Write-Verbose 'Invoke task with' -Verbose
@@ -115,8 +117,10 @@ jobs:
             ValidateBicepParentConfiguration  = $true
           }
 
-          if ($env.GITHUB_REF_NAME -eq "main"){
-            $functionInput['CreateIssues'] = $true
+          $branch = git branch --show-current
+          $branchName = $branch.split('/')[-1]
+          if ($branchName -eq "main"){
+              $functionInput['CreateIssues'] = $true
           }
 
           Write-Verbose 'Invoke task with' -Verbose
@@ -140,8 +144,10 @@ jobs:
             ValidateTerraformTeamsPermissons = $true
           }
 
-          if ($env.GITHUB_REF_NAME -eq "main"){
-            $functionInput['CreateIssues'] = $true
+          $branch = git branch --show-current
+          $branchName = $branch.split('/')[-1]
+          if ($branchName -eq "main"){
+              $functionInput['CreateIssues'] = $true
           }
 
           Write-Verbose 'Invoke task with' -Verbose
@@ -165,8 +171,10 @@ jobs:
             ValidateTerraformTeamsPermissons  = $true
           }
 
-          if ($env.GITHUB_REF_NAME -eq "main"){
-            $functionInput['CreateIssues'] = $true
+          $branch = git branch --show-current
+          $branchName = $branch.split('/')[-1]
+          if ($branchName -eq "main"){
+              $functionInput['CreateIssues'] = $true
           }
 
           Write-Verbose 'Invoke task with' -Verbose

--- a/.github/workflows/github-teams-check-existance.yml
+++ b/.github/workflows/github-teams-check-existance.yml
@@ -62,7 +62,7 @@ jobs:
           if ($env.GITHUB_REF_NAME -eq "main"){
             $functionInput['CreateIssues'] = $true
           }
-
+          Write-Verbose 'Ref: $($env:GITHUB_REF_NAME)' -Verbose
           Write-Verbose 'Invoke task with' -Verbose
           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 

--- a/.github/workflows/github-teams-check-existance.yml
+++ b/.github/workflows/github-teams-check-existance.yml
@@ -58,8 +58,8 @@ jobs:
             ValidateBicepParentConfiguration  = $true
           }
 
-
-          $branchName = $GITHUB_REF_NAME -replace 'refs/heads/', ''
+          $branch = git branch --show-current
+          $branchName = $branch.split('/')[-1]
           if ($branchName -eq "main"){
               $functionInput['CreateIssues'] = $true
           }

--- a/.github/workflows/github-teams-check-existance.yml
+++ b/.github/workflows/github-teams-check-existance.yml
@@ -63,7 +63,7 @@ jobs:
           if ($branchName -eq "main"){
               $functionInput['CreateIssues'] = $true
           }
-          Write-Verbose "Ref: $($env:branchName)" -Verbose
+          Write-Verbose "Ref: $($branchName)" -Verbose
           Write-Verbose 'Invoke task with' -Verbose
           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 

--- a/.github/workflows/github-teams-check-existance.yml
+++ b/.github/workflows/github-teams-check-existance.yml
@@ -59,10 +59,11 @@ jobs:
           }
 
 
-          if ($env.GITHUB_REF_NAME -eq "main"){
-            $functionInput['CreateIssues'] = $true
+          $branchName = $env:GITHUB_REF -replace 'refs/heads/', ''
+          if ($branchName -eq "main"){
+              $functionInput['CreateIssues'] = $true
           }
-          Write-Verbose 'Ref: $($env:GITHUB_REF_NAME)' -Verbose
+          Write-Verbose 'Ref: $($env:branchName)' -Verbose
           Write-Verbose 'Invoke task with' -Verbose
           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 

--- a/.github/workflows/github-teams-check-existance.yml
+++ b/.github/workflows/github-teams-check-existance.yml
@@ -59,7 +59,7 @@ jobs:
           }
 
 
-          $branchName = $env:GITHUB_REF_NAME -replace 'refs/heads/', ''
+          $branchName = $GITHUB_REF_NAME -replace 'refs/heads/', ''
           if ($branchName -eq "main"){
               $functionInput['CreateIssues'] = $true
           }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixing the branch logic from GitHub ENV which is not available to git ref. This uses the same logic applied at publishing level

[![Github Team - Check Existance](https://github.com/Azure/Azure-Verified-Modules/actions/workflows/github-teams-check-existance.yml/badge.svg)](https://github.com/Azure/Azure-Verified-Modules/actions/workflows/github-teams-check-existance.yml)

## This PR fixes/adds/changes/removes

### Breaking Changes

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
