### PR TITLE
Separation of duties between Bicep and TF part of the AVM core team

### DIFF
--- a/docs/content/contributing/terraform/terraform-contribution-flow/_index.md
+++ b/docs/content/contributing/terraform/terraform-contribution-flow/_index.md
@@ -250,7 +250,7 @@ Simply run `terraform init` and `terraform apply` in the `example` folder you wa
 
 Once you are satisfied with your contribution and validated it, open a PR from your forked repository to the original Terraform Module repository. Make sure you:
 
-1. Include/Add [`@Azure/avm-core-team-technical`](https://github.com/orgs/Azure/teams/avm-core-team-technical/members) as a reviewer.
+1. Include/Add [`@Azure/avm-core-team-technical-terraform`](https://github.com/orgs/Azure/teams/avm-core-team-technical-terraform) as a reviewer.
 2. Make sure all Pull Requst Checks (e2e tests with all examples, linting and version-check) are passing.
 3. Watch comments from the PR checks and reviewers (Module owner or AVM core team) and address them accordingly.
 4. Once your PR is approved, merge it into the upstream repository and the Module owner will publish the module to the HashiCorp Terraform Registry.

--- a/docs/content/contributing/terraform/terraform-contribution-flow/owner-contribution-flow.md
+++ b/docs/content/contributing/terraform/terraform-contribution-flow/owner-contribution-flow.md
@@ -47,7 +47,6 @@ Familiarise yourself with the AVM Resource Module Naming in the [module index cs
 3. Add these teams with the following permissions to the repository:
 
 - Admin: `@Azure/avm-core-team-technical-terraform` = AVM Core Team (Terraform Technical)
-- Admin: `@Azure/avm-core-team-technical` = AVM Core Team (Technical Only)
 - Admin: `@Azure/terraform-azure` = Terraform PG
 - Admin: `@Azure/avm-res-<RP>-<modulename>-module-owners-tf` = AVM Terraform Module Owners
 - Write: `@Azure/avm-res-<RP>-<modulename>-module-contributors-tf` = AVM Terraform Module Contributors
@@ -143,7 +142,7 @@ Ensure your module is ready for publishing:
 1. All tests are passing.
 2. All examples are passing.
 3. All documentation is generated.
-4. Include/Add [`@Azure/avm-core-team-technical-terraform`](https://github.com/orgs/Azure/teams/avm-core-team-technical/members) as a reviewer (if not added automatically added already).
+4. Include/Add [`@Azure/avm-core-team-technical-terraform`](https://github.com/orgs/Azure/teams/avm-core-team-technical-terraform) as a reviewer (if not added automatically added already).
 5. Create a tag for the module version you want to publish.
 - Create tag: `git tag -a 0.1.0 -m "0.1.0"`
 - Push tag: `git push`

--- a/docs/content/specs/shared/_index.md
+++ b/docs/content/specs/shared/_index.md
@@ -350,7 +350,7 @@ Modules **MUST** pass all tests that ensure compliance to AVM specifications. Th
 
 Please note these are still under development at this time and will be published and available soon for module owners.
 
-Module owners **MUST** request a manual GitHub Pull Request review, prior to their first release of version `0.1.0` of their module, from the following GitHub Team: [`@Azure/avm-core-team-technical`](https://github.com/orgs/Azure/teams/avm-core-team-technical/members)
+Module owners **MUST** request a manual GitHub Pull Request review, prior to their first release of version `0.1.0` of their module, from the related GitHub Team: [`@Azure/avm-core-team-technical-bicep`](https://github.com/orgs/Azure/teams/avm-core-team-technical-bicep), OR [`@Azure/avm-core-team-technical-terraform`](https://github.com/orgs/Azure/teams/avm-core-team-technical-terraform).
 
 {{< /hint >}}
 
@@ -587,7 +587,7 @@ A module owner **MUST** make the following GitHub teams in the Azure GitHub orga
 
 ##### Bicep
 
-- [`@Azure/avm-core-team`](https://github.com/orgs/Azure/teams/avm-core-team/members?query=membership:child-team) = AVM Core Team
+- [`@Azure/avm-core-team-technical-bicep`](https://github.com/orgs/Azure/teams/avm-core-team-technical-bicep) = AVM Core Team
 - [`@Azure/bicep-admins`](https://github.com/orgs/Azure/teams/bicep-admins) = Bicep PG team
 
 {{< hint type=note >}}
@@ -596,7 +596,7 @@ These required GitHub teams are already associated to the [BRM](https://aka.ms/B
 
 ##### Terraform
 
-- [`@Azure/avm-core-team`](https://github.com/orgs/Azure/teams/avm-core-team/members?query=membership:child-team) = AVM Core Team
+- [`@Azure/avm-core-team-technical-terraform`](https://github.com/orgs/Azure/teams/avm-core-team-technical-terraform) = AVM Core Team
 - [`@Azure/terraform-azure`](https://github.com/orgs/Azure/teams/terraform-azure) = Terraform PG
 
 {{< hint type=important >}}


### PR DESCRIPTION
# Overview/Summary

## This PR fixes/adds/changes/removes

Updated documentation to reflect separation of duties between the teams of `avm-core-team-technical-bicep` and `avm-core-team-technical-terraform`.

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
