### PR TITLE
ITA24 - update scheduled search

### DIFF
--- a/.github/policies/scheduledSearches.yml
+++ b/.github/policies/scheduledSearches.yml
@@ -78,6 +78,8 @@ configuration:
       - isOpen
       - hasLabel:
           label: 'Type: New Module Proposal :bulb:'
+      - hasLabel:
+          label: 'Status: Owners Identified :metal:'
       - noActivitySince:
           days: 21
       - isNotLabeledWith:

--- a/.github/policies/scheduledSearches.yml
+++ b/.github/policies/scheduledSearches.yml
@@ -83,7 +83,7 @@ configuration:
       - noActivitySince:
           days: 21
       - isNotLabeledWith:
-          label: 'Status: No Recent Activity :zzz:'
+          label: 'Status: Long Term :hourglass_flowing_sand:'
       actions:
       - addReply:
           reply: |


### PR DESCRIPTION
# Overview/Summary

## This PR fixes/adds/changes/removes

Updating ITA24 scheduled search, so that it only gets triggered when a module proposal does have an owner identified.

This has previously left messages, such as "**no assignees**, this issue has not had any activity in the last 3 weeks. Please feel free to reach out to the AVM core team should you have any questions or need any help with the development of this module."

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
