### PR TITLE
Fix - refactor `customer_managed_key` interface type

### DIFF
--- a/docs/static/includes/interfaces/int.cmk.schema.tf
+++ b/docs/static/includes/interfaces/int.cmk.schema.tf
@@ -1,9 +1,11 @@
 variable "customer_managed_key" {
   type = object({
-    key_vault_resource_id              = string
-    key_name                           = string
-    key_version                        = optional(string, null)
-    user_assigned_identity_resource_id = optional(string, null)
+    key_vault_resource_id  = string
+    key_name               = string
+    key_version            = optional(string, null)
+    user_assigned_identity = optional(object({
+      resource_id = string
+    }), null)
   })
   default = null
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

The original Terraform `customer_managed_key` interface would trigger an issue when the module author tried to use it in a conditional expression, for example the `azurerm_cognitive_account_customer_managed_key` resource requires [identity client id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cognitive_account_customer_managed_key#identity_client_id), we have to use `data.azurerm_user_assigned_identity` to retrieve the client id when `user_assigned_identity.resource_id` is not `null`, but when it is `null` we cannot use the data source, therefore we have to check `user_assigned_identity.resource_id` in a `count` expression, which would lead us to an error when this value is expored directly by another `azurerm_user_assigned_identity` resource.

This pr fixes this issue by wrapping the resource id with an `object`.

### Breaking Changes

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
