### PR TITLE
fixes: Added missing `.` at the end of the `conditions` parameter's description

### DIFF
--- a/docs/static/includes/interfaces/int.rbac.udt.schema.bicep
+++ b/docs/static/includes/interfaces/int.rbac.udt.schema.bicep
@@ -11,7 +11,7 @@ type roleAssignmentType = {
   @description('Optional. The description of the role assignment.')
   description: string?
 
-  @description('Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container"')
+  @description('Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container".')
   condition: string?
 
   @description('Optional. Version of the condition.')


### PR DESCRIPTION
Added missing `.` at the end of the `conditions` parameter's description