### PR TITLE
Add new label for looking for assistance

### DIFF
--- a/docs/static/governance/avm-standard-github-labels.csv
+++ b/docs/static/governance/avm-standard-github-labels.csv
@@ -24,6 +24,7 @@ Status: Owners Identified :metal:,This module has its owners identified,FBEF2A
 Status: Module Available :green_circle:,The module is published,C8E6C9
 Status: Module Orphaned :eyes:,The module has no owner and is therefore orphaned at this time,F4A460
 Status: Response Overdue :triangular_flag_on_post:,When an issue/PR has not been responded to for X amount of days,850000
+Status: Looking For Assistance :duck:,This item is looking for assistance from anyone to help develop the code and submit a PR for resolution,03FCC2
 Type: Bug :bug:,Something isn't working,D73A4A
 Type: Documentation :page_facing_up:,Improvements or additions to documentation,0075CA
 Type: Duplicate :palms_up_together:,This issue or pull request already exists,CFD3D7


### PR DESCRIPTION
This pull request includes a minor change to the `docs/static/governance/avm-standard-github-labels.csv` file. A new status label, "Looking For Assistance :duck:", has been added. This label is intended to be used for items that are seeking help from anyone to develop the code and submit a PR for resolution.