### PR TITLE
issue template improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Module Issue ➕🐛🔒
+    url: https://aka.ms/AVM/Bicep/ModuleIssue
+    about: Want to request a new Module feature or report a bug? Let us know!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
-  - name: Module Issue ➕🐛🔒
+  - name: Bicep Module Issue ➕🐛🔒
     url: https://aka.ms/AVM/Bicep/ModuleIssue
-    about: Want to request a new Module feature or report a bug? Let us know!
+    about: Want to request a new Bicep Module feature or report a bug? Let us know!
+  - name: Terraform Module Issue ➕🐛🔒
+    url: https://aka.ms/AVM/index/tf
+    about: Want to request a new Terraform Module feature or report a bug? Find your module's repository in the index and file a Module Issue there!


### PR DESCRIPTION
# Overview/Summary

This PR implements improvements to the AVM issue templates.

## This PR fixes/adds/changes/removes

- adds links pointing to the module issue template in the BRM repo and the TF module registry to open module issues

![image](https://github.com/Azure/Azure-Verified-Modules/assets/22733424/db5d37c0-d3bb-41c6-a070-659b8dae7899)


### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
