### PR TITLE
Heredoc alignment suggestion

### DIFF
--- a/docs/content/specs/terraform/_index.md
+++ b/docs/content/specs/terraform/_index.md
@@ -600,7 +600,7 @@ The target audience of `description` is the module users.
 
 For a newly created `variable` (Eg. `variable` for switching `dynamic` block on-off), it's `description` should precisely describe the input parameter's purpose and the expected data type. `description` should not contain any information for module developers, this kind of information can only exist in code comments.
 
-For `object` type `variable`, `description` can be composed in HEREDOC format:
+For `object` type `variable`, `description` can be composed in HEREDOC format. The HEREDOC string SHOULD use an indented definition (`<<-`) and indent the content to allow collapsing of `variable` and `description` blocks in a neat way. This is for the developers benefit. The delimiter word SHOULD be `DESCRIPTION`.
 
 ```terraform
 variable "kubernetes_cluster_key_management_service" {
@@ -609,10 +609,10 @@ variable "kubernetes_cluster_key_management_service" {
     key_vault_network_access = optional(string)
   })
   default     = null
-  description = <<-EOT
-  - `key_vault_key_id` - (Required) Identifier of Azure Key Vault key. See [key identifier format](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details. When Azure Key Vault key management service is enabled, this field is required and must be a valid key identifier. When `enabled` is `false`, leave the field empty.
-  - `key_vault_network_access` - (Optional) Network access of the key vault Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. Defaults to `Public`.
-EOT
+  description = <<-DESCRIPTION
+    - `key_vault_key_id` - (Required) Identifier of Azure Key Vault key. See [key identifier format](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details. When Azure Key Vault key management service is enabled, this field is required and must be a valid key identifier. When `enabled` is `false`, leave the field empty.
+    - `key_vault_network_access` - (Optional) Network access of the key vault Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. Defaults to `Public`.
+  DESCRIPTION
 }
 ```
 

--- a/docs/static/includes/interfaces/int.cmk.schema.tf
+++ b/docs/static/includes/interfaces/int.cmk.schema.tf
@@ -6,4 +6,12 @@ variable "customer_managed_key" {
     user_assigned_identity_resource_id = optional(string, null)
   })
   default = null
+  description = <<-DESCRIPTION
+    The customer managed key (CMK) to use for encryption.
+
+    - `key_vault_resource_id` - (Required) The resource ID of the Key Vault.
+    - `key_name` - (Required) The name of the key in the Key Vault.
+    - `key_version` - (Optional) The version of the key in the Key Vault.
+    - `user_assigned_identity_resource_id` - (Optional) The resource ID of the user-assigned managed identity to use for accessing the key vault.
+  DESCRIPTION
 }

--- a/docs/static/includes/interfaces/int.diag.schema.tf
+++ b/docs/static/includes/interfaces/int.diag.schema.tf
@@ -27,20 +27,20 @@ variable "diagnostic_settings" {
     )
     error_message = "At least one of `workspace_resource_id`, `storage_account_resource_id`, `marketplace_partner_resource_id`, or `event_hub_authorization_rule_resource_id`, must be set."
   }
-  description = <<DESCRIPTION
-A map of diagnostic settings to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+  description = <<-DESCRIPTION
+    A map of diagnostic settings to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
 
-- `name` - (Optional) The name of the diagnostic setting. One will be generated if not set, however this will not be unique if you want to create multiple diagnostic setting resources.
-- `log_categories` - (Optional) A set of log categories to send to the log analytics workspace. Defaults to `[]`.
-- `log_groups` - (Optional) A set of log groups to send to the log analytics workspace. Defaults to `["allLogs"]`.
-- `metric_categories` - (Optional) A set of metric categories to send to the log analytics workspace. Defaults to `["AllMetrics"]`.
-- `log_analytics_destination_type` - (Optional) The destination type for the diagnostic setting. Possible values are `Dedicated` and `AzureDiagnostics`. Defaults to `Dedicated`.
-- `workspace_resource_id` - (Optional) The resource ID of the log analytics workspace to send logs and metrics to.
-- `storage_account_resource_id` - (Optional) The resource ID of the storage account to send logs and metrics to.
-- `event_hub_authorization_rule_resource_id` - (Optional) The resource ID of the event hub authorization rule to send logs and metrics to.
-- `event_hub_name` - (Optional) The name of the event hub. If none is specified, the default event hub will be selected.
-- `marketplace_partner_resource_id` - (Optional) The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic LogsLogs.
-DESCRIPTION
+    - `name` - (Optional) The name of the diagnostic setting. One will be generated if not set, however this will not be unique if you want to create multiple diagnostic setting resources.
+    - `log_categories` - (Optional) A set of log categories to send to the log analytics workspace. Defaults to `[]`.
+    - `log_groups` - (Optional) A set of log groups to send to the log analytics workspace. Defaults to `["allLogs"]`.
+    - `metric_categories` - (Optional) A set of metric categories to send to the log analytics workspace. Defaults to `["AllMetrics"]`.
+    - `log_analytics_destination_type` - (Optional) The destination type for the diagnostic setting. Possible values are `Dedicated` and `AzureDiagnostics`. Defaults to `Dedicated`.
+    - `workspace_resource_id` - (Optional) The resource ID of the log analytics workspace to send logs and metrics to.
+    - `storage_account_resource_id` - (Optional) The resource ID of the storage account to send logs and metrics to.
+    - `event_hub_authorization_rule_resource_id` - (Optional) The resource ID of the event hub authorization rule to send logs and metrics to.
+    - `event_hub_name` - (Optional) The name of the event hub. If none is specified, the default event hub will be selected.
+    - `marketplace_partner_resource_id` - (Optional) The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic LogsLogs.
+  DESCRIPTION
 }
 
 # Sample resource

--- a/docs/static/includes/interfaces/int.locks.schema.tf
+++ b/docs/static/includes/interfaces/int.locks.schema.tf
@@ -4,12 +4,12 @@ variable "lock" {
     name = optional(string, null)
   })
   default     = null
-  description = <<DESCRIPTION
-Controls the Resource Lock configuration for this resource. The following properties can be specified:
+  description = <<-DESCRIPTION
+    Controls the Resource Lock configuration for this resource. The following properties can be specified:
 
-- `kind` - (Required) The type of lock. Possible values are `\"CanNotDelete\"` and `\"ReadOnly\"`.
-- `name` - (Optional) The name of the lock. If not specified, a name will be generated based on the `kind` value. Changing this forces the creation of a new resource.
-DESCRIPTION
+    - `kind` - (Required) The type of lock. Possible values are `\"CanNotDelete\"` and `\"ReadOnly\"`.
+    - `name` - (Optional) The name of the lock. If not specified, a name will be generated based on the `kind` value. Changing this forces the creation of a new resource.
+  DESCRIPTION
 
   validation {
     condition     = var.lock != null ? contains(["CanNotDelete", "ReadOnly"], var.lock.kind) : true

--- a/docs/static/includes/interfaces/int.mi.schema.tf
+++ b/docs/static/includes/interfaces/int.mi.schema.tf
@@ -5,12 +5,12 @@ variable "managed_identities" {
   })
   default     = {}
   nullable    = false
-  description = <<DESCRIPTION
-Controls the Managed Identity configuration on this resource. The following properties can be specified:
+  description = <<-DESCRIPTION
+    Controls the Managed Identity configuration on this resource. The following properties can be specified:
 
-- `system_assigned` - (Optional) Specifies if the System Assigned Managed Identity should be enabled.
-- `user_assigned_resource_ids` - (Optional) Specifies a list of User Assigned Managed Identity resource IDs to be assigned to this resource.
-DESCRIPTION
+    - `system_assigned` - (Optional) Specifies if the System Assigned Managed Identity should be enabled.
+    - `user_assigned_resource_ids` - (Optional) Specifies a list of User Assigned Managed Identity resource IDs to be assigned to this resource.
+  DESCRIPTION
 }
 
 # Helper locals to make the dynamic block more readable

--- a/docs/static/includes/interfaces/int.pe.schema.tf
+++ b/docs/static/includes/interfaces/int.pe.schema.tf
@@ -37,25 +37,25 @@ variable "private_endpoints" {
   }))
   default     = {}
   nullable    = false
-  description = <<DESCRIPTION
-A map of private endpoints to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+  description = <<-DESCRIPTION
+    A map of private endpoints to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
 
-- `name` - (Optional) The name of the private endpoint. One will be generated if not set.
-- `role_assignments` - (Optional) A map of role assignments to create on the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time. See `var.role_assignments` for more information.
-- `lock` - (Optional) The lock level to apply to the private endpoint. Default is `None`. Possible values are `None`, `CanNotDelete`, and `ReadOnly`.
-- `tags` - (Optional) A mapping of tags to assign to the private endpoint.
-- `subnet_resource_id` - The resource ID of the subnet to deploy the private endpoint in.
-- `private_dns_zone_group_name` - (Optional) The name of the private DNS zone group. One will be generated if not set.
-- `private_dns_zone_resource_ids` - (Optional) A set of resource IDs of private DNS zones to associate with the private endpoint. If not set, no zone groups will be created and the private endpoint will not be associated with any private DNS zones. DNS records must be managed external to this module.
-- `application_security_group_resource_ids` - (Optional) A map of resource IDs of application security groups to associate with the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
-- `private_service_connection_name` - (Optional) The name of the private service connection. One will be generated if not set.
-- `network_interface_name` - (Optional) The name of the network interface. One will be generated if not set.
-- `location` - (Optional) The Azure location where the resources will be deployed. Defaults to the location of the resource group.
-- `resource_group_name` - (Optional) The resource group where the resources will be deployed. Defaults to the resource group of the Key Vault.
-- `ip_configurations` - (Optional) A map of IP configurations to create on the private endpoint. If not specified the platform will create one. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
-  - `name` - The name of the IP configuration.
-  - `private_ip_address` - The private IP address of the IP configuration.
-DESCRIPTION
+    - `name` - (Optional) The name of the private endpoint. One will be generated if not set.
+    - `role_assignments` - (Optional) A map of role assignments to create on the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time. See `var.role_assignments` for more information.
+    - `lock` - (Optional) The lock level to apply to the private endpoint. Default is `None`. Possible values are `None`, `CanNotDelete`, and `ReadOnly`.
+    - `tags` - (Optional) A mapping of tags to assign to the private endpoint.
+    - `subnet_resource_id` - The resource ID of the subnet to deploy the private endpoint in.
+    - `private_dns_zone_group_name` - (Optional) The name of the private DNS zone group. One will be generated if not set.
+    - `private_dns_zone_resource_ids` - (Optional) A set of resource IDs of private DNS zones to associate with the private endpoint. If not set, no zone groups will be created and the private endpoint will not be associated with any private DNS zones. DNS records must be managed external to this module.
+    - `application_security_group_resource_ids` - (Optional) A map of resource IDs of application security groups to associate with the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+    - `private_service_connection_name` - (Optional) The name of the private service connection. One will be generated if not set.
+    - `network_interface_name` - (Optional) The name of the network interface. One will be generated if not set.
+    - `location` - (Optional) The Azure location where the resources will be deployed. Defaults to the location of the resource group.
+    - `resource_group_name` - (Optional) The resource group where the resources will be deployed. Defaults to the resource group of the Key Vault.
+    - `ip_configurations` - (Optional) A map of IP configurations to create on the private endpoint. If not specified the platform will create one. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+      - `name` - The name of the IP configuration.
+      - `private_ip_address` - The private IP address of the IP configuration.
+  DESCRIPTION
 }
 
 # The PE resource when we are managing the private_dns_zone_group block:
@@ -134,7 +134,7 @@ resource "azurerm_private_endpoint_application_security_group_association" "this
 # In your output you need to select the correct resource based on the value of var.private_endpoints_manage_dns_zone_group:
 output "private_endpoints" {
   value       = var.private_endpoints_manage_dns_zone_group ? azurerm_private_endpoint.this_managed_dns_zone_groups : azurerm_private_endpoint.this_unmanaged_dns_zone_groups
-  description = <<DESCRIPTION
-A map of the private endpoints created.
-DESCRIPTION
+  description = <<-DESCRIPTION
+    A map of the private endpoints created.
+  DESCRIPTION
 }

--- a/docs/static/includes/interfaces/int.rbac.schema.tf
+++ b/docs/static/includes/interfaces/int.rbac.schema.tf
@@ -10,18 +10,18 @@ variable "role_assignments" {
   }))
   default     = {}
   nullable    = false
-  description = <<DESCRIPTION
-A map of role assignments to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+  description = <<-DESCRIPTION
+    A map of role assignments to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
 
-- `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
-- `principal_id` - The ID of the principal to assign the role to.
-- `description` - The description of the role assignment.
-- `skip_service_principal_aad_check` - If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
-- `condition` - The condition which will be used to scope the role assignment.
-- `condition_version` - The version of the condition syntax. Leave as `null` if you are not using a condition, if you are then valid values are '2.0'.
+    - `role_definition_id_or_name` - (Required) The ID or name of the role definition to assign to the principal.
+    - `principal_id` - (Required) The ID of the principal to assign the role to.
+    - `description` - (Optional) The description of the role assignment.
+    - `skip_service_principal_aad_check` - (Optional) If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
+    - `condition` - (Optional) The condition which will be used to scope the role assignment.
+    - `condition_version` - (Optional) The version of the condition syntax. Leave as `null` if you are not using a condition, if you are then valid values are '2.0'.
 
-> Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
-DESCRIPTION
+    > Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
+  DESCRIPTION
 }
 
 locals {

--- a/docs/static/includes/interfaces/int.tags.schema.tf
+++ b/docs/static/includes/interfaces/int.tags.schema.tf
@@ -4,5 +4,5 @@ variable "tags" {
   type     = map(string)
   default  = {}
   nullable = false
-  description = "A mapping of tags which should be assigned to the resource."
+  description = "(Optional) A mapping of tags which should be assigned to the resource."
 }

--- a/docs/static/includes/interfaces/int.tags.schema.tf
+++ b/docs/static/includes/interfaces/int.tags.schema.tf
@@ -4,4 +4,5 @@ variable "tags" {
   type     = map(string)
   default  = {}
   nullable = false
+  description = "A mapping of tags which should be assigned to the resource."
 }

--- a/docs/static/includes/sample.var_example.tf
+++ b/docs/static/includes/sample.var_example.tf
@@ -3,25 +3,25 @@ variable "my_complex_input" {
     param1 = string
     param2 = optional(number, null)
   }))
-  description = <<DESCRIPTION
-A complex input variable that is a map of objects.
-Each object has two attributes:
+  description = <<-DESCRIPTION
+    A complex input variable that is a map of objects.
+    Each object has two attributes:
 
-- `param1`: A required string parameter.
-- `param2`: (Optional) An optional number parameter.
+    - `param1`: A required string parameter.
+    - `param2`: (Optional) An optional number parameter.
 
-Example Input:
+    Example Input:
 
-```terraform
-my_complex_input = {
-  "object1" = {
-    param1 = "value1"
-    param2 = 2
-  }
-  "object2" = {
-    param1 = "value2"
-  }
-}
-```
-DESCRIPTION
+    ```terraform
+    my_complex_input = {
+      "object1" = {
+        param1 = "value1"
+        param2 = 2
+      }
+      "object2" = {
+        param1 = "value2"
+      }
+    }
+    ```
+  DESCRIPTION
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Define details on how we should use [Heredoc strings](https://developer.hashicorp.com/terraform/language/expressions/strings#heredoc-strings) for in-code documentation.

## This PR fixes/adds/changes/removes

1. Suggests changes to use of HEREDOCS.
   - Intention is to make code collapsible (developers benefit), without affecting readme's.
   - Consistent approach across doc and examples. Now there is a mix of `<<-`, `<<` and `EOT`, `DESCRIPTION`.

TODO: 
- [x] Terraform spec:
  - [x] TFNFR1
  - [x] TFNFR17
- [x] Interfaces:
  - [x] Diagnostic settings
  - [x] Role Assignments
  - [x] Resource locks
  - [x] Tags -> Missing description
  - [x] Managed Identities
  - [x] Private Endpoints
  - [x] Customer Managed Keys -> Missing description

### Breaking Changes

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
