### PR TITLE
update SNFR20 with direct link to GH team creation

### DIFF
--- a/docs/content/contributing/q-and-a.md
+++ b/docs/content/contributing/q-and-a.md
@@ -79,7 +79,7 @@ You can propose a new module [here][ModuleProposal].
 
 ### How long will it take for someone to respond and a module to be created/updated and published?
 
-Whilst there are SLAs defined for providing [support][ModuleSupport] for existing modules, there are currently no SLAs in place for the creation of new modules. The AVM core team is a small team and is currently working on automating the module creation process to make it as easy as possible for module owners to create and publish modules on their own.
+While there are SLAs defined for providing [support][ModuleSupport] for existing modules, there are currently no SLAs in place for the creation of new modules. The AVM core team is a small team and is currently working on automating the module creation process to make it as easy as possible for module owners to create and publish modules on their own.
 
 Beside of providing program level governance, the [AVM core team][AVMCoreTeam] is mainly responsible for defining the module specifications, providing tooling (such as test frameworks and pipelines), guidance and support to module owners, as well as facilitating the creation of new modules by maintaining the module catalog and identifying volunteers for owning the modules. However, modules will be created and maintained by a broader community of [module owners][ModuleOwners].
 

--- a/docs/content/faq/_index.md
+++ b/docs/content/faq/_index.md
@@ -150,7 +150,7 @@ In these scenarios the AVM modules will not enforce the additional resources to 
 
 {{< hint type=important >}}
 
-Whilst every Well-Architected Framework pillar's recommendations should equally be considered by the module owners/contributors, within AVM we are taking an approach to prioritize reliability and security over cost optimization. This provides consumers of the AVM modules, by default, more resilient and secure resources and patterns.
+While every Well-Architected Framework pillar's recommendations should equally be considered by the module owners/contributors, within AVM we are taking an approach to prioritize reliability and security over cost optimization. This provides consumers of the AVM modules, by default, more resilient and secure resources and patterns.
 
 However, please note these defaulted values can be altered via input parameter/variables in each of the modules so that you can meet your specific requirements.
 
@@ -186,7 +186,7 @@ If the relevant AVM module isn't available to use to assist the Landing Zone Acc
 
 ## Does/will AVM cover Microsoft 365, Azure DevOps, GitHub, etc.?
 
-Whilst the principles and practices of AVM are largely applicable to other clouds and services such as, Microsoft 365 & Azure DevOps, the AVM program (today) only covers Azure cloud resources and architectures.
+While the principles and practices of AVM are largely applicable to other clouds and services such as, Microsoft 365 & Azure DevOps, the AVM program (today) only covers Azure cloud resources and architectures.
 
 However, if you think this program, or a similar one, should exist to cover these other Microsoft Cloud offerings, please give a 👍 or leave a comment on this [GitHub Issue #71](https://github.com/Azure/Azure-Verified-Modules/issues/71) in the AVM repository.
 

--- a/docs/content/help-support/issue-triage/brm-issue-triage.md
+++ b/docs/content/help-support/issue-triage/brm-issue-triage.md
@@ -33,7 +33,7 @@ Every module needs a module proposal to be created in the AVM repository. This a
 
 During the triage process, module owners are expected to check, complete and follow up on the items described in the sections below.
 
-Module owners **MUST** meet the SLAs defined on the [Module Support](/Azure-Verified-Modules/help-support/module-support/) page! Whilst there's automation in place to support meeting these SLAs, module owners **MUST** check for new issues on a regular basis.
+Module owners **MUST** meet the SLAs defined on the [Module Support](/Azure-Verified-Modules/help-support/module-support/) page! While there's automation in place to support meeting these SLAs, module owners **MUST** check for new issues on a regular basis.
 
 {{< hint type=important >}}
 The [BRM repository](https://aka.ms/BRM) includes other, non-AVM modules and related GitHub issues. As a module owner, make sure you're only triaging, managing or otherwise working on issues that are related to AVM modules!

--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -42,7 +42,7 @@ Listed below are both functional and non-functional requirements for both classi
 
 {{< hint type=note >}}
 
-Whilst every effort is being made to standardize requirements and implementation details across all languages, it is expected that some of the specifications will be different between their respective languages to ensure we follow the best practices and leverage features of each language.
+While every effort is being made to standardize requirements and implementation details across all languages, it is expected that some of the specifications will be different between their respective languages to ensure we follow the best practices and leverage features of each language.
 
 {{< /hint >}}
 
@@ -506,21 +506,33 @@ Unless explicitly requested and agreed, members of the AVM core team or any PG t
 
 {{< hint type=note >}}
 
-In case of Bicep modules, permissions to the [BRM](https://aka.ms/BRM) repository (the repo of the Bicep Registry) are granted via assigning the `-module-owners-` and `-module-contributors-` teams to parent teams that already have the required level access configured. Whilst it's the module owner's responsibility to initiate the addition of their teams to the respective parents, only the AVM core team can approve this parent-child relationship.
+In case of Bicep modules, permissions to the [BRM](https://aka.ms/BRM) repository (the repo of the Bicep Registry) are granted via assigning the `-module-owners-` and `-module-contributors-` teams to parent teams that already have the required level access configured. While it is the module owner's responsibility to initiate the addition of their teams to the respective parents, only the AVM core team can approve this parent-child relationship.
 
 {{< /hint >}}
 
-Module owners **MUST** create their `-module-owners-` and `-module-contributors-` teams and as part of the provisioning process, they **MUST** request the addition of these teams to their respective parent teams (see the table below for details). Direct link to perform these actions: [Create new team](https://github.com/orgs/Azure/new-team)
+Module owners **MUST** create their `-module-owners-` and `-module-contributors-` teams and as part of the provisioning process, they **MUST** request the addition of these teams to their respective parent teams (see the table below for details).
 
-| GitHub Team Name                                     | Description                                                                  | Permissions | Permissions granted through                                        | Where to work?          |
-|------------------------------------------------------|------------------------------------------------------------------------------|-------------|--------------------------------------------------------------------|-------------------------|
-| `<hyphenated module name>-module-owners-bicep`       | Module Owners of the <module name> AVM Bicep <resource/pattern> module       | **Write**   | Assignment to the **`avm-technical-reviewers-bicep`** parent team. | Need to work in a fork. |
-| `<hyphenated module name>-module-contributors-bicep` | Module Contributors of the <module name> AVM Bicep <resource/pattern> module | **Triage**  | **`avm-module-contributors-bicep`** parent team.                   | Need to work in a fork. |
+| GitHub Team Name                                     | Description                                    | Permissions | Permissions granted through                                        | Where to work?          |
+|------------------------------------------------------|------------------------------------------------|-------------|--------------------------------------------------------------------|-------------------------|
+| `<hyphenated module name>-module-owners-bicep`       | AVM Bicep Module Owners - \<module name>       | **Write**   | Assignment to the **`avm-technical-reviewers-bicep`** parent team. | Need to work in a fork. |
+| `<hyphenated module name>-module-contributors-bicep` | AVM Bicep Module Contributors - \<module name> | **Triage**  | **`avm-module-contributors-bicep`** parent team.                   | Need to work in a fork. |
 
 Examples - GitHub teams required for the Bicep resource module of Azure Virtual Network (`avm/res/network/virtual-network`):
 
 - `avm-res-network-virtualnetwork-module-owners-bicep` --> assign to the `avm-technical-reviewers-bicep` parent team.
 - `avm-res-network-virtualnetwork-module-contributors-bicep` --> assign to the `avm-module-contributors-bicep` parent team.
+
+{{< hint type=tip >}}
+Direct link to create a new GitHub team and assign it to its parent: [Create new team](https://github.com/orgs/Azure/new-team)
+
+Fill in the values as follows:
+
+- **Team name**: Following the naming convention described above, use the value defined in the module indexes.
+- **Description**: Follow the guidance above (see the Description column in the table above).
+- **Parent team**: Follow the guidance above (see the Permissions granted through column in the table above).
+- **Team visibility**: `Visible`
+- **Team notifications**: `Enabled`
+{{< /hint >}}
 
 ##### CODEOWNERS file
 
@@ -546,10 +558,10 @@ Example - `CODEOWNERS` entry for the Bicep resource module of Azure Virtual Netw
 
 Module owners **MUST** assign the `-module-owners-`and `-module-contributors-` teams the necessary permissions on their Terraform module repository and edit the `CODEOWNERS` file as per the guidance below.
 
-| GitHub Team Name                       | Description                                                                      | Permissions | Permissions granted through | Where to work?                                                                                |
-|----------------------------------------|----------------------------------------------------------------------------------|-------------|-----------------------------|-----------------------------------------------------------------------------------------------|
-| `<module name>-module-owners-tf`       | Module Owners of the <module name> AVM Terraform <resource/pattern> module       | **Admin**   | Direct assignment to repo   | Module owner can decide whether they want to work in a branch local to the repo or in a fork. |
-| `<module name>-module-contributors-tf` | Module Contributors of the <module name> AVM Terraform <resource/pattern> module | **Write**   | Direct assignment to repo   | Need to work in a fork.                                                                       |
+| GitHub Team Name                       | Description                                       | Permissions | Permissions granted through | Where to work?                                                                                |
+|----------------------------------------|---------------------------------------------------|-------------|-----------------------------|-----------------------------------------------------------------------------------------------|
+| `<module name>-module-owners-tf`       | AVM Terraform Module Owners - \<module name>       | **Admin**   | Direct assignment to repo   | Module owner can decide whether they want to work in a branch local to the repo or in a fork. |
+| `<module name>-module-contributors-tf` | AVM Terraform Module Contributors - \<module name> | **Write**   | Direct assignment to repo   | Need to work in a fork.                                                                       |
 
 {{< hint type=important >}}
 
@@ -557,6 +569,18 @@ The `CODEOWNERS` file **MUST** be updated for every module to be onboarded: the 
 
 For more details on how to modify the `CODEOWNERS` file, please see the [documentation on Github](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
 
+{{< /hint >}}
+
+{{< hint type=tip >}}
+Direct link to create a new GitHub team: [Create new team](https://github.com/orgs/Azure/new-team)
+
+Fill in the values as follows:
+
+- **Team name**: Following the naming convention described above, use the value defined in the module indexes.
+- **Description**: Follow the guidance above (see the Description column in the table above).
+- **Parent team**: Do not assign the team to any parent team.
+- **Team visibility**: `Visible`
+- **Team notifications**: `Enabled`
 {{< /hint >}}
 
 <br>

--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -510,7 +510,7 @@ In case of Bicep modules, permissions to the [BRM](https://aka.ms/BRM) repositor
 
 {{< /hint >}}
 
-Module owners **MUST** create their `-module-owners-` and `-module-contributors-` teams and as part of the provisioning process, they **MUST** request the addition of these teams to their respective parent teams (see the table below for details). Direct link to perform these actions: https://github.com/orgs/Azure/new-team
+Module owners **MUST** create their `-module-owners-` and `-module-contributors-` teams and as part of the provisioning process, they **MUST** request the addition of these teams to their respective parent teams (see the table below for details). Direct link to perform these actions: [Create new team](https://github.com/orgs/Azure/new-team)
 
 | GitHub Team Name                                     | Description                                                                  | Permissions | Permissions granted through                                        | Where to work?          |
 |------------------------------------------------------|------------------------------------------------------------------------------|-------------|--------------------------------------------------------------------|-------------------------|

--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -506,11 +506,11 @@ Unless explicitly requested and agreed, members of the AVM core team or any PG t
 
 {{< hint type=note >}}
 
-In case of Bicep modules, permissions to the [BRM](https://aka.ms/BRM) repository (the repo of the Bicep Registry) are granted via assigning the `-module-owners-` and `-module-contributors-` teams to parent teams that already have the required level access configured. Whilst it't the module owner's responsibility to initiate the addition of their teams to the respective parents, only the AVM core team **CAN** approve this parent-child relationship.
+In case of Bicep modules, permissions to the [BRM](https://aka.ms/BRM) repository (the repo of the Bicep Registry) are granted via assigning the `-module-owners-` and `-module-contributors-` teams to parent teams that already have the required level access configured. Whilst it's the module owner's responsibility to initiate the addition of their teams to the respective parents, only the AVM core team can approve this parent-child relationship.
 
 {{< /hint >}}
 
-Module owners **MUST** create their `-module-owners-` and `-module-contributors-` teams and as part of the provisioning process, they **MUST** request the addition of these teams to their respective parent teams (see the table below for details).
+Module owners **MUST** create their `-module-owners-` and `-module-contributors-` teams and as part of the provisioning process, they **MUST** request the addition of these teams to their respective parent teams (see the table below for details). Direct link to perform these actions: https://github.com/orgs/Azure/new-team
 
 | GitHub Team Name                                     | Description                                                                  | Permissions | Permissions granted through                                        | Where to work?          |
 |------------------------------------------------------|------------------------------------------------------------------------------|-------------|--------------------------------------------------------------------|-------------------------|

--- a/docs/content/specs/shared/module-lifecycle.md
+++ b/docs/content/specs/shared/module-lifecycle.md
@@ -31,7 +31,7 @@ It is critical to the consumers experience that modules continue to be maintaine
 1. The module owner is responsible for finding a replacement owner and providing a handover.
 2. If no replacement can be found or the module owner leaves Microsoft without giving warning to the AVM core team, the AVM core team will provide essential maintenance (critical bug and security fixes), as per the [Module Support page](/Azure-Verified-Modules/help-support/module-support/)
 3. The AVM core team will continue to try and re-assign the module ownership.
-4. Whilst a module is in an orphaned state, only security and bug fixes **MUST** be made, no new feature development will be worked on until a new owner is found that can then lead this effort for the module.
+4. While a module is in an orphaned state, only security and bug fixes **MUST** be made, no new feature development will be worked on until a new owner is found that can then lead this effort for the module.
 5. An issue will be created on the central AVM repo (`Azure/Azure-Verified-Modules`) to track the finding of a new owner for a module
 
 ### Notification of a Module Becoming Orphaned


### PR DESCRIPTION
# Overview/Summary

## This PR fixes/adds/changes/removes

Update SNFR20 with direct link to GH team creation and additional clarification on steps of team creation and their assignment to parent teams.

Related issue: #479

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
