### PR TITLE
docs: remove codeowners requirement for terraform

### DIFF
--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -556,20 +556,12 @@ Example - `CODEOWNERS` entry for the Bicep resource module of Azure Virtual Netw
 
 ##### Grant Permissions - Terraform
 
-Module owners **MUST** assign the `-module-owners-`and `-module-contributors-` teams the necessary permissions on their Terraform module repository and edit the `CODEOWNERS` file as per the guidance below.
+Module owners **MUST** assign the `-module-owners-`and `-module-contributors-` teams the necessary permissions on their Terraform module repository per the guidance below.
 
 | GitHub Team Name                       | Description                                       | Permissions | Permissions granted through | Where to work?                                                                                |
 |----------------------------------------|---------------------------------------------------|-------------|-----------------------------|-----------------------------------------------------------------------------------------------|
 | `<module name>-module-owners-tf`       | AVM Terraform Module Owners - \<module name>       | **Admin**   | Direct assignment to repo   | Module owner can decide whether they want to work in a branch local to the repo or in a fork. |
 | `<module name>-module-contributors-tf` | AVM Terraform Module Contributors - \<module name> | **Write**   | Direct assignment to repo   | Need to work in a fork.                                                                       |
-
-{{< hint type=important >}}
-
-The `CODEOWNERS` file **MUST** be updated for every module to be onboarded: the `-module-owners-`team **MUST** be added **for all code in the repo**.
-
-For more details on how to modify the `CODEOWNERS` file, please see the [documentation on Github](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
-
-{{< /hint >}}
 
 {{< hint type=tip >}}
 Direct link to create a new GitHub team: [Create new team](https://github.com/orgs/Azure/new-team)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

The spec is out of date for the requirements for CODEOWNERS in Terraform. It is handled by grept and only needs a couple of files to be controlled.

## This PR fixes/adds/changes/removes

N/A

### Breaking Changes

None, docs only.

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
