### PR TITLE
Update github label scripts and instructions

### DIFF
--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -667,7 +667,31 @@ For most scenario this is the command you'll need to call the below PowerShell s
 Set-AvmGitHubLabels.ps1 -RepositoryName "Org/MyGitHubRepo" -CreateCsvLabelExports $false -NoUserPrompts $true
 ```
 
+```shell
+# Linux / MacOs
+# For Windows replace $PWD with your the local path or your repository
+#
+docker run -it -v $PWD:/repo -w /repo mcr.microsoft.com/powershell pwsh -Command '
+    #Invoke-WebRequest -Uri "https://azure.github.io/Azure-Verified-Modules/scripts/Set-AvmGitHubLabels.ps1" -OutFile "Set-AvmGitHubLabels.ps1"
+    $gh_version = "2.44.1"
+    Invoke-WebRequest -Uri "https://github.com/cli/cli/releases/download/v2.44.1/gh_2.44.1_linux_amd64.tar.gz" -OutFile "gh_$($gh_version)_linux_amd64.tar.gz"
+    apt-get update && apt-get install -y git
+    tar -xzf "gh_$($gh_version)_linux_amd64.tar.gz"
+    ls -lsa
+    mv "gh_$($gh_version)_linux_amd64/bin/gh" /usr/local/bin/
+    rm "gh_$($gh_version)_linux_amd64.tar.gz" && rm -rf "gh_$($gh_version)_linux_amd64"
+    gh --version
+    ls -lsa
+    gh auth login
+    $OrgProject = "Azure/terraform-azurerm-avm-res-kusto-cluster"
+    gh auth status
+    ./Set-AvmGitHubLabels.ps1 -RepositoryName $OrgProject -CreateCsvLabelExports $false -NoUserPrompts $true
+  '
+```
+
 By default this script will only update and append labels on the repository specified. However, this can be changed by setting the parameter `-UpdateAndAddLabelsOnly` to `$false`, which will remove all the labels from the repository first and then apply the AVM labels from the CSV only.
+
+Make sure you elevate your privilege to admin level or the labels will not be applied to your repository. Go to https://repos.opensource.microsoft.com/orgs/Azure/repos/<your avm repo>
 
 Full Script:
 

--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -691,7 +691,7 @@ docker run -it -v $PWD:/repo -w /repo mcr.microsoft.com/powershell pwsh -Command
 
 By default this script will only update and append labels on the repository specified. However, this can be changed by setting the parameter `-UpdateAndAddLabelsOnly` to `$false`, which will remove all the labels from the repository first and then apply the AVM labels from the CSV only.
 
-Make sure you elevate your privilege to admin level or the labels will not be applied to your repository. Go to https://repos.opensource.microsoft.com/orgs/Azure/repos/<your avm repo>
+Make sure you elevate your privilege to admin level or the labels will not be applied to your repository. Go to repos.opensource.microsoft.com/orgs/Azure/repos/<your avm repo> to request admin access before running the script.
 
 Full Script:
 

--- a/docs/static/scripts/Set-AvmGitHubLabels.ps1
+++ b/docs/static/scripts/Set-AvmGitHubLabels.ps1
@@ -117,6 +117,7 @@ Write-Host "The GitHub CLI is installed..." -ForegroundColor Green
 # Check if GitHub CLI is authenticated
 $GitHubCliAuthenticated = gh auth status
 if ($LASTEXITCODE -ne 0) {
+  Write-Host $GitHubCliAuthenticated -ForegroundColor Read
   throw "Not authenticated to GitHub. Please authenticate to GitHub using the GitHub CLI, `gh auth login`, and try again."
 }
 Write-Host "Authenticated to GitHub..." -ForegroundColor Green
@@ -130,6 +131,7 @@ if ($false -eq $GitHubRepositoryNameValid) {
 # List GitHub repository provided and check it exists
 $GitHubRepository = gh repo view $RepositoryName
 if ($LASTEXITCODE -ne 0) {
+  Write-Host $GitHubCliAuthenticated -ForegroundColor Read
   throw "The GitHub repository $RepositoryName does not exist. Please check the repository name and try again."
 }
 Write-Host "The GitHub repository $RepositoryName exists..." -ForegroundColor Green

--- a/docs/static/scripts/Set-AvmGitHubLabels.ps1
+++ b/docs/static/scripts/Set-AvmGitHubLabels.ps1
@@ -117,7 +117,7 @@ Write-Host "The GitHub CLI is installed..." -ForegroundColor Green
 # Check if GitHub CLI is authenticated
 $GitHubCliAuthenticated = gh auth status
 if ($LASTEXITCODE -ne 0) {
-  Write-Host $GitHubCliAuthenticated -ForegroundColor Read
+  Write-Host $GitHubCliAuthenticated -ForegroundColor Red
   throw "Not authenticated to GitHub. Please authenticate to GitHub using the GitHub CLI, `gh auth login`, and try again."
 }
 Write-Host "Authenticated to GitHub..." -ForegroundColor Green

--- a/docs/static/scripts/Set-AvmGitHubLabels.ps1
+++ b/docs/static/scripts/Set-AvmGitHubLabels.ps1
@@ -131,7 +131,7 @@ if ($false -eq $GitHubRepositoryNameValid) {
 # List GitHub repository provided and check it exists
 $GitHubRepository = gh repo view $RepositoryName
 if ($LASTEXITCODE -ne 0) {
-  Write-Host $GitHubRepository -ForegroundColor Read
+  Write-Host $GitHubRepository -ForegroundColor Red
   throw "The GitHub repository $RepositoryName does not exist. Please check the repository name and try again."
 }
 Write-Host "The GitHub repository $RepositoryName exists..." -ForegroundColor Green

--- a/docs/static/scripts/Set-AvmGitHubLabels.ps1
+++ b/docs/static/scripts/Set-AvmGitHubLabels.ps1
@@ -131,7 +131,7 @@ if ($false -eq $GitHubRepositoryNameValid) {
 # List GitHub repository provided and check it exists
 $GitHubRepository = gh repo view $RepositoryName
 if ($LASTEXITCODE -ne 0) {
-  Write-Host $GitHubCliAuthenticated -ForegroundColor Read
+  Write-Host $GitHubRepository -ForegroundColor Read
   throw "The GitHub repository $RepositoryName does not exist. Please check the repository name and try again."
 }
 Write-Host "The GitHub repository $RepositoryName exists..." -ForegroundColor Green

--- a/docs/static/scripts/Set-AvmGitHubLabels.ps1
+++ b/docs/static/scripts/Set-AvmGitHubLabels.ps1
@@ -116,7 +116,7 @@ Write-Host "The GitHub CLI is installed..." -ForegroundColor Green
 
 # Check if GitHub CLI is authenticated
 $GitHubCliAuthenticated = gh auth status
-if ($null -eq $GitHubCliAuthenticated) {
+if ($LASTEXITCODE -ne 0) {
   throw "Not authenticated to GitHub. Please authenticate to GitHub using the GitHub CLI, `gh auth login`, and try again."
 }
 Write-Host "Authenticated to GitHub..." -ForegroundColor Green
@@ -129,7 +129,7 @@ if ($false -eq $GitHubRepositoryNameValid) {
 
 # List GitHub repository provided and check it exists
 $GitHubRepository = gh repo view $RepositoryName
-if ($null -eq $GitHubRepository) {
+if ($LASTEXITCODE -ne 0) {
   throw "The GitHub repository $RepositoryName does not exist. Please check the repository name and try again."
 }
 Write-Host "The GitHub repository $RepositoryName exists..." -ForegroundColor Green


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This PR update the documentation:

- Add an option to run the script to set the labels based on a docker run (from codespace or OS who don't have powershell installed)
- Update the Powershell script to evaluate based on returned code



### Breaking Changes

No

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

Tests:

```bash
docker run -it -v $PWD:/repo -w /repo mcr.microsoft.com/powershell pwsh -Command '
>     #Invoke-WebRequest -Uri "https://azure.github.io/Azure-Verified-Modules/scripts/Set-AvmGitHubLabels.ps1" -OutFile "Set-AvmGitHubLabels.ps1"
>     $gh_version = "2.44.1"
>     Invoke-WebRequest -Uri "https://github.com/cli/cli/releases/download/v2.44.1/gh_2.44.1_linux_amd64.tar.gz" -OutFile "gh_$($gh_version)_linux_amd64.tar.gz"
>     apt-get update && apt-get install -y git
>     tar -xzf "gh_$($gh_version)_linux_amd64.tar.gz"
>     ls -lsa
>     mv "gh_$($gh_version)_linux_amd64/bin/gh" /usr/local/bin/
>     rm "gh_$($gh_version)_linux_amd64.tar.gz" && rm -rf "gh_$($gh_version)_linux_amd64"
>     gh --version
>     ls -lsa
>     gh auth login
>     $OrgProject = "Azure/terraform-azurerm-avm-res-kusto-cluster"
>     gh auth status
>     ./Set-AvmGitHubLabels.ps1 -RepositoryName $OrgProject -CreateCsvLabelExports $false -NoUserPrompts $true
>   '
Get:1 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
Get:2 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]              
Get:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]                
Get:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [109 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy/multiverse amd64 Packages [266 kB]
Get:6 http://archive.ubuntu.com/ubuntu jammy/restricted amd64 Packages [164 kB]
Get:7 http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages [17.5 MB]            
Get:8 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 Packages [44.6 kB]
Get:9 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [1,070 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages [1,792 kB]
Get:11 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse amd64 Packages [50.4 kB]      
Get:12 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1,343 kB]       
Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [1,834 kB]    
Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [1,742 kB]     
Get:15 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [28.1 kB]
Get:16 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [50.4 kB]   
Get:17 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [1,796 kB]
Get:18 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [1,463 kB]
Fetched 29.7 MB in 3s (11.3 MB/s)                           
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  git-man libbrotli1 libcurl3-gnutls liberror-perl libexpat1 libgdbm-compat4 libgdbm6 libldap-2.5-0 libldap-common libnghttp2-14 libperl5.34 libpsl5 librtmp1 libsasl2-2 libsasl2-modules
  libsasl2-modules-db libssh-4 netbase patch perl perl-modules-5.34 publicsuffix
Suggested packages:
  gettext-base git-daemon-run | git-daemon-sysvinit git-doc git-email git-gui gitk gitweb git-cvs git-mediawiki git-svn gdbm-l10n libsasl2-modules-gssapi-mit | libsasl2-modules-gssapi-heimdal
  libsasl2-modules-ldap libsasl2-modules-otp libsasl2-modules-sql ed diffutils-doc perl-doc libterm-readline-gnu-perl | libterm-readline-perl-perl make libtap-harness-archive-perl
The following NEW packages will be installed:
  git git-man libbrotli1 libcurl3-gnutls liberror-perl libexpat1 libgdbm-compat4 libgdbm6 libldap-2.5-0 libldap-common libnghttp2-14 libperl5.34 libpsl5 librtmp1 libsasl2-2 libsasl2-modules
  libsasl2-modules-db libssh-4 netbase patch perl perl-modules-5.34 publicsuffix
0 upgraded, 23 newly installed, 0 to remove and 6 not upgraded.
Need to get 13.9 MB of archives.
After this operation, 74.0 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 perl-modules-5.34 all 5.34.0-3ubuntu1.3 [2,976 kB]
Get:2 http://archive.ubuntu.com/ubuntu jammy/main amd64 libgdbm6 amd64 1.23-1 [33.9 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy/main amd64 libgdbm-compat4 amd64 1.23-1 [6,606 B]
Get:4 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libperl5.34 amd64 5.34.0-3ubuntu1.3 [4,820 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 perl amd64 5.34.0-3ubuntu1.3 [232 kB]
Get:6 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libexpat1 amd64 2.4.7-1ubuntu0.2 [91.0 kB]
Get:7 http://archive.ubuntu.com/ubuntu jammy/main amd64 netbase all 6.3 [12.9 kB]
Get:8 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libnghttp2-14 amd64 1.43.0-1ubuntu0.1 [76.7 kB]
Get:9 http://archive.ubuntu.com/ubuntu jammy/main amd64 libpsl5 amd64 0.21.0-1.2build2 [58.4 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy/main amd64 publicsuffix all 20211207.1025-1 [129 kB]
Get:11 http://archive.ubuntu.com/ubuntu jammy/main amd64 libbrotli1 amd64 1.0.9-2build6 [315 kB]
Get:12 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsasl2-modules-db amd64 2.1.27+dfsg2-3ubuntu1.2 [20.5 kB]
Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsasl2-2 amd64 2.1.27+dfsg2-3ubuntu1.2 [53.8 kB]
Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libldap-2.5-0 amd64 2.5.16+dfsg-0ubuntu0.22.04.2 [183 kB]
Get:15 http://archive.ubuntu.com/ubuntu jammy/main amd64 librtmp1 amd64 2.4+20151223.gitfa8646d.1-2build4 [58.2 kB]
Get:16 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libssh-4 amd64 0.9.6-2ubuntu0.22.04.3 [186 kB]
Get:17 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libcurl3-gnutls amd64 7.81.0-1ubuntu1.15 [284 kB]
Get:18 http://archive.ubuntu.com/ubuntu jammy/main amd64 liberror-perl all 0.17029-1 [26.5 kB]
Get:19 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 git-man all 1:2.34.1-1ubuntu1.10 [954 kB]
Get:20 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 git amd64 1:2.34.1-1ubuntu1.10 [3,166 kB]
Get:21 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libldap-common all 2.5.16+dfsg-0ubuntu0.22.04.2 [15.5 kB]
Get:22 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsasl2-modules amd64 2.1.27+dfsg2-3ubuntu1.2 [68.8 kB]
Get:23 http://archive.ubuntu.com/ubuntu jammy/main amd64 patch amd64 2.7.6-7build2 [109 kB]
Fetched 13.9 MB in 1s (9,868 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package perl-modules-5.34.
(Reading database ... 6346 files and directories currently installed.)
Preparing to unpack .../00-perl-modules-5.34_5.34.0-3ubuntu1.3_all.deb ...
Unpacking perl-modules-5.34 (5.34.0-3ubuntu1.3) ...
Selecting previously unselected package libgdbm6:amd64.
Preparing to unpack .../01-libgdbm6_1.23-1_amd64.deb ...
Unpacking libgdbm6:amd64 (1.23-1) ...
Selecting previously unselected package libgdbm-compat4:amd64.
Preparing to unpack .../02-libgdbm-compat4_1.23-1_amd64.deb ...
Unpacking libgdbm-compat4:amd64 (1.23-1) ...
Selecting previously unselected package libperl5.34:amd64.
Preparing to unpack .../03-libperl5.34_5.34.0-3ubuntu1.3_amd64.deb ...
Unpacking libperl5.34:amd64 (5.34.0-3ubuntu1.3) ...
Selecting previously unselected package perl.
Preparing to unpack .../04-perl_5.34.0-3ubuntu1.3_amd64.deb ...
Unpacking perl (5.34.0-3ubuntu1.3) ...
Selecting previously unselected package libexpat1:amd64.
Preparing to unpack .../05-libexpat1_2.4.7-1ubuntu0.2_amd64.deb ...
Unpacking libexpat1:amd64 (2.4.7-1ubuntu0.2) ...
Selecting previously unselected package netbase.
Preparing to unpack .../06-netbase_6.3_all.deb ...
Unpacking netbase (6.3) ...
Selecting previously unselected package libnghttp2-14:amd64.
Preparing to unpack .../07-libnghttp2-14_1.43.0-1ubuntu0.1_amd64.deb ...
Unpacking libnghttp2-14:amd64 (1.43.0-1ubuntu0.1) ...
Selecting previously unselected package libpsl5:amd64.
Preparing to unpack .../08-libpsl5_0.21.0-1.2build2_amd64.deb ...
Unpacking libpsl5:amd64 (0.21.0-1.2build2) ...
Selecting previously unselected package publicsuffix.
Preparing to unpack .../09-publicsuffix_20211207.1025-1_all.deb ...
Unpacking publicsuffix (20211207.1025-1) ...
Selecting previously unselected package libbrotli1:amd64.
Preparing to unpack .../10-libbrotli1_1.0.9-2build6_amd64.deb ...
Unpacking libbrotli1:amd64 (1.0.9-2build6) ...
Selecting previously unselected package libsasl2-modules-db:amd64.
Preparing to unpack .../11-libsasl2-modules-db_2.1.27+dfsg2-3ubuntu1.2_amd64.deb ...
Unpacking libsasl2-modules-db:amd64 (2.1.27+dfsg2-3ubuntu1.2) ...
Selecting previously unselected package libsasl2-2:amd64.
Preparing to unpack .../12-libsasl2-2_2.1.27+dfsg2-3ubuntu1.2_amd64.deb ...
Unpacking libsasl2-2:amd64 (2.1.27+dfsg2-3ubuntu1.2) ...
Selecting previously unselected package libldap-2.5-0:amd64.
Preparing to unpack .../13-libldap-2.5-0_2.5.16+dfsg-0ubuntu0.22.04.2_amd64.deb ...
Unpacking libldap-2.5-0:amd64 (2.5.16+dfsg-0ubuntu0.22.04.2) ...
Selecting previously unselected package librtmp1:amd64.
Preparing to unpack .../14-librtmp1_2.4+20151223.gitfa8646d.1-2build4_amd64.deb ...
Unpacking librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build4) ...
Selecting previously unselected package libssh-4:amd64.
Preparing to unpack .../15-libssh-4_0.9.6-2ubuntu0.22.04.3_amd64.deb ...
Unpacking libssh-4:amd64 (0.9.6-2ubuntu0.22.04.3) ...
Selecting previously unselected package libcurl3-gnutls:amd64.
Preparing to unpack .../16-libcurl3-gnutls_7.81.0-1ubuntu1.15_amd64.deb ...
Unpacking libcurl3-gnutls:amd64 (7.81.0-1ubuntu1.15) ...
Selecting previously unselected package liberror-perl.
Preparing to unpack .../17-liberror-perl_0.17029-1_all.deb ...
Unpacking liberror-perl (0.17029-1) ...
Selecting previously unselected package git-man.
Preparing to unpack .../18-git-man_1%3a2.34.1-1ubuntu1.10_all.deb ...
Unpacking git-man (1:2.34.1-1ubuntu1.10) ...
Selecting previously unselected package git.
Preparing to unpack .../19-git_1%3a2.34.1-1ubuntu1.10_amd64.deb ...
Unpacking git (1:2.34.1-1ubuntu1.10) ...
Selecting previously unselected package libldap-common.
Preparing to unpack .../20-libldap-common_2.5.16+dfsg-0ubuntu0.22.04.2_all.deb ...
Unpacking libldap-common (2.5.16+dfsg-0ubuntu0.22.04.2) ...
Selecting previously unselected package libsasl2-modules:amd64.
Preparing to unpack .../21-libsasl2-modules_2.1.27+dfsg2-3ubuntu1.2_amd64.deb ...
Unpacking libsasl2-modules:amd64 (2.1.27+dfsg2-3ubuntu1.2) ...
Selecting previously unselected package patch.
Preparing to unpack .../22-patch_2.7.6-7build2_amd64.deb ...
Unpacking patch (2.7.6-7build2) ...
Setting up libexpat1:amd64 (2.4.7-1ubuntu0.2) ...
Setting up libpsl5:amd64 (0.21.0-1.2build2) ...
Setting up libbrotli1:amd64 (1.0.9-2build6) ...
Setting up libsasl2-modules:amd64 (2.1.27+dfsg2-3ubuntu1.2) ...
Setting up libnghttp2-14:amd64 (1.43.0-1ubuntu0.1) ...
Setting up perl-modules-5.34 (5.34.0-3ubuntu1.3) ...
Setting up libldap-common (2.5.16+dfsg-0ubuntu0.22.04.2) ...
Setting up libsasl2-modules-db:amd64 (2.1.27+dfsg2-3ubuntu1.2) ...
Setting up librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build4) ...
Setting up patch (2.7.6-7build2) ...
Setting up libsasl2-2:amd64 (2.1.27+dfsg2-3ubuntu1.2) ...
Setting up libssh-4:amd64 (0.9.6-2ubuntu0.22.04.3) ...
Setting up git-man (1:2.34.1-1ubuntu1.10) ...
Setting up netbase (6.3) ...
Setting up publicsuffix (20211207.1025-1) ...
Setting up libgdbm6:amd64 (1.23-1) ...
Setting up libldap-2.5-0:amd64 (2.5.16+dfsg-0ubuntu0.22.04.2) ...
Setting up libgdbm-compat4:amd64 (1.23-1) ...
Setting up libperl5.34:amd64 (5.34.0-3ubuntu1.3) ...
Setting up libcurl3-gnutls:amd64 (7.81.0-1ubuntu1.15) ...
Setting up perl (5.34.0-3ubuntu1.3) ...
Setting up liberror-perl (0.17029-1) ...
Setting up git (1:2.34.1-1ubuntu1.10) ...
Processing triggers for libc-bin (2.35-0ubuntu3.6) ...
total 21132
    4 drwxrwxrwx+ 10 root root     4096 Feb 22 22:20 .
    4 drwxr-xr-x   1 root root     4096 Feb 22 22:20 ..
    4 -rwxrwxrwx   1 root root      625 Feb 22 16:36 avm
    4 -rw-rw-rw-   1 root root      839 Feb 22 16:36 avm.bat
    4 -rw-rw-rw-   1 root root      444 Feb 22 16:36 CODE_OF_CONDUCT.md
    4 drwxrwxrwx+  2 root root     4096 Feb 22 16:36 .devcontainer
    4 drwxrwxrwx+  3 root root     4096 Feb 22 16:36 examples
    4 -rw-rw-rw-   1 root root      902 Feb 22 16:36 _footer.md
    4 drwxr-xr-x+  4 root root     4096 Feb 22 22:20 gh_2.44.1_linux_amd64
10460 -rw-rw-rw-   1 root root 10709425 Feb 22 22:20 gh_2.44.1_linux_amd64.tar.gz
    4 drwxrwxrwx+  8 root root     4096 Feb 22 16:38 .git
    4 drwxrwxrwx+  5 root root     4096 Feb 22 16:36 .github
    4 -rw-rw-rw-   1 root root     1011 Feb 22 16:36 .gitignore
    4 -rw-rw-rw-   1 root root     1716 Feb 22 16:36 _header.md
    4 -rw-rw-rw-   1 root root     1141 Feb 22 16:36 LICENSE
    4 -rw-rw-rw-   1 root root     1365 Feb 22 16:43 locals.telemetry.tf
    4 -rw-rw-rw-   1 root root      606 Feb 22 16:38 locals.tf
    4 -rw-rw-rw-   1 root root       52 Feb 22 16:36 locals.version.tf.json
    4 -rw-rw-rw-   1 root root      519 Feb 22 16:38 main.cluster_principal_assignment.tf
    4 -rw-rw-rw-   1 root root      570 Feb 22 16:38 main.database_principal_assignment.tf
    4 -rw-rw-rw-   1 root root      622 Feb 22 16:38 main.database.tf
    4 -rw-rw-rw-   1 root root     1811 Feb 22 16:38 main.privateendpoint.tf
    4 -rw-rw-rw-   1 root root      589 Feb 22 16:38 main.telemetry.tf
    8 -rw-rw-rw-   1 root root     4376 Feb 22 16:38 main.tf
    4 -rw-rw-rw-   1 root root      187 Feb 22 16:36 Makefile
    4 drwxrwxrwx+  5 root root     4096 Feb 22 16:38 modules
    4 -rw-rw-rw-   1 root root     1312 Feb 22 16:38 outputs.tf
   32 -rw-rw-rw-   1 root root    28924 Feb 22 22:20 README.md
    4 -rw-rw-rw-   1 root root     2757 Feb 22 16:36 SECURITY.md
   16 -rw-rw-rw-   1 root root    13567 Feb 22 19:09 Set-AvmGitHubLabels.ps1
    4 -rw-rw-rw-   1 root root     1217 Feb 22 16:36 SUPPORT.md
    4 -rw-rw-rw-   1 root root     1058 Feb 22 16:36 .terraform-docs.yml
    4 -rw-rw-rw-   1 root root      242 Feb 22 16:38 terraform.tf
    4 -rw-rw-rw-   1 root root        5 Feb 22 16:38 .terraform-version
    4 drwxrwxrwx+  4 root root     4096 Feb 22 16:38 tests
   28 -rw-rw-rw-   1 root root    27711 Feb 22 16:38 variables.tf
    4 drwxrwxrwx+  2 root root     4096 Feb 22 16:36 .vscode
gh version 2.44.1 (2024-02-16)
https://github.com/cli/cli/releases/tag/v2.44.1
total 10668
    4 drwxrwxrwx+ 9 root root     4096 Feb 22 22:20 .
    4 drwxr-xr-x  1 root root     4096 Feb 22 22:20 ..
    4 -rwxrwxrwx  1 root root      625 Feb 22 16:36 avm
    4 -rw-rw-rw-  1 root root      839 Feb 22 16:36 avm.bat
    4 -rw-rw-rw-  1 root root      444 Feb 22 16:36 CODE_OF_CONDUCT.md
    4 drwxrwxrwx+ 2 root root     4096 Feb 22 16:36 .devcontainer
    4 drwxrwxrwx+ 3 root root     4096 Feb 22 16:36 examples
    4 -rw-rw-rw-  1 root root      902 Feb 22 16:36 _footer.md
10460 -rw-rw-rw-  1 root root 10709425 Feb 22 19:21 gh_2.44.2_linux_amd64.tar.gz
    4 drwxrwxrwx+ 8 root root     4096 Feb 22 16:38 .git
    4 drwxrwxrwx+ 5 root root     4096 Feb 22 16:36 .github
    4 -rw-rw-rw-  1 root root     1011 Feb 22 16:36 .gitignore
    4 -rw-rw-rw-  1 root root     1716 Feb 22 16:36 _header.md
    4 -rw-rw-rw-  1 root root     1141 Feb 22 16:36 LICENSE
    4 -rw-rw-rw-  1 root root     1365 Feb 22 16:43 locals.telemetry.tf
    4 -rw-rw-rw-  1 root root      606 Feb 22 16:38 locals.tf
    4 -rw-rw-rw-  1 root root       52 Feb 22 16:36 locals.version.tf.json
    4 -rw-rw-rw-  1 root root      519 Feb 22 16:38 main.cluster_principal_assignment.tf
    4 -rw-rw-rw-  1 root root      570 Feb 22 16:38 main.database_principal_assignment.tf
    4 -rw-rw-rw-  1 root root      622 Feb 22 16:38 main.database.tf
    4 -rw-rw-rw-  1 root root     1811 Feb 22 16:38 main.privateendpoint.tf
    4 -rw-rw-rw-  1 root root      589 Feb 22 16:38 main.telemetry.tf
    8 -rw-rw-rw-  1 root root     4376 Feb 22 16:38 main.tf
    4 -rw-rw-rw-  1 root root      187 Feb 22 16:36 Makefile
    4 drwxrwxrwx+ 5 root root     4096 Feb 22 16:38 modules
    4 -rw-rw-rw-  1 root root     1312 Feb 22 16:38 outputs.tf
   32 -rw-rw-rw-  1 root root    28924 Feb 22 22:20 README.md
    4 -rw-rw-rw-  1 root root     2757 Feb 22 16:36 SECURITY.md
   16 -rw-rw-rw-  1 root root    13567 Feb 22 19:09 Set-AvmGitHubLabels.ps1
    4 -rw-rw-rw-  1 root root     1217 Feb 22 16:36 SUPPORT.md
    4 -rw-rw-rw-  1 root root     1058 Feb 22 16:36 .terraform-docs.yml
    4 -rw-rw-rw-  1 root root      242 Feb 22 16:38 terraform.tf
    4 -rw-rw-rw-  1 root root        5 Feb 22 16:38 .terraform-version
    4 drwxrwxrwx+ 4 root root     4096 Feb 22 16:38 tests
   28 -rw-rw-rw-  1 root root    27711 Feb 22 16:38 variables.tf
    4 drwxrwxrwx+ 2 root root     4096 Feb 22 16:36 .vscode
? What account do you want to log into? GitHub.com
? What is your preferred protocol for Git operations on this host? HTTPS
? Authenticate Git with your GitHub credentials? Yes
? How would you like to authenticate GitHub CLI? Login with a web browser

! First copy your one-time code: xxxx-xxxx
Press Enter to open github.com in your browser... 
! Failed opening a web browser at https://github.com/login/device
  exec: "xdg-open,x-www-browser,www-browser,wslview": executable file not found in $PATH
  Please try entering the URL in your browser manually
✓ Authentication complete.
- gh config set -h github.com git_protocol https
✓ Configured git protocol
! Authentication credentials saved in plain text
✓ Logged in as LaurentLesle
github.com
  ✓ Logged in to github.com account LaurentLesle (/root/.config/gh/hosts.yml)
  - Active account: true
  - Git operations protocol: https
  - Token: gho_************************************
  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
The GitHub CLI is installed...
Authenticated to GitHub...
The GitHub repository Azure/terraform-azurerm-avm-res-kusto-cluster exists...
Getting the current GitHub repository (pre) labels for Azure/terraform-azurerm-avm-res-kusto-cluster...
Checking https://azure.github.io/Azure-Verified-Modules/governance/avm-standard-github-labels.csv is valid...
The LabelsToApplyCsvUri https://azure.github.io/Azure-Verified-Modules/governance/avm-standard-github-labels.csv is valid...
The labels CSV file contains the required columns: Name, Description, HEX                                               
Creating/Updating the 38 AVM labels in Azure/terraform-azurerm-avm-res-kusto-cluster...
The label AZD :technologist: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "AZD :technologist:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Needs: Attention :wave: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Needs: Attention :wave:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Needs: Immediate Attention :bangbang: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Needs: Immediate Attention :bangbang:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Needs: Author Feedback :ear: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Needs: Author Feedback :ear:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Needs: External Changes :hammer_and_pick: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Needs: External Changes :hammer_and_pick:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Needs: More Evidence :balance_scale: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Needs: More Evidence :balance_scale:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Needs: Triage :mag: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Needs: Triage :mag:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Needs: Module Owner :mega: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Needs: Module Owner :mega:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Awaiting Release To Be Cut :scissors: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Awaiting Release To Be Cut :scissors:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Do Not Merge :no_entry: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Do Not Merge :no_entry:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: External Contribution :earth_africa: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: External Contribution :earth_africa:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Fixed :white_check_mark: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Fixed :white_check_mark:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Help Wanted :sos: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Help Wanted :sos:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: In Triage :mag: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: In Triage :mag:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: In PR :point_right: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: In PR :point_right:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Invalid :x: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Invalid :x:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Long Term :hourglass_flowing_sand: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Long Term :hourglass_flowing_sand:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: No Recent Activity :zzz: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: No Recent Activity :zzz:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Won't Fix :broken_heart: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Won't Fix :broken_heart:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Migrate from CARML :articulated_lorry: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Migrate from CARML :articulated_lorry:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Migrate from TFVM :articulated_lorry: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Migrate from TFVM :articulated_lorry:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Owners Identified :metal: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Owners Identified :metal:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Module Available :green_circle: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Module Available :green_circle:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Module Orphaned :eyes: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Module Orphaned :eyes:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Status: Response Overdue :triangular_flag_on_post: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Status: Response Overdue :triangular_flag_on_post:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Type: Bug :bug: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Type: Bug :bug:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Type: Documentation :page_facing_up: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Type: Documentation :page_facing_up:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Type: Duplicate :palms_up_together: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Type: Duplicate :palms_up_together:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Type: Feature Request :heavy_plus_sign: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Type: Feature Request :heavy_plus_sign:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Type: Hygiene :broom: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Type: Hygiene :broom:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Type: New Module Proposal :bulb: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Type: New Module Proposal :bulb:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Type: Question/Feedback :raising_hand: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Type: Question/Feedback :raising_hand:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Type: Security Bug :lock: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Type: Security Bug :lock:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Type: AVM :a: :v: :m: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Type: AVM :a: :v: :m:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Language: Terraform :globe_with_meridians: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Language: Terraform :globe_with_meridians:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Language: Bicep :muscle: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Language: Bicep :muscle:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Class: Resource Module :package: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Class: Resource Module :package:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The label Class: Pattern Module :package: already exists in Azure/terraform-azurerm-avm-res-kusto-cluster. Updating the label to ensure description and color are consitent...
✓ Label "Class: Pattern Module :package:" created in Azure/terraform-azurerm-avm-res-kusto-cluster
The CSV labels have been created/updated in Azure/terraform-azurerm-avm-res-kusto-cluster...
```
