### PR TITLE
fix: team-linter issue duplication

### DIFF
--- a/utilities/pipelines/sharedScripts/teamLinter/Find-GitHubIssue.ps1
+++ b/utilities/pipelines/sharedScripts/teamLinter/Find-GitHubIssue.ps1
@@ -6,7 +6,7 @@ function Find-GithubIssue {
         [string]$title
     )
 
-    $issueList = gh issue list --json number,title,assignees,labels,id | ConvertFrom-Json
+    $issueList = gh issue list --limit 500 --json number,title,assignees,labels,id | ConvertFrom-Json
     $issueDetails = $null
 
     foreach ($issueItem in $issueList) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

@matebarabas made me aware the team linter seems to be duplicating #399  & #400. This PR fixes this duplication cuased by the default value `gh cli` adds to the returned issues in a list

## This PR fixes/adds/changes/removes

1. limit updated `30 (default) > 500' 

### Breaking Changes

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
