### PR TITLE
Triage automation and documentation improvements

### DIFF
--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -20,7 +20,10 @@ configuration:
           - addReply:
               reply: |
                 > [!IMPORTANT]
-                > **The "Needs: Triage :mag:" label must be removed as part of the triage process (when the issue/PR is first responded to) !**
+                > **The "Needs: Triage :mag:" label must be removed once the triage process is complete !**
+
+                > [!TIP]
+                > For additional guidance on how to triage this issue/PR, see the [AVM Issue Triage](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/avm-issue-triage/) documentation.
 
                 > [!NOTE]
                 > This label was added as per [ITA06](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita06).

--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -10,13 +10,18 @@ configuration:
       - description: 'ITA06 - If a new issue or PR is opened add the "Needs: Triage :mag:" label'
         if:
           - or:
-            - payloadType: Issues
-            - payloadType: Pull_Request
+              - payloadType: Issues
+              - payloadType: Pull_Request
           - isAction:
               action: Opened
         then:
           - addLabel:
-              label: 'Needs: Triage :mag:'
+              label: "Needs: Triage :mag:"
+          - addReply:
+              reply: |
+                The "Needs: Triage :mag:" label must be removed once the issue/PR has been triaged (and the issue/PR has been first responded)!
+
+                > **NOTE**: The "Needs: Triage :mag:" label was added as per [ITA06](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita06).
 
       - description: 'ITA09 - When #RR is used in an issue, add the "Needs: Author Feedback :ear:" label'
         if:
@@ -28,6 +33,9 @@ configuration:
         then:
           - addLabel:
               label: 'Needs: Author Feedback :ear:'
+          - addReply:
+              reply: |
+                > **NOTE**: The "Needs: Author Feedback :ear:" label was added as per [ITA09](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita09).
 
       - description: 'ITA10 - When #wontfix is used in an issue, mark it by using the label of "Status: Won''t Fix :broken_heart:"'
         if:
@@ -40,6 +48,9 @@ configuration:
           - addLabel:
               label: 'Status: Won''t Fix :broken_heart:'
           - closeIssue
+          - addReply:
+              reply: |
+                > **NOTE**: The "Status: Won't Fix :broken_heart:" label was added and the issue was closed as per [ITA10](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita10).
 
       - description: 'ITA11 - When a reply from anyone to an issue occurs, remove the "Needs: Author Feedback :ear:" label and label with "Needs: Attention :wave:"'
         if:
@@ -56,6 +67,9 @@ configuration:
               label: 'Needs: Author Feedback :ear:'
           - addLabel:
               label: 'Needs: Attention :wave:'
+          - addReply:
+              reply: |
+                > **NOTE**: The "Needs: Author Feedback :ear:" label was removed and the "Needs: Attention :wave:" label was added as per [ITA11](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita11).
 
       - description: 'ITA12 - Clean email replies on every comment'
         if:
@@ -76,6 +90,9 @@ configuration:
         then:
           - addLabel:
               label: 'Language: Bicep :muscle:'
+          - addReply:
+              reply: |
+                > **NOTE**: The "Language: Bicep :muscle:" label was added as per [ITA13](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita13).
 
       - description: 'ITA14 - If the language is set to Terraform in the Module proposal, add the "Language: Terraform :globe_with_meridians:" label on the issue'
         if:
@@ -90,6 +107,9 @@ configuration:
         then:
           - addLabel:
               label: 'Language: Terraform :globe_with_meridians:'
+          - addReply:
+              reply: |
+                > **NOTE**: The "Language: Terraform :globe_with_meridians:" label was added as per [ITA14](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita14).
 
       - description: 'ITA15 - remove the "Needs: Triage" label from a PR, if it already has a "Type: XYZ" label added at the time of creating it.'
         if:
@@ -118,6 +138,9 @@ configuration:
         then:
           - removeLabel:
               label: 'Needs: Triage :mag:'
+          - addReply:
+              reply: |
+                > **NOTE**: The "Needs: Triage :mag:" label was removed as per [ITA15](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita15).
 
       - description: 'ITA16 - Add the "Status: Owners Identified :metal:" label when someone is assigned to a Module Proposal'
         if:
@@ -131,6 +154,9 @@ configuration:
         then:
           - addLabel:
               label: 'Status: Owners Identified :metal:'
+          - addReply:
+              reply: |
+                > **NOTE**: The "Status: Owners Identified :metal:" label was added as per [ITA15](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita15).
         triggerOnOwnActions: true
 
       - description: 'ITA17 - If the issue author says they want to be the module owner, assign the issue to the author and respond to them.'
@@ -154,6 +180,8 @@ configuration:
 
                 The AVM core team will review this module proposal and respond to you first. Thank you!
 
+                > **NOTE**: This message was posted as per [ITA17](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita17).
+
       - description: 'ITA18 - Send automatic response to the issue author if they don''t want to be module owner and don''t have any candidate in mind. Add the "Needs: Module Owner :mega:" label.'
         if:
           - payloadType: Issues
@@ -176,6 +204,8 @@ configuration:
                 @${issueAuthor}, thanks for submitting this module proposal!
 
                 The AVM core team will review it and will try to find a module owner.
+
+                > **NOTE**: This message was posted as per [ITA18](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita18).
 
       - description: 'ITA19 - Send automatic response to the issue author if they don''t want to be module owner but have a candidate in mind. Add the "Status: Owners Identified :metal:" label.'
         if:
@@ -204,6 +234,8 @@ configuration:
 
                 The AVM core team will review this module proposal and respond to you and/or the module owner first. Thank you!
 
+                > **NOTE**: This message was posted as per [ITA19](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita19).
+
       - description: 'ITA23 - Remove the "Status: In PR" label from an issue when it''s closed.'
         if:
           - payloadType: Issues
@@ -212,3 +244,6 @@ configuration:
         then:
           - removeLabel:
               label: 'Status: In PR :point_right:'
+          - addReply:
+              reply: |
+                > **NOTE**: The "Status: In PR :point_right:" label was removed as per [ITA23](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita23).

--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -63,7 +63,7 @@ configuration:
         then:
           - cleanEmailReply
 
-      - description: 'ITA13 - If the language is set to Bicep in the Module proposal, assign the "Language: Bicep :muscle:" label on the issue'
+      - description: 'ITA13 - If the language is set to Bicep in the Module proposal, add the "Language: Bicep :muscle:" label on the issue'
         if:
           - payloadType: Issues
           - isAction:
@@ -77,7 +77,7 @@ configuration:
           - addLabel:
               label: 'Language: Bicep :muscle:'
 
-      - description: 'ITA14 - If the language is set to Terraform in the Module proposal, assign the "Language: Terraform :globe_with_meridians:" label on the issue'
+      - description: 'ITA14 - If the language is set to Terraform in the Module proposal, add the "Language: Terraform :globe_with_meridians:" label on the issue'
         if:
           - payloadType: Issues
           - isAction:
@@ -91,7 +91,7 @@ configuration:
           - addLabel:
               label: 'Language: Terraform :globe_with_meridians:'
 
-      - description: 'ITA15 - remove the "Needs: Triage" label from a PR, if it already has a "Type: XYZ" label assigned at the time of creating it.'
+      - description: 'ITA15 - remove the "Needs: Triage" label from a PR, if it already has a "Type: XYZ" label added at the time of creating it.'
         if:
           - payloadType: Pull_Request
           - or:
@@ -133,7 +133,7 @@ configuration:
               label: 'Status: Owners Identified :metal:'
         triggerOnOwnActions: true
 
-      - description: 'ITA17A - If the issue author says they want to be the module owner, assign the issue to the author and respond to them.'
+      - description: 'ITA17 - If the issue author says they want to be the module owner, assign the issue to the author and respond to them.'
         if:
           - payloadType: Issues
           - isAction:
@@ -146,18 +146,6 @@ configuration:
         then:
           - assignTo:
               author: true
-
-      - description: 'ITA17B - If the issue author says they want to be the module owner, assign the issue to the author and respond to them.'
-        if:
-          - payloadType: Issues
-          - isAction:
-              action: Opened
-          - bodyContains:
-              pattern: |
-                ### Do you want to be the owner of this module?
-
-                Yes
-        then:
           - addReply:
               reply: |
                 @${issueAuthor}, thanks for volunteering to be a module owner!
@@ -166,7 +154,7 @@ configuration:
 
                 The AVM core team will review this module proposal and respond to you first. Thank you!
 
-      - description: 'ITA18 - Send automatic response to the issue author if they don''t want to be module owner and don''t have any candidate in mind. Assign the "Needs: Module Owner :mega:" label.'
+      - description: 'ITA18 - Send automatic response to the issue author if they don''t want to be module owner and don''t have any candidate in mind. Add the "Needs: Module Owner :mega:" label.'
         if:
           - payloadType: Issues
           - isAction:
@@ -189,7 +177,7 @@ configuration:
 
                 The AVM core team will review it and will try to find a module owner.
 
-      - description: 'ITA19 - Send automatic response to the issue author if they don''t want to be module owner but have a candidate in mind. Assign the "Status: Owners Identified :metal:" label.'
+      - description: 'ITA19 - Send automatic response to the issue author if they don''t want to be module owner but have a candidate in mind. Add the "Status: Owners Identified :metal:" label.'
         if:
           - payloadType: Issues
           - isAction:

--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -19,9 +19,11 @@ configuration:
               label: "Needs: Triage :mag:"
           - addReply:
               reply: |
-                The "Needs: Triage :mag:" label must be removed once the issue/PR has been triaged (and the issue/PR has been first responded)!
+                > [!IMPORTANT]
+                > **The "Needs: Triage :mag:" label must be removed as part of the triage process (when the issue/PR is first responded to) !**
 
-                > **NOTE**: The "Needs: Triage :mag:" label was added as per [ITA06](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita06).
+                > [!NOTE]
+                > This label was added as per [ITA06](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita06).
 
       - description: 'ITA09 - When #RR is used in an issue, add the "Needs: Author Feedback :ear:" label'
         if:
@@ -29,13 +31,14 @@ configuration:
               - payloadType: Pull_Request_Review_Comment
               - payloadType: Issue_Comment
           - commentContains:
-              pattern: '#RR'
+              pattern: "#RR"
         then:
           - addLabel:
-              label: 'Needs: Author Feedback :ear:'
+              label: "Needs: Author Feedback :ear:"
           - addReply:
               reply: |
-                > **NOTE**: The "Needs: Author Feedback :ear:" label was added as per [ITA09](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita09).
+                > [!NOTE]
+                > The "Needs: Author Feedback :ear:" label was added as per [ITA09](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita09).
 
       - description: 'ITA10 - When #wontfix is used in an issue, mark it by using the label of "Status: Won''t Fix :broken_heart:"'
         if:
@@ -43,14 +46,15 @@ configuration:
               - payloadType: Pull_Request_Review_Comment
               - payloadType: Issue_Comment
           - commentContains:
-              pattern: '#wontfix'
+              pattern: "#wontfix"
         then:
           - addLabel:
-              label: 'Status: Won''t Fix :broken_heart:'
+              label: "Status: Won't Fix :broken_heart:"
           - closeIssue
           - addReply:
               reply: |
-                > **NOTE**: The "Status: Won't Fix :broken_heart:" label was added and the issue was closed as per [ITA10](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita10).
+                > [!NOTE]
+                > The "Status: Won't Fix :broken_heart:" label was added and the issue was closed as per [ITA10](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita10).
 
       - description: 'ITA11 - When a reply from anyone to an issue occurs, remove the "Needs: Author Feedback :ear:" label and label with "Needs: Attention :wave:"'
         if:
@@ -61,17 +65,18 @@ configuration:
               isAction:
                 action: Closed
           - hasLabel:
-              label: 'Needs: Author Feedback :ear:'
+              label: "Needs: Author Feedback :ear:"
         then:
           - removeLabel:
-              label: 'Needs: Author Feedback :ear:'
+              label: "Needs: Author Feedback :ear:"
           - addLabel:
-              label: 'Needs: Attention :wave:'
+              label: "Needs: Attention :wave:"
           - addReply:
               reply: |
-                > **NOTE**: The "Needs: Author Feedback :ear:" label was removed and the "Needs: Attention :wave:" label was added as per [ITA11](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita11).
+                > [!NOTE]
+                > The "Needs: Author Feedback :ear:" label was removed and the "Needs: Attention :wave:" label was added as per [ITA11](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita11).
 
-      - description: 'ITA12 - Clean email replies on every comment'
+      - description: "ITA12 - Clean email replies on every comment"
         if:
           - payloadType: Issue_Comment
         then:
@@ -89,10 +94,11 @@ configuration:
                 Bicep
         then:
           - addLabel:
-              label: 'Language: Bicep :muscle:'
+              label: "Language: Bicep :muscle:"
           - addReply:
               reply: |
-                > **NOTE**: The "Language: Bicep :muscle:" label was added as per [ITA13](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita13).
+                > [!NOTE]
+                > The "Language: Bicep :muscle:" label was added as per [ITA13](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita13).
 
       - description: 'ITA14 - If the language is set to Terraform in the Module proposal, add the "Language: Terraform :globe_with_meridians:" label on the issue'
         if:
@@ -106,41 +112,43 @@ configuration:
                 Terraform
         then:
           - addLabel:
-              label: 'Language: Terraform :globe_with_meridians:'
+              label: "Language: Terraform :globe_with_meridians:"
           - addReply:
               reply: |
-                > **NOTE**: The "Language: Terraform :globe_with_meridians:" label was added as per [ITA14](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita14).
+                > [!NOTE]
+                > The "Language: Terraform :globe_with_meridians:" label was added as per [ITA14](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita14).
 
       - description: 'ITA15 - remove the "Needs: Triage" label from a PR, if it already has a "Type: XYZ" label added at the time of creating it.'
         if:
           - payloadType: Pull_Request
           - or:
-            - hasLabel:
-                label: 'Type: Bug :bug:'
-            - hasLabel:
-                label: 'Type: Documentation :page_facing_up:'
-            - hasLabel:
-                label: 'Type: Duplicate :palms_up_together:'
-            - hasLabel:
-                label: 'Type: Feature Request :heavy_plus_sign:'
-            - hasLabel:
-                label: 'Type: Hygiene :broom:'
-            - hasLabel:
-                label: 'Type: New Module Proposal :bulb:'
-            - hasLabel:
-                label: 'Type: Question/Feedback :raising_hand:'
-            - hasLabel:
-                label: 'Type: Security Bug :lock:'
-            - hasLabel:
-                label: 'Type: AVM :a: :v: :m:'
+              - hasLabel:
+                  label: "Type: Bug :bug:"
+              - hasLabel:
+                  label: "Type: Documentation :page_facing_up:"
+              - hasLabel:
+                  label: "Type: Duplicate :palms_up_together:"
+              - hasLabel:
+                  label: "Type: Feature Request :heavy_plus_sign:"
+              - hasLabel:
+                  label: "Type: Hygiene :broom:"
+              - hasLabel:
+                  label: "Type: New Module Proposal :bulb:"
+              - hasLabel:
+                  label: "Type: Question/Feedback :raising_hand:"
+              - hasLabel:
+                  label: "Type: Security Bug :lock:"
+              - hasLabel:
+                  label: "Type: AVM :a: :v: :m:"
           - isAction:
               action: Opened
         then:
           - removeLabel:
-              label: 'Needs: Triage :mag:'
+              label: "Needs: Triage :mag:"
           - addReply:
               reply: |
-                > **NOTE**: The "Needs: Triage :mag:" label was removed as per [ITA15](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita15).
+                > [!NOTE]
+                > The "Needs: Triage :mag:" label was removed as per [ITA15](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita15).
 
       - description: 'ITA16 - Add the "Status: Owners Identified :metal:" label when someone is assigned to a Module Proposal'
         if:
@@ -149,17 +157,18 @@ configuration:
               isAction:
                 action: Closed
           - hasLabel:
-              label: 'Type: New Module Proposal :bulb:'
+              label: "Type: New Module Proposal :bulb:"
           - isAssignedToSomeone
         then:
           - addLabel:
-              label: 'Status: Owners Identified :metal:'
+              label: "Status: Owners Identified :metal:"
           - addReply:
               reply: |
-                > **NOTE**: The "Status: Owners Identified :metal:" label was added as per [ITA15](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita15).
+                > [!NOTE]
+                > The "Status: Owners Identified :metal:" label was added as per [ITA15](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita15).
         triggerOnOwnActions: true
 
-      - description: 'ITA17 - If the issue author says they want to be the module owner, assign the issue to the author and respond to them.'
+      - description: "ITA17 - If the issue author says they want to be the module owner, assign the issue to the author and respond to them."
         if:
           - payloadType: Issues
           - isAction:
@@ -176,11 +185,13 @@ configuration:
               reply: |
                 @${issueAuthor}, thanks for volunteering to be a module owner!
 
-                **Please don't start the development just yet!**
+                > [!IMPORTANT]
+                > **Please don't start the development just yet!**
+                >
+                > The AVM core team will review this module proposal and respond to you first. Thank you!
 
-                The AVM core team will review this module proposal and respond to you first. Thank you!
-
-                > **NOTE**: This message was posted as per [ITA17](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita17).
+                > [!NOTE]
+                > This message was posted as per [ITA17](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita17).
 
       - description: 'ITA18 - Send automatic response to the issue author if they don''t want to be module owner and don''t have any candidate in mind. Add the "Needs: Module Owner :mega:" label.'
         if:
@@ -198,14 +209,16 @@ configuration:
                 _No response_
         then:
           - addLabel:
-              label: 'Needs: Module Owner :mega:'
+              label: "Needs: Module Owner :mega:"
           - addReply:
               reply: |
-                @${issueAuthor}, thanks for submitting this module proposal!
+                **@${issueAuthor}, thanks for submitting this module proposal!**
 
-                The AVM core team will review it and will try to find a module owner.
+                > [!IMPORTANT]
+                > The AVM core team will review it and will try to find a module owner.
 
-                > **NOTE**: This message was posted as per [ITA18](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita18).
+                > [!NOTE]
+                > This message was posted as per [ITA18](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita18).
 
       - description: 'ITA19 - Send automatic response to the issue author if they don''t want to be module owner but have a candidate in mind. Add the "Status: Owners Identified :metal:" label.'
         if:
@@ -225,16 +238,18 @@ configuration:
                   _No response_
         then:
           - addLabel:
-              label: 'Status: Owners Identified :metal:'
+              label: "Status: Owners Identified :metal:"
           - addReply:
               reply: |
-                @${issueAuthor}, thanks for submitting this module proposal with a module owner in mind!
+                **@${issueAuthor}, thanks for submitting this module proposal with a module owner in mind!**
 
-                **Please don't start the development just yet!**
+                > [!IMPORTANT]
+                > **Please don't start the development just yet!**
+                >
+                > The AVM core team will review this module proposal and respond to you and/or the module owner first. Thank you!
 
-                The AVM core team will review this module proposal and respond to you and/or the module owner first. Thank you!
-
-                > **NOTE**: This message was posted as per [ITA19](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita19).
+                > [!NOTE]
+                > This message was posted as per [ITA19](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita19).
 
       - description: 'ITA23 - Remove the "Status: In PR" label from an issue when it''s closed.'
         if:
@@ -243,7 +258,8 @@ configuration:
               action: Closed
         then:
           - removeLabel:
-              label: 'Status: In PR :point_right:'
+              label: "Status: In PR :point_right:"
           - addReply:
               reply: |
-                > **NOTE**: The "Status: In PR :point_right:" label was removed as per [ITA23](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita23).
+                > [!NOTE]
+                > The "Status: In PR :point_right:" label was removed as per [ITA23](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita23).

--- a/.github/policies/scheduledSearches.yml
+++ b/.github/policies/scheduledSearches.yml
@@ -9,65 +9,80 @@ configuration:
     scheduledSearches:
     - description: 'ITA04 - Label issues that have been marked as requiring author feedback but have not had any activity for 4 days.'
       frequencies:
-      - hourly:
-          hour: 3
+        - hourly:
+            hour: 3
       filters:
-      - isIssue
-      - isOpen
-      - hasLabel:
-          label: 'Needs: Author Feedback :ear:'
-      - noActivitySince:
-          days: 4
-      - isNotLabeledWith:
-          label: 'Status: No Recent Activity :zzz:'
+        - isIssue
+        - isOpen
+        - hasLabel:
+            label: "Needs: Author Feedback :ear:"
+        - noActivitySince:
+            days: 4
+        - isNotLabeledWith:
+            label: "Status: No Recent Activity :zzz:"
       actions:
-      - addLabel:
-          label: 'Status: No Recent Activity :zzz:'
-      - addReply:
-          reply: |
-            @${issueAuthor}, this issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
+        - addLabel:
+            label: "Status: No Recent Activity :zzz:"
+        - addReply:
+            reply: |
+              @${issueAuthor}, this issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
+
+              > **NOTE**: This message was posted as per [ITA04](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita04).
+              >
+              > To prevent further actions to take effect, one of the following conditions must be met:
+              >   - The author must respond in a comment within 3 days of this comment.
+              >   - The "Status: No Recent Activity :zzz:" label must be removed.
+              >   - If applicable, the "Status: Long Term :hourglass_flowing_sand:" or the "Needs: Module Owner :mega:" label must be added.
 
     - description: 'ITA05A - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
       frequencies:
-      - hourly:
-          hour: 3
+        - hourly:
+            hour: 3
       filters:
-      - isIssue
-      - isOpen
-      - hasLabel:
-          label: 'Needs: Author Feedback :ear:'
-      - hasLabel:
-          label: 'Status: No Recent Activity :zzz:'
-      - isNotLabeledWith:
-          label: 'Needs: Module Owner :mega:'
-      - noActivitySince:
-          days: 3
+        - isIssue
+        - isOpen
+        - hasLabel:
+            label: "Needs: Author Feedback :ear:"
+        - hasLabel:
+            label: "Status: No Recent Activity :zzz:"
+        - isNotLabeledWith:
+            label: "Needs: Module Owner :mega:"
+        - noActivitySince:
+            days: 3
       actions:
-      - addReply:
-          reply: |
-            @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
-      - closeIssue
+        - addReply:
+            reply: |
+              @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
+
+              > **NOTE**: This message was posted as per [ITA05](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita05).
+              >
+              > In case this issue needs to be reopened (e.g., the author responds after the issue was closed), the "Status: No Recent Activity :zzz:" label must be removed.
+        - closeIssue
 
     - description: 'ITA05B - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
       frequencies:
-      - hourly:
-          hour: 3
+        - hourly:
+            hour: 3
       filters:
-      - isIssue
-      - isOpen
-      - hasLabel:
-          label: 'Needs: Author Feedback :ear:'
-      - hasLabel:
-          label: 'Status: No Recent Activity :zzz:'
-      - isNotLabeledWith:
-          label: 'Status: Long Term :hourglass_flowing_sand:'
-      - noActivitySince:
-          days: 3
+        - isIssue
+        - isOpen
+        - hasLabel:
+            label: "Needs: Author Feedback :ear:"
+        - hasLabel:
+            label: "Status: No Recent Activity :zzz:"
+        - isNotLabeledWith:
+            label: "Status: Long Term :hourglass_flowing_sand:"
+        - noActivitySince:
+            days: 3
       actions:
-      - addReply:
-          reply: |
-            @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
-      - closeIssue
+        - addReply:
+            reply: |
+              @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
+
+              > **NOTE**: This message was posted as per [ITA05](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita05).
+              >
+              > In case this issue needs to be reopened (e.g., the author responds after the issue was closed), the "Status: No Recent Activity :zzz:" label must be removed.
+        - closeIssue
 
     - description: 'ITA24 - Remind module owner(s) to start or continue working on this module if there was no activity on the Module Proposal issue for more than 3 weeks. "Add Needs: Attention :wave:" label.'
       frequencies:
@@ -88,5 +103,7 @@ configuration:
       - addReply:
           reply: |
             ${assignees}, this issue has not had any activity in the last **3 weeks**. Please feel free to reach out to the AVM core team should you have any questions or need any help with the development of this module.
+
+            > **NOTE**: This message was posted as per [ITA24](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita24).
       - addLabel:
           label: 'Needs: Attention :wave:'

--- a/.github/policies/scheduledSearches.yml
+++ b/.github/policies/scheduledSearches.yml
@@ -7,103 +7,117 @@ disabled: false
 configuration:
   resourceManagementConfiguration:
     scheduledSearches:
-    - description: 'ITA04 - Label issues that have been marked as requiring author feedback but have not had any activity for 4 days.'
-      frequencies:
-        - hourly:
-            hour: 3
-      filters:
-        - isIssue
-        - isOpen
-        - hasLabel:
-            label: "Needs: Author Feedback :ear:"
-        - noActivitySince:
-            days: 4
-        - isNotLabeledWith:
-            label: "Status: No Recent Activity :zzz:"
-      actions:
-        - addLabel:
-            label: "Status: No Recent Activity :zzz:"
-        - addReply:
-            reply: |
-              @${issueAuthor}, this issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
+      - description: "ITA04 - Label issues that have been marked as requiring author feedback but have not had any activity for 4 days."
+        frequencies:
+          - hourly:
+              hour: 3
+        filters:
+          - isIssue
+          - isOpen
+          - hasLabel:
+              label: "Needs: Author Feedback :ear:"
+          - noActivitySince:
+              days: 4
+          - isNotLabeledWith:
+              label: "Status: No Recent Activity :zzz:"
+        actions:
+          - addLabel:
+              label: "Status: No Recent Activity :zzz:"
+          - addReply:
+              reply: |
+                > [!IMPORTANT]
+                > @${issueAuthor}, this issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
 
-              > **NOTE**: This message was posted as per [ITA04](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita04).
-              >
-              > To prevent further actions to take effect, one of the following conditions must be met:
-              >   - The author must respond in a comment within 3 days of this comment.
-              >   - The "Status: No Recent Activity :zzz:" label must be removed.
-              >   - If applicable, the "Status: Long Term :hourglass_flowing_sand:" or the "Needs: Module Owner :mega:" label must be added.
+                > [!TIP]
+                > To prevent further actions to take effect, one of the following conditions must be met:
+                >   - The author must respond in a comment within 3 days of this comment.
+                >   - The "Status: No Recent Activity :zzz:" label must be removed.
+                >   - If applicable, the "Status: Long Term :hourglass_flowing_sand:" or the "Needs: Module Owner :mega:" label must be added.
 
-    - description: 'ITA05A - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
-      frequencies:
-        - hourly:
-            hour: 3
-      filters:
-        - isIssue
-        - isOpen
-        - hasLabel:
-            label: "Needs: Author Feedback :ear:"
-        - hasLabel:
-            label: "Status: No Recent Activity :zzz:"
-        - isNotLabeledWith:
-            label: "Needs: Module Owner :mega:"
-        - noActivitySince:
-            days: 3
-      actions:
-        - addReply:
-            reply: |
-              @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
+                > [!NOTE]
+                > This message was posted as per [ITA04](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita04).
 
-              > **NOTE**: This message was posted as per [ITA05](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita05).
-              >
-              > In case this issue needs to be reopened (e.g., the author responds after the issue was closed), the "Status: No Recent Activity :zzz:" label must be removed.
-        - closeIssue
+      - description: 'ITA05A - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
+        frequencies:
+          - hourly:
+              hour: 3
+        filters:
+          - isIssue
+          - isOpen
+          - hasLabel:
+              label: "Needs: Author Feedback :ear:"
+          - hasLabel:
+              label: "Status: No Recent Activity :zzz:"
+          - isNotLabeledWith:
+              label: "Needs: Module Owner :mega:"
+          - noActivitySince:
+              days: 3
+        actions:
+          - addReply:
+              reply: |
+                > [!WARNING]
+                > @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
 
-    - description: 'ITA05B - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
-      frequencies:
-        - hourly:
-            hour: 3
-      filters:
-        - isIssue
-        - isOpen
-        - hasLabel:
-            label: "Needs: Author Feedback :ear:"
-        - hasLabel:
-            label: "Status: No Recent Activity :zzz:"
-        - isNotLabeledWith:
-            label: "Status: Long Term :hourglass_flowing_sand:"
-        - noActivitySince:
-            days: 3
-      actions:
-        - addReply:
-            reply: |
-              @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
+                > [!TIP]
+                > In case this issue needs to be reopened (e.g., the author responds after the issue was closed), the "Status: No Recent Activity :zzz:" label must be removed.
 
-              > **NOTE**: This message was posted as per [ITA05](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita05).
-              >
-              > In case this issue needs to be reopened (e.g., the author responds after the issue was closed), the "Status: No Recent Activity :zzz:" label must be removed.
-        - closeIssue
+                > [!NOTE]
+                > This message was posted as per [ITA05](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita05).
+          - closeIssue
 
-    - description: 'ITA24 - Remind module owner(s) to start or continue working on this module if there was no activity on the Module Proposal issue for more than 3 weeks. "Add Needs: Attention :wave:" label.'
-      frequencies:
-      - hourly:
-          hour: 3
-      filters:
-      - isIssue
-      - isOpen
-      - hasLabel:
-          label: 'Type: New Module Proposal :bulb:'
-      - hasLabel:
-          label: 'Status: Owners Identified :metal:'
-      - noActivitySince:
-          days: 21
-      - isNotLabeledWith:
-          label: 'Status: Long Term :hourglass_flowing_sand:'
-      actions:
-      - addReply:
-          reply: |
-            ${assignees}, this issue has not had any activity in the last **3 weeks**. Please feel free to reach out to the AVM core team should you have any questions or need any help with the development of this module.
+      - description: 'ITA05B - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
+        frequencies:
+          - hourly:
+              hour: 3
+        filters:
+          - isIssue
+          - isOpen
+          - hasLabel:
+              label: "Needs: Author Feedback :ear:"
+          - hasLabel:
+              label: "Status: No Recent Activity :zzz:"
+          - isNotLabeledWith:
+              label: "Status: Long Term :hourglass_flowing_sand:"
+          - noActivitySince:
+              days: 3
+        actions:
+          - addReply:
+              reply: |
+                > [!WARNING]
+                > @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
 
-            > **NOTE**: This message was posted as per [ITA24](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita24).
-      - addLabel:
-          label: 'Needs: Attention :wave:'
+                > [!TIP]
+                > In case this issue needs to be reopened (e.g., the author responds after the issue was closed), the "Status: No Recent Activity :zzz:" label must be removed.
+
+                > [!NOTE]
+                > This message was posted as per [ITA05](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita05).
+          - closeIssue
+
+      - description: 'ITA24 - Remind module owner(s) to start or continue working on this module if there was no activity on the Module Proposal issue for more than 3 weeks. "Add Needs: Attention :wave:" label.'
+        frequencies:
+          - hourly:
+              hour: 3
+        filters:
+          - isIssue
+          - isOpen
+          - hasLabel:
+              label: "Type: New Module Proposal :bulb:"
+          - hasLabel:
+              label: "Status: Owners Identified :metal:"
+          - noActivitySince:
+              days: 21
+          - isNotLabeledWith:
+              label: "Status: Long Term :hourglass_flowing_sand:"
+        actions:
+          - addReply:
+              reply: |
+                > [!IMPORTANT]
+                > ${assignees}, this issue has not had any activity in the last **3 weeks**. Please feel free to reach out to the AVM core team should you have any questions or need any help with the development of this module.
+
+                > [!TIP]
+                > To silence this notification, provide an update every 3 weeks on the Module Proposal issue, or add the "Status: Long Term :hourglass_flowing_sand:" label.
+
+                > [!NOTE]
+                > This message was posted as per [ITA24](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita24).
+          - addLabel:
+              label: "Needs: Attention :wave:"

--- a/docs/content/help-support/issue-triage/brm-issue-triage.md
+++ b/docs/content/help-support/issue-triage/brm-issue-triage.md
@@ -59,25 +59,24 @@ An issue is considered to be an "AVM module issue" if
 {{< hint type=note >}}
 Module issues can only be opened for existing AVM modules. Module issues **MUST NOT** be used to file a module proposal.
 
-If the issue was opened as a misplaced module proposal, mention the `@Azure/AVM-core-team` in the comment section and ask them to move the issue to the AVM repository.
+If the issue was opened as a misplaced module proposal, mention the `@Azure/AVM-core-team-technical-bicep` team in the comment section and ask them to move the issue to the AVM repository.
 {{< /hint >}}
 
-1. Add the "<mark style="background-color:#E4E669;">Status: In Triage 🔍</mark>" label to indicate you're in the process of triaging the issue.
-2. Check the Module issue:
+### Triaging a Module Issue
+
+1. Check the Module issue:
     - Make sure the issue has the "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" applied to it.
-    - Use the AVM module indexes to identify the module owner(s).
-    - Assign the issue to the module owner(s).
-    - If the module is orphaned (has no owner), make sure there's an orphaned module issue in the AVM repository
+    - Use the AVM module indexes for the module owner(s) and make sure they are assigned/mentioned/informed.
+    - If the module is orphaned (has no owner), make sure there's an orphaned module issue in the AVM repository.
     - Make sure the module's details are captured correctly in the description - i.e., name, classification (resource/pattern), language (Bicep/Terraform), etc.
     - Make sure the issue is categorized using one of the following type labels:
       - "<mark style="background-color:#A2EEEF;">Type: Feature Request ➕</mark>"
       - "<mark style="background-color:#D73A4A;color:white;">Type: Bug 🐛</mark>"
       - "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>"
-3. Apply relevant labels
-    - Module language: "<mark style="background-color:#1D73B3;color:white;">Language: Bicep 💪</mark>" or "<mark style="background-color:#7740B6;color:white;">Language: Terraform 🌐</mark>"
-    - Module classification (resource/pattern): "<mark style="background-color:#D3D3D3;">Class: Resource Module 📦</mark>" or "<mark style="background-color:#A9A9A9;">Class: Pattern Module 📦</mark>"
-4. Communicate next steps to the requestor (issue author).
-5. When plans are available, communicate expected timeline for the update/fix to the requestor (issue author).
+2. Apply relevant labels for module classification (resource/pattern): "<mark style="background-color:#D3D3D3;">Class: Resource Module 📦</mark>" or "<mark style="background-color:#A9A9A9;">Class: Pattern Module 📦</mark>"
+3. Communicate next steps to the requestor (issue author).
+4. Remove the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label.
+5. When more detailed plans are available, communicate expected timeline for the update/fix to the requestor (issue author).
 6. Only close the issue, once the next version of the module was fully developed, tested and published.
 
 <br>
@@ -92,14 +91,22 @@ An issue is considered to be an "AVM Question/Feedback" if
 
 An issue is considered to be a "standard issue" or "blank issue" if it was opened without using an issue template, and hence it does **NOT** have any labels assigned, OR only has the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label assigned.
 
-When triaging the issue, consider adding one of the following labels as fits:
+### Triaging a General Question/Feedback and other standard issues
 
-- <mark style="background-color:#0075CA;color:white;">Type: Documentation 📄</mark>
-- <mark style="background-color:#A2EEEF;">Type: Feature Request ➕</mark>
-- <mark style="background-color:#D73A4A;color:white;">Type: Bug 🐛</mark>
-- <mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>
+1. When triaging the issue, consider adding one of the following labels as fits:
 
-To see the full list of available labels, please refer to the [GitHub Repo Labels](/Azure-Verified-Modules/specs/shared/#id-snfr23---category-contributionsupport---github-repo-labels) section.
+   - <mark style="background-color:#0075CA;color:white;">Type: Documentation 📄</mark>
+   - <mark style="background-color:#A2EEEF;">Type: Feature Request ➕</mark>
+   - <mark style="background-color:#D73A4A;color:white;">Type: Bug 🐛</mark>
+   - <mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>
+
+> To see the full list of available labels, please refer to the [GitHub Repo Labels](/Azure-Verified-Modules/specs/shared/#id-snfr23---category-contributionsupport---github-repo-labels) section.
+
+2. Add any (additional) labels that apply.
+3. Communicate next steps to the requestor (issue author).
+4. Remove the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label.
+5. When more detailed plans are available, communicate expected timeline for the update/fix to the requestor (issue author).
+6. Once the question/feedback/topic is fully addressed, close the issue.
 
 {{< hint type=note >}}
 

--- a/docs/content/help-support/issue-triage/brm-issue-triage.md
+++ b/docs/content/help-support/issue-triage/brm-issue-triage.md
@@ -95,10 +95,10 @@ An issue is considered to be a "standard issue" or "blank issue" if it was opene
 
 1. When triaging the issue, consider adding one of the following labels as fits:
 
-   - <mark style="background-color:#0075CA;color:white;">Type: Documentation 📄</mark>
-   - <mark style="background-color:#A2EEEF;">Type: Feature Request ➕</mark>
-   - <mark style="background-color:#D73A4A;color:white;">Type: Bug 🐛</mark>
-   - <mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>
+    - <mark style="background-color:#0075CA;color:white;">Type: Documentation 📄</mark>
+    - <mark style="background-color:#A2EEEF;">Type: Feature Request ➕</mark>
+    - <mark style="background-color:#D73A4A;color:white;">Type: Bug 🐛</mark>
+    - <mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>
 
 > To see the full list of available labels, please refer to the [GitHub Repo Labels](/Azure-Verified-Modules/specs/shared/#id-snfr23---category-contributionsupport---github-repo-labels) section.
 

--- a/docs/content/help-support/issue-triage/issue-triage-automation.md
+++ b/docs/content/help-support/issue-triage/issue-triage-automation.md
@@ -37,10 +37,10 @@ If a bug/feature/request/general question that has the labels of "<mark style="b
 - Add a reply, mentioning the `Azure/avm-core-team-technical-bicep` team.
 - Add the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label.
 
-**Tip:**
-
-- To prevent further actions to take effect, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed.
-- To avoid this rule being triggered at all, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label must be removed once the issue has been triaged (and the issue is first responded).
+{{< hint type=tip >}}
+- To prevent further actions to take effect, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed, once this issue has been responded to.
+- To avoid this rule being (re)triggered, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" must be removed as part of the triage process (when the issue is first responded to).
+{{< /hint >}}
 
 ---
 
@@ -63,10 +63,10 @@ If a bug/feature/request/general question that has the "<mark style="background-
 - Add a reply, mentioning the `Azure/avm-core-team-technical-bicep` team.
 - Add the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label.
 
-**Tip:**
-
-- To prevent further actions to take effect, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed.
-- To avoid this rule being triggered at all, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label must be removed once the issue has been triaged (and the issue is first responded).
+{{< hint type=tip >}}
+- To prevent further actions to take effect, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed, once this issue has been responded to.
+- To avoid this rule being (re)triggered, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" must be removed as part of the triage process (when the issue is first responded to).
+{{< /hint >}}
 
 ---
 
@@ -89,9 +89,10 @@ If after an additional 3 business days there's still no update to the issue that
 - Add a reply, mentioning the `Azure/avm-core-team-technical-bicep` team.
 - Add the "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label.
 
-**Tip:**
-
-- To avoid this rule being triggered at all, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed.
+{{< hint type=tip >}}
+- To avoid this rule being (re)triggered, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" labels must be removed when the issue is first responded to!
+- Remove the "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label once the issue has been responded to.
+{{< /hint >}}
 
 ---
 
@@ -114,9 +115,10 @@ If after an additional 3 business days there's still no update to the issue that
 - Add a reply, mentioning the `Azure/avm-core-team-technical-bicep` team.
 - Add the "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label.
 
-**Tip:**
-
-- To avoid this rule being triggered at all, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed.
+{{< hint type=tip >}}
+- To avoid this rule being (re)triggered, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" labels must be removed when the issue is first responded to!
+- Remove the "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label once the issue has been responded to.
+{{< /hint >}}
 
 ---
 
@@ -139,9 +141,10 @@ If there's still no response after 5 days (total from start of issue being raise
 - Add a reply, mentioning the `Azure/bicep-admins` team.
 - Add the "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label.
 
-**Tip:**
-
-- To avoid this rule being triggered at all, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label must be removed once the issue has been triaged (and the issue is first responded).
+{{< hint type=tip >}}
+- To avoid this rule being (re)triggered, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" labels must be removed when the issue is first responded to!
+- Remove the "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label once the issue has been responded to.
+{{< /hint >}}
 
 ---
 
@@ -186,13 +189,13 @@ If an issue/PR has been labelled with "<mark style="background-color:#CB6BA2;col
 - Add the "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" label.
 - Add a reply.
 
-**Tip:**
-
+{{< hint type=tip >}}
 To prevent further actions to take effect, one of the following conditions must be met:
 
 - The author must respond in a comment within 3 days of the automatic comment left on the issue.
 - The "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" label must be removed.
 - If applicable, the "<mark style="background-color:#B60205;color:white;">Status: Long Term ⏳</mark>" or the "<mark style="background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark>" label must be added.
+{{< /hint >}}
 
 ---
 
@@ -216,9 +219,9 @@ If an issue/PR has been labelled with "<mark style="background-color:#808080;col
 - Add a reply.
 - Close the issue.
 
-**Tip:**
-
+{{< hint type=tip >}}
 - In case the issue needs to be reopened (e.g., the author responds after the issue was closed), the "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" label must be removed.
+{{< /hint >}}
 
 ---
 
@@ -242,9 +245,9 @@ Remind module owner(s) to start or continue working on this module if there was 
 - Add a reply.
 - Add the "<mark style="background-color:#E99695;color:white;">Needs: Attention 👋</mark>" label.
 
-**Tip:**
-
+{{< hint type=tip >}}
 - To avoid/silence this notification, provide an update every 3 weeks on the Module Proposal issue, or add the "<mark style="background-color:#B60205;color:white;">Status: Long Term ⏳</mark>" label.
+{{< /hint >}}
 
 ---
 

--- a/docs/content/help-support/issue-triage/issue-triage-automation.md
+++ b/docs/content/help-support/issue-triage/issue-triage-automation.md
@@ -42,6 +42,8 @@ If a bug/feature/request/general question that has the labels of "<mark style="b
 - To prevent further actions to take effect, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed.
 - To avoid this rule being triggered at all, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label must be removed once the issue has been triaged (and the issue is first responded).
 
+---
+
 ### ITA01TF.1-2
 
 If a bug/feature/request/general question that has the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label added is not responded to after 3 business days, then the issue will be marked with the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label and the AVM Core team will be mentioned in a comment on the issue to reach out to the module owner.
@@ -66,6 +68,8 @@ If a bug/feature/request/general question that has the "<mark style="background-
 - To prevent further actions to take effect, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed.
 - To avoid this rule being triggered at all, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label must be removed once the issue has been triaged (and the issue is first responded).
 
+---
+
 ### ITA02BCP.1-2
 
 If after an additional 3 business days there's still no update to the issue that has the labels of "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>", the AVM core team will be mentioned on the issue and a further comment stating module owner is unresponsive will be added. The "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label will also be added.
@@ -88,6 +92,8 @@ If after an additional 3 business days there's still no update to the issue that
 **Tip:**
 
 - To avoid this rule being triggered at all, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed.
+
+---
 
 ### ITA02TF.1-2
 
@@ -112,6 +118,8 @@ If after an additional 3 business days there's still no update to the issue that
 
 - To avoid this rule being triggered at all, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed.
 
+---
+
 ### ITA03BCP
 
 If there's still no response after 5 days (total from start of issue being raised) on an issue that has the labels of "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>", "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>", "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>" and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>", the Bicep PG GitHub Team will be mentioned on the issue to assist. The "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label will also be added.
@@ -135,6 +143,8 @@ If there's still no response after 5 days (total from start of issue being raise
 
 - To avoid this rule being triggered at all, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label must be removed once the issue has been triaged (and the issue is first responded).
 
+---
+
 ### ITA03TF
 
 If there's still no response after 5 days (total from start of issue being raised) on an issue that has the labels of "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>", "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>" and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>", the Terraform PG GitHub Team will be mentioned on the issue to assist. The "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label will also be added.
@@ -153,6 +163,8 @@ If there's still no response after 5 days (total from start of issue being raise
 
 - Add a reply, mentioning the `Azure/terraform-avm` team.
 - Add the "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label.
+
+---
 
 ### ITA04
 
@@ -182,6 +194,8 @@ To prevent further actions to take effect, one of the following conditions must 
 - The "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" label must be removed.
 - If applicable, the "<mark style="background-color:#B60205;color:white;">Status: Long Term ⏳</mark>" or the "<mark style="background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark>" label must be added.
 
+---
+
 ### ITA05
 
 If an issue/PR has been labelled with "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" and hasn't had any update in 3 days from that point, automatically close it and comment, unless the issue/PR has a "<mark style="background-color:#B60205;color:white;">Status: Long Term ⏳</mark>" - in which case, do not close it.
@@ -205,6 +219,8 @@ If an issue/PR has been labelled with "<mark style="background-color:#808080;col
 **Tip:**
 
 - In case the issue needs to be reopened (e.g., the author responds after the issue was closed), the "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" label must be removed.
+
+---
 
 ### ITA24
 
@@ -230,6 +246,8 @@ Remind module owner(s) to start or continue working on this module if there was 
 
 - To avoid/silence this notification, provide an update every 3 weeks on the Module Proposal issue, or add the "<mark style="background-color:#B60205;color:white;">Status: Long Term ⏳</mark>" label.
 
+---
+
 <br>
 
 ## Event based automation
@@ -247,6 +265,9 @@ When a new issue or PR of any type is created add the "<mark style="background-c
 **Action(s):**
 
 - Add the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label.
+- Add a reply to explain the action(s).
+
+---
 
 ### ITA08BCP
 
@@ -259,6 +280,9 @@ If AVM or "Azure Verified Modules" is mentioned in an uncategorized issue (i.e.,
 **Action(s):**
 
 - Add the "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" label.
+- Add a reply to explain the action(s).
+
+---
 
 ### ITA09
 
@@ -267,10 +291,13 @@ When #RR is used in an issue, add the label of "<mark style="background-color:#C
 **Trigger criteria:**
 
 - An issue comment or PR comment contains the string of "#RR".
+- Add a reply to explain the action(s).
 
 **Action(s):**
 
 - Add the "<mark style="background-color:#CB6BA2;color:white;">Needs: Author Feedback 👂</mark>" label.
+
+---
 
 ### ITA10
 
@@ -284,6 +311,9 @@ When #wontfix is used in an issue, mark it by using the label of "<mark style="b
 
 - Add the "<mark style="background-color:#FFFFFF;">Status: Won't Fix 💔</mark>" label.
 - Close the issue.
+- Add a reply to explain the action(s).
+
+---
 
 ### ITA11
 
@@ -297,6 +327,9 @@ When a reply from anyone to an issue occurs, remove the "<mark style="background
 **Action(s):**
 
 - Add the "<mark style="background-color:#E99695;color:white;">Needs: Attention 👋</mark>" label.
+- Add a reply to explain the action(s).
+
+---
 
 ### ITA12
 
@@ -310,72 +343,264 @@ Clean up e-mail replies to GitHub Issues for readability.
 
 - Clean email reply. This is useful when someone directly responds to an email notification from GitHub, and the email signature is included in the comment.
 
+---
+
 ### ITA13
 
 If the language is set to Bicep in the Module proposal, add the "<mark style="background-color:#1D73B3;color:white;">Language: Bicep 💪</mark>" label on the issue.
+
+**Trigger criteria:**
+
+- An issue is opened with its body matching the below pattern.
+
+```markdown
+### Bicep or Terraform?
+
+Bicep
+```
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#1D73B3;color:white;">Language: Bicep 💪</mark>" label.
+- Add a reply to explain the action(s).
+
+---
 
 ### ITA14
 
 If the language is set to Terraform in the Module proposal, add the "<mark style="background-color:#7740B6;color:white;">Language: Terraform 🌐</mark>" label on the issue.
 
+**Trigger criteria:**
+
+- An issue is opened with its body matching the below pattern.
+
+```markdown
+### Bicep or Terraform?
+
+Terraform
+```
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#7740B6;color:white;">Language: Terraform 🌐</mark>" label.
+- Add a reply to explain the action(s).
+
+---
+
 ### ITA15
 
 Remove the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label from a PR, if it already has a "<mark>Type: *XYZ*</mark>" label added at the time of creating it.
+
+**Trigger criteria:**
+
+- A PR is opened with any of the following labels added:
+  - "<mark style="background-color:#D73A4A;color:white;">Type: Bug 🐛</mark>"
+  - "<mark style="background-color:#0075CA;color:white;">Type: Documentation 📄</mark>"
+  - "<mark style="background-color:#CFD3D7;">Type: Duplicate 🤲</mark>"
+  - "<mark style="background-color:#A2EEEF;">Type: Feature Request ➕</mark>"
+  - "<mark style="background-color:#17016A;color:white;">Type: Hygiene 🧹</mark>"
+  - "<mark style="background-color:#ADD8E6;">Type: New Module Proposal 💡</mark>"
+  - "<mark style="background-color:#CB6BA2;color:white;">Type: Question/Feedback 🙋‍♀️</mark>"
+  - "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>"
+  - "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>"
+
+**Action(s):**
+
+- Remove the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label.
+- Add a reply to explain the action(s).
+
+---
 
 ### ITA16
 
 Add the "<mark style="background-color:#FBEF2A;">Status: Owners Identified 🤘</mark>" label when someone is assigned to a Module Proposal.
 
+**Trigger criteria:**
+
+- Any action on an issue except closing.
+- Has the "<mark style="background-color:#ADD8E6;">Type: New Module Proposal 💡</mark>" added.
+- The issue is assigned to someone.
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#FBEF2A;">Status: Owners Identified 🤘</mark>" label.
+- Add a reply to explain the action(s).
+
+---
+
 ### ITA17
 
 If the issue author says they want to be the module owner, assign the issue to the author and respond to them.
 
-```markdown
-@${issueAuthor}, thanks for volunteering to be a module owner!
+**Trigger criteria:**
 
-**Please don't start the development just yet!**
+- An issue is opened with its body matching the below pattern.
 
-The AVM core team will review this module proposal and respond to you first. Thank you!
-```
+  ```markdown
+  ### Do you want to be the owner of this module?
+
+  Yes
+  ```
+
+**Action(s):**
+
+- Assign the issue to the author.
+- Add the below reply and explain the action(s).
+
+  ```markdown
+  @${issueAuthor}, thanks for volunteering to be a module owner!
+
+  **Please don't start the development just yet!**
+
+  The AVM core team will review this module proposal and respond to you first. Thank you!
+  ```
+
+---
 
 ### ITA18
 
 Send automatic response to the issue author if they don't want to be module owner and don't have any candidate in mind. Add the "<mark style="background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark>" label.
 
-```markdown
-@${issueAuthor}, thanks for submitting this module proposal!
-The AVM core team will review it and will try to find a module owner.
-```
+**Trigger criteria:**
+
+- An issue is opened with its body matching the below pattern.
+
+  ```markdown
+    ### Do you want to be the owner of this module?
+
+    No
+
+    ### Module Owner's GitHub Username (handle)
+
+    _No response_
+  ```
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark>" label.
+- Add the below reply and explain the action(s).
+
+  ```markdown
+  @${issueAuthor}, thanks for submitting this module proposal!
+  The AVM core team will review it and will try to find a module owner.
+  ```
+
+---
 
 ### ITA19
 
 Send automatic response to the issue author if they don't want to be module owner but have a candidate in mind. Add the "<mark style="background-color:#FBEF2A;">Status: Owners Identified 🤘</mark>" label.
 
-```markdown
-@${issueAuthor}, thanks for submitting this module proposal with a module owner in mind!
+**Trigger criteria:**
 
-**Please don't start the development just yet!**
+- An issue is opened with its body matching the below pattern...
 
-The AVM core team will review this module proposal and respond to you and/or the module owner first. Thank you!
-```
+  ```markdown
+    ### Do you want to be the owner of this module?
+
+    No
+  ```
+
+- ...AND NOT matching the below pattern.
+
+  ```markdown
+  ### Module Owner's GitHub Username (handle)
+
+  _No response_
+  ```
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#FBEF2A;">Status: Owners Identified 🤘</mark>" label.
+- Add the below reply and explain the action(s).
+
+  ```markdown
+  @${issueAuthor}, thanks for submitting this module proposal with a module owner in mind!
+
+  **Please don't start the development just yet!**
+
+  The AVM core team will review this module proposal and respond to you and/or the module owner first. Thank you!
+  ```
+
+---
 
 ### ITA20
 
 If the issue type is feature request, add the "<mark style="background-color:#A2EEEF;">Type: Feature Request ➕</mark>" label on the issue.
 
+**Trigger criteria:**
+
+- An issue is opened with its body matching the below pattern.
+
+  ```markdown
+  ### Issue Type?
+
+  Feature Request
+  ```
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#A2EEEF;">Type: Feature Request ➕</mark>" label.
+- Add a reply to explain the action(s).
+
+---
+
 ### ITA21
 
 If the issue type is bug, add the "<mark style="background-color:#D73A4A;color:white;">Type: Bug 🐛</mark>" label on the issue.
+
+**Trigger criteria:**
+
+- An issue is opened with its body matching the below pattern.
+
+  ```markdown
+  ### Issue Type?
+
+  Bug
+  ```
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#D73A4A;color:white;">Type: Bug 🐛</mark>" label.
+- Add a reply to explain the action(s).
+
+---
 
 ### ITA22
 
 If the issue type is security bug, add the "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>" label on the issue.
 
+**Trigger criteria:**
+
+- An issue is opened with its body matching the below pattern.
+
+  ```markdown
+  ### Issue Type?
+
+  Security Bug
+  ```
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>" label.
+- Add a reply to explain the action(s).
+
+---
+
 ### ITA23
 
 Remove the "<mark style="background-color:#EDEDED;">Status: In PR 👉</mark>" label from an issue when it's closed.
 
-<br>
+**Trigger criteria:**
+
+- An issue is opened.
+
+**Action(s):**
+
+- Remove the "<mark style="background-color:#EDEDED;">Status: In PR 👉</mark>" label.
+- Add a reply to explain the action(s).
+
+---
 
 ## Where to apply these rules?
 

--- a/docs/content/help-support/issue-triage/issue-triage-automation.md
+++ b/docs/content/help-support/issue-triage/issue-triage-automation.md
@@ -246,7 +246,7 @@ Remind module owner(s) to start or continue working on this module if there was 
 - Add the "<mark style="background-color:#E99695;color:white;">Needs: Attention 👋</mark>" label.
 
 {{< hint type=tip >}}
-- To avoid/silence this notification, provide an update every 3 weeks on the Module Proposal issue, or add the "<mark style="background-color:#B60205;color:white;">Status: Long Term ⏳</mark>" label.
+- To silence this notification, provide an update every 3 weeks on the Module Proposal issue, or add the "<mark style="background-color:#B60205;color:white;">Status: Long Term ⏳</mark>" label.
 {{< /hint >}}
 
 ---

--- a/docs/content/help-support/issue-triage/issue-triage-automation.md
+++ b/docs/content/help-support/issue-triage/issue-triage-automation.md
@@ -155,6 +155,8 @@ Remove the "<mark style="background-color:#EDEDED;">Status: In PR 👉</mark>" l
 
 The below table details which repositories the above rules are applied to.
 
+### Rules applied for Schedule based automation
+
 | ID                          | AVM Core repository | BRM repository | TF repositories |
 |-----------------------------|:-------------------:|:--------------:|:---------------:|
 | [ITA01BCP1-2](#ita01bcp1-2) |                     |       ✔️       |                 |
@@ -165,6 +167,12 @@ The below table details which repositories the above rules are applied to.
 | [ITA03TF](#ita03tf)         |                     |                |       ✔️        |
 | [ITA04](#ita04)             |         ✔️          |       ✔️       |       ✔️        |
 | [ITA05](#ita05)             |         ✔️          |       ✔️       |       ✔️        |
+| [ITA24](#ita24)             |          ✔️         |                |                 |
+
+### Rules applied for Event based automation
+
+| ID                          | AVM Core repository | BRM repository | TF repositories |
+|-----------------------------|:-------------------:|:--------------:|:---------------:|
 | [ITA06](#ita06)             |         ✔️          |       ✔️       |       ✔️        |
 | [ITA08BCP](#ita08bcp)       |                     |       ✔️       |                 |
 | [ITA09](#ita09)             |         ✔️          |       ✔️       |       ✔️        |
@@ -182,4 +190,3 @@ The below table details which repositories the above rules are applied to.
 | [ITA21](#ita21)             |                     |       ✔️       |        ✔️       |
 | [ITA22](#ita22)             |                     |       ✔️       |        ✔️       |
 | [ITA23](#ita23)             |          ✔️         |                |        ✔️       |
-| [ITA24](#ita24)             |          ✔️         |                |                 |

--- a/docs/content/help-support/issue-triage/issue-triage-automation.md
+++ b/docs/content/help-support/issue-triage/issue-triage-automation.md
@@ -20,39 +20,215 @@ When calculating the number of business days in the issue/triage automation, the
 
 ### ITA01BCP.1-2
 
-If a bug/feature/request/general question that has the labels of "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" and "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" is not responded to after 3 business days, then the issue will be marked with the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label and the AVM Core team will be tagged in a comment on the issue to reach out to the module owner. The AVM core team will also be assigned on the issue.
+If a bug/feature/request/general question that has the labels of "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" and "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" is not responded to after 3 business days, then the issue will be marked with the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label and the AVM Core team will be mentioned in a comment on the issue to reach out to the module owner.
+
+**Schedule:**
+
+- Triggered every Monday-Friday, at 12:00.
+
+**Trigger criteria:**
+
+- Is an open issue.
+- Had no activity in the last 3 business days.
+- Has the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" and "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" labels added.
+
+**Action(s):**
+
+- Add a reply, mentioning the `Azure/avm-core-team-technical-bicep` team.
+- Add the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label.
+
+**Tip:**
+
+- To prevent further actions to take effect, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed.
+- To avoid this rule being triggered at all, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label must be removed once the issue has been triaged (and the issue is first responded).
 
 ### ITA01TF.1-2
 
-If a bug/feature/request/general question that has the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label assigned is not responded to after 3 business days, then the issue will be marked with the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label and the AVM Core team will be tagged in a comment on the issue to reach out to the module owner. The AVM core team will also be assigned on the issue.
+If a bug/feature/request/general question that has the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label added is not responded to after 3 business days, then the issue will be marked with the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label and the AVM Core team will be mentioned in a comment on the issue to reach out to the module owner.
+
+**Schedule:**
+
+- Triggered every Monday-Friday, at 12:00.
+
+**Trigger criteria:**
+
+- Is an open issue.
+- Had no activity in the last 3 business days.
+- Has the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label added.
+
+**Action(s):**
+
+- Add a reply, mentioning the `Azure/avm-core-team-technical-bicep` team.
+- Add the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label.
+
+**Tip:**
+
+- To prevent further actions to take effect, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed.
+- To avoid this rule being triggered at all, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label must be removed once the issue has been triaged (and the issue is first responded).
 
 ### ITA02BCP.1-2
 
-If after an additional 3 business days there's still no update to the issue that has the labels of "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>", the AVM core team will be assigned to the issue and a further comment stating module owner is unresponsive. The "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label will also be assigned.
+If after an additional 3 business days there's still no update to the issue that has the labels of "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>", the AVM core team will be mentioned on the issue and a further comment stating module owner is unresponsive will be added. The "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label will also be added.
+
+**Schedule:**
+
+- Triggered every Monday-Friday, at 12:00.
+
+**Trigger criteria:**
+
+- Is an open issue.
+- Had no activity in the last 3 business days.
+- Has the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" and "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" labels added.
+
+**Action(s):**
+
+- Add a reply, mentioning the `Azure/avm-core-team-technical-bicep` team.
+- Add the "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label.
+
+**Tip:**
+
+- To avoid this rule being triggered at all, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed.
 
 ### ITA02TF.1-2
 
-If after an additional 3 business days there's still no update to the issue that has the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label assigned, the AVM core team will be assigned to the issue and a further comment stating module owner is unresponsive. The "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label will also be assigned.
+If after an additional 3 business days there's still no update to the issue that has the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label added, the AVM core team will be mentioned on the issue and a further comment stating module owner is unresponsive will be added. The "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label will also be added.
+
+**Schedule:**
+
+- Triggered every Monday-Friday, at 12:00.
+
+**Trigger criteria:**
+
+- Is an open issue.
+- Had no activity in the last 3 business days.
+- Has the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label added.
+
+**Action(s):**
+
+- Add a reply, mentioning the `Azure/avm-core-team-technical-bicep` team.
+- Add the "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label.
+
+**Tip:**
+
+- To avoid this rule being triggered at all, the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" label must be removed.
 
 ### ITA03BCP
 
-If there's still no response after 5 days (total from start of issue being raised) on an issue that has the labels of "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>", "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>", "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>" and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>", the Bicep PG GitHub Team will be tagged and assigned to the issue to assist. The "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label will also be assigned.
+If there's still no response after 5 days (total from start of issue being raised) on an issue that has the labels of "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>", "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>", "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>" and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>", the Bicep PG GitHub Team will be mentioned on the issue to assist. The "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label will also be added.
+
+**Schedule:**
+
+- Triggered every Monday-Friday, at 12:00.
+
+**Trigger criteria:**
+
+- Is an open issue.
+- Had no activity in the last 5 business days.
+- Has the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>", the "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>", the "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>",  and "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" labels added.
+
+**Action(s):**
+
+- Add a reply, mentioning the `Azure/bicep-admins` team.
+- Add the "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label.
+
+**Tip:**
+
+- To avoid this rule being triggered at all, the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label must be removed once the issue has been triaged (and the issue is first responded).
 
 ### ITA03TF
 
-If there's still no response after 5 days (total from start of issue being raised) on an issue that has the labels of "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>", "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>" and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>", the Terraform PG GitHub Team will be tagged and assigned to the issue to assist. The "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label will also be assigned.
+If there's still no response after 5 days (total from start of issue being raised) on an issue that has the labels of "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>", "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>" and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>", the Terraform PG GitHub Team will be mentioned on the issue to assist. The "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label will also be added.
+
+**Schedule:**
+
+- Triggered every Monday-Friday, at 12:00.
+
+**Trigger criteria:**
+
+- Is an open issue.
+- Had no activity in the last 5 business days.
+- Has the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>", the "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>", and "<mark style="background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>" labels added.
+
+**Action(s):**
+
+- Add a reply, mentioning the `Azure/terraform-avm` team.
+- Add the "<mark style="background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>" label.
 
 ### ITA04
 
 If an issue/PR has been labelled with "<mark style="background-color:#CB6BA2;color:white;">Needs: Author Feedback 👂</mark>" and hasn't had a response in 4 days, label with "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" and add a comment.
 
+**Schedule:**
+
+- Triggered every 3 hours.
+
+**Trigger criteria:**
+
+- Is an open issue.
+- Had no activity in the last 4 days.
+- Has the "<mark style="background-color:#CB6BA2;color:white;">Needs: Author Feedback 👂</mark>" label added.
+- Does not have the "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" label added.
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" label.
+- Add a reply.
+
+**Tip:**
+
+To prevent further actions to take effect, one of the following conditions must be met:
+
+- The author must respond in a comment within 3 days of the automatic comment left on the issue.
+- The "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" label must be removed.
+- If applicable, the "<mark style="background-color:#B60205;color:white;">Status: Long Term ⏳</mark>" or the "<mark style="background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark>" label must be added.
+
 ### ITA05
 
-If an issue/PR has been labelled with "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" and hasn't had any update in 3 days from that point, automatically close it and comment, unless the issue/PR has a "<mark style="background-color:#B60205;color:white;">Status: long-term ⏳</mark>" - in which case, do not close it.
+If an issue/PR has been labelled with "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" and hasn't had any update in 3 days from that point, automatically close it and comment, unless the issue/PR has a "<mark style="background-color:#B60205;color:white;">Status: Long Term ⏳</mark>" - in which case, do not close it.
+
+**Schedule:**
+
+- Triggered every 3 hours.
+
+**Trigger criteria:**
+
+- Is an open issue.
+- Had no activity in the last 3 days.
+- Has the "<mark style="background-color:#CB6BA2;color:white;">Needs: Author Feedback 👂</mark>" and the "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" labels added.
+- Does not have the "<mark style="background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark>" or "<mark style="background-color:#B60205;color:white;">Status: Long Term ⏳</mark>" labels added.
+
+**Action(s):**
+
+- Add a reply.
+- Close the issue.
+
+**Tip:**
+
+- In case the issue needs to be reopened (e.g., the author responds after the issue was closed), the "<mark style="background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>" label must be removed.
 
 ### ITA24
 
-Remind module owner(s) to start or continue working on this module if there was no activity on the Module Proposal issue for more than 3 weeks. Add "<mark style="background-color:#E99695;">Needs: Attention 👋</mark>" label.
+Remind module owner(s) to start or continue working on this module if there was no activity on the Module Proposal issue for more than 3 weeks. Add "<mark style="background-color:#E99695;color:white;">Needs: Attention 👋</mark>" label.
+
+**Schedule:**
+
+- Triggered every 3 hours.
+
+**Trigger criteria:**
+
+- Is an open issue.
+- Had no activity in the last 21 days.
+- Has the "<mark style="background-color:#ADD8E6;">Type: New Module Proposal 💡</mark>" and the "<mark style="background-color:#FBEF2A;">Status: Owners Identified 🤘</mark>" labels added.
+- Does not have the "<mark style="background-color:#B60205;color:white;">Status: Long Term ⏳</mark>" label added.
+
+**Action(s):**
+
+- Add a reply.
+- Add the "<mark style="background-color:#E99695;color:white;">Needs: Attention 👋</mark>" label.
+
+**Tip:**
+
+- To avoid/silence this notification, provide an update every 3 weeks on the Module Proposal issue, or add the "<mark style="background-color:#B60205;color:white;">Status: Long Term ⏳</mark>" label.
 
 <br>
 
@@ -64,37 +240,87 @@ This chapter details all automation rules that are based on an event.
 
 When a new issue or PR of any type is created add the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label.
 
+**Trigger criteria:**
+
+- An issue or PR is opened.
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label.
+
 ### ITA08BCP
 
 If AVM or "Azure Verified Modules" is mentioned in an uncategorized issue (i.e., one not using any template), apply the label of "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" on the issue.
+
+**Trigger criteria:**
+
+- An issue, issue comment, PR, or PR comment is opened, created or edited and the body or comment contains the strings of "AVM" or "Azure Verified Modules".
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" label.
 
 ### ITA09
 
 When #RR is used in an issue, add the label of "<mark style="background-color:#CB6BA2;color:white;">Needs: Author Feedback 👂</mark>".
 
+**Trigger criteria:**
+
+- An issue comment or PR comment contains the string of "#RR".
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#CB6BA2;color:white;">Needs: Author Feedback 👂</mark>" label.
+
 ### ITA10
 
-When #wontfix is used in an issue, mark it by using the label of "<mark style="background-color:#FFFFFF;">Status: Won't Fix 💔</mark>" and close it as not planned.
+When #wontfix is used in an issue, mark it by using the label of "<mark style="background-color:#FFFFFF;">Status: Won't Fix 💔</mark>" and close the issue.
+
+**Trigger criteria:**
+
+- An issue comment or PR comment contains the string of "#RR".
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#FFFFFF;">Status: Won't Fix 💔</mark>" label.
+- Close the issue.
 
 ### ITA11
 
 When a reply from anyone to an issue occurs, remove the "<mark style="background-color:#CB6BA2;color:white;">Needs: Author Feedback 👂</mark>" label and label with "<mark style="background-color:#E99695;color:white;">Needs: Attention 👋</mark>".
 
+**Trigger criteria:**
+
+- Any action on an issue comment or PR comment except closing.
+- Has the "<mark style="background-color:#CB6BA2;color:white;">Needs: Author Feedback 👂</mark>" label added.
+
+**Action(s):**
+
+- Add the "<mark style="background-color:#E99695;color:white;">Needs: Attention 👋</mark>" label.
+
 ### ITA12
 
 Clean up e-mail replies to GitHub Issues for readability.
 
+**Trigger criteria:**
+
+- Any action on an issue comment.
+
+**Action(s):**
+
+- Clean email reply. This is useful when someone directly responds to an email notification from GitHub, and the email signature is included in the comment.
+
 ### ITA13
 
-If the language is set to Bicep in the Module proposal, assign the "<mark style="background-color:#1D73B3;color:white;">Language: Bicep 💪</mark>" label on the issue.
+If the language is set to Bicep in the Module proposal, add the "<mark style="background-color:#1D73B3;color:white;">Language: Bicep 💪</mark>" label on the issue.
 
 ### ITA14
 
-If the language is set to Terraform in the Module proposal, assign the "<mark style="background-color:#7740B6;color:white;">Language: Terraform 🌐</mark>" label on the issue.
+If the language is set to Terraform in the Module proposal, add the "<mark style="background-color:#7740B6;color:white;">Language: Terraform 🌐</mark>" label on the issue.
 
 ### ITA15
 
-Remove the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label from a PR, if it already has a "<mark>Type: *XYZ*</mark>" label assigned at the time of creating it.
+Remove the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label from a PR, if it already has a "<mark>Type: *XYZ*</mark>" label added at the time of creating it.
 
 ### ITA16
 
@@ -114,7 +340,7 @@ The AVM core team will review this module proposal and respond to you first. Tha
 
 ### ITA18
 
-Send automatic response to the issue author if they don't want to be module owner and don't have any candidate in mind. Assign the "<mark style="background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark>" label.
+Send automatic response to the issue author if they don't want to be module owner and don't have any candidate in mind. Add the "<mark style="background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark>" label.
 
 ```markdown
 @${issueAuthor}, thanks for submitting this module proposal!
@@ -123,7 +349,7 @@ The AVM core team will review it and will try to find a module owner.
 
 ### ITA19
 
-Send automatic response to the issue author if they don't want to be module owner but have a candidate in mind. Assign the "<mark style="background-color:#FBEF2A;">Status: Owners Identified 🤘</mark>" label.
+Send automatic response to the issue author if they don't want to be module owner but have a candidate in mind. Add the "<mark style="background-color:#FBEF2A;">Status: Owners Identified 🤘</mark>" label.
 
 ```markdown
 @${issueAuthor}, thanks for submitting this module proposal with a module owner in mind!
@@ -135,15 +361,15 @@ The AVM core team will review this module proposal and respond to you and/or the
 
 ### ITA20
 
-If the issue type is feature request, assign the "<mark style="background-color:#A2EEEF;">Type: Feature Request ➕</mark>" label on the issue.
+If the issue type is feature request, add the "<mark style="background-color:#A2EEEF;">Type: Feature Request ➕</mark>" label on the issue.
 
 ### ITA21
 
-If the issue type is bug, assign the "<mark style="background-color:#D73A4A;color:white;">Type: Bug 🐛</mark>" label on the issue.
+If the issue type is bug, add the "<mark style="background-color:#D73A4A;color:white;">Type: Bug 🐛</mark>" label on the issue.
 
 ### ITA22
 
-If the issue type is security bug, assign the "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>" label on the issue.
+If the issue type is security bug, add the "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>" label on the issue.
 
 ### ITA23
 


### PR DESCRIPTION
# Overview/Summary

This PR includes improvements to the issue triage automation and its documentation.

This PR must be merged, before this other one: https://github.com/Azure/bicep-registry-modules/pull/1372

## This PR fixes/adds/changes/removes

1. Improve documentation by adding details to each GH policy service rule, such as triage criteria, actions and tips
2. Improve each GH policy service rule by explaining what the bot is reacting to, and provide in-context tips.

### Example - When opening a new issue 

<img width="502" alt="image" src="https://github.com/Azure/Azure-Verified-Modules/assets/22733424/5fae8af6-1d0f-443a-aed5-263b35a6bf18">

### Example - When a Type label is added

<img width="509" alt="image" src="https://github.com/Azure/Azure-Verified-Modules/assets/22733424/0caf3338-1128-4001-b114-dbc77b1cde8c">

### Example - When a response is overdue

<img width="508" alt="image" src="https://github.com/Azure/Azure-Verified-Modules/assets/22733424/e5e32cc0-9f0c-406e-ac07-ab15f07498c6">

### Example - Documentation update with details

<img width="498" alt="image" src="https://github.com/Azure/Azure-Verified-Modules/assets/22733424/1704c61c-03f3-43b5-b9ca-10ee6fd337c0">

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
