### PR TITLE
Add module versions to indexes

### DIFF
--- a/.github/workflows/hugo-site-build.yml
+++ b/.github/workflows/hugo-site-build.yml
@@ -2,7 +2,7 @@
 name: Deploy Hugo site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting the default branch and everyday at 1 am to update dynamic info
   push:
     branches:
       - main

--- a/.github/workflows/hugo-site-build.yml
+++ b/.github/workflows/hugo-site-build.yml
@@ -8,6 +8,8 @@ on:
       - main
     paths:
       - 'docs/**'
+  schedule:
+    - cron: "0 1 * * *" # Daily Update at 1 am
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch: {}

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -2,6 +2,8 @@ baseURL = "https://azure.github.io/Azure-Verified-Modules"
 title = "Azure Verified Modules"
 theme = "hugo-geekdoc"
 
+ignoreLogs = ['error-remote-getjson']
+
 # Required to get well formatted code blocks
 pygmentsUseClasses = true
 pygmentsCodeFences = true

--- a/docs/layouts/shortcodes/expand.html
+++ b/docs/layouts/shortcodes/expand.html
@@ -10,6 +10,6 @@
   <input id="{{ $id }}-{{ .Ordinal }}" type="checkbox" class="gdoc-expand__control hidden" />
   {{ end }}
   <div class="gdoc-markdown--nested gdoc-expand__content">
-    {{ .Inner | $.Page.RenderString | htmlUnescape | safeHTML }}
+    {{ .Inner | $.Page.RenderString }}
   </div>
 </div>

--- a/docs/layouts/shortcodes/moduleHistory.html
+++ b/docs/layouts/shortcodes/moduleHistory.html
@@ -183,7 +183,7 @@
       <th>Module Name</th>
       <th>Source Code</th>
       <th>Module Display Name</th>
-      <th>Module Status</th>
+      <th>Module Status & Versions</th>
       <th>Primary Module Owner<br>GitHub Handle<br>(& Display Name)</th>
     </tr>
   </thead>

--- a/docs/layouts/shortcodes/moduleHistory.html
+++ b/docs/layouts/shortcodes/moduleHistory.html
@@ -137,18 +137,28 @@
       <th>No.</th>
       <th>Module Name</th>
       <th>Module Display Name</th>
-      <th>Module Status</th>
+      <th>Module Status & Versions</th>
       <th>Primary Module Owner<br>GitHub Handle<br>(& Display Name)</th>
     </tr>
   </thead>
   {{ end }}
   {{ range $item, $modules }}
   {{ if and (eq $item.FirstPublishedInColumnId $publicationDate) (not ( in $exclude $item.ModuleStatus )) }}
+    {{ $moduleMcrUrl := printf "https://mcr.microsoft.com/v2/bicep/%s/tags/list" $item.ModuleName }}
+    {{ $moduleMcrData := getJSON $moduleMcrUrl }}
+    {{ $moduleVersions := $moduleMcrData.tags }}
+    {{ $moduleLatestVersion := "" }}
+    {{ if $moduleVersions }}
+        {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
+    {{ else }}
+        {{ $moduleLatestVersion = "NA"}}
+    {{ end }}
+    {{ $trimmedModuleStatus := replace $item.ModuleStatus "Module " "" }}
   <tr>
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>
     <td>{{ $item.ModuleDisplayName }}</td>
-    <td>{{ emojify $item.ModuleStatus }}</td>
+    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="https://mcr.microsoft.com/v2/bicep/{{ $item.ModuleName }}/tags/list"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-blue"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-NA-blue"/></a> {{ end }}</td>
     <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
   </tr>
   {{ end }}
@@ -180,12 +190,27 @@
   {{ end }}
   {{ range $item, $modules }}
   {{ if and (eq $item.FirstPublishedInColumnId $publicationDate) (not ( in $exclude $item.ModuleStatus )) }}
+    {{ $moduleTfRegApiUrl := printf "https://registry.terraform.io/v1/modules/Azure/%s/azurerm/versions" $item.ModuleName }}
+    {{ $moduleTfRegApiData := getJSON $moduleTfRegApiUrl }}
+    {{ $moduleVersions := slice }}
+    {{ range $moduleTfRegApiData.modules }}
+      {{ range .versions }}
+        {{ $moduleVersions = $moduleVersions | append .version }}
+      {{ end }}
+    {{ end }}
+    {{ $moduleLatestVersion := "" }}
+    {{ if $moduleVersions }}
+        {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
+    {{ else }}
+        {{ $moduleLatestVersion = "NA"}}
+    {{ end }}
+    {{ $trimmedModuleStatus := replace $item.ModuleStatus "Module " "" }}
   <tr>
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.PublicRegistryReference }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">📄</a> {{ else }} {{ "n/a" }} {{ end }} {{else}} {{ "n/a" }} {{ end }} </td>
     <td>{{ $item.ModuleDisplayName }}</td>
-    <td>{{ emojify $item.ModuleStatus }}</td>
+    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="{{ $item.PublicRegistryReference }}"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-purple"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-NA-purple"/></a> {{ end }}</td>
     <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
 
   </tr>

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -117,7 +117,7 @@
       <th>No.</th>
       <th>Module Name</th>
       <th>Module Display Name</th>
-      <th>Module Status</th>
+      <th>Module Status & Versions</th>
       <th>Primary Module Owner<br>GitHub Handle<br>(& Display Name)</th>
     </tr>
   </thead>
@@ -128,7 +128,7 @@
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>
     <td>{{ $item.ModuleDisplayName }}</td>
-    <td>{{ emojify $item.ModuleStatus }}</td>
+    <td><a href="https://mcr.microsoft.com/v2/bicep/{{ $item.ModuleName }}/tags/list"><image src="https://img.shields.io/badge/{{ emojify $item.ModuleStatus }}-Click_on_me-blue"/></a></td>
     <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
   </tr>
   {{ $hasModulesAvailable = true }}

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -127,7 +127,12 @@
     {{ $moduleMcrUrl := printf "https://mcr.microsoft.com/v2/bicep/%s/tags/list" $item.ModuleName }}
     {{ $moduleMcrData := getJSON $moduleMcrUrl }}
     {{ $moduleVersions := $moduleMcrData.tags }}
-    {{ $moduleLatestVersion := index $moduleVersions 0 }}
+    {{ $moduleLatestVersion := "" }}
+    {{ if $moduleVersions }}
+        {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
+    {{ else }}
+        {{ $moduleLatestVersion = "NA"}}
+    {{ end }}
   <tr>
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -170,12 +170,13 @@
   {{ end }}
   {{ range $item, $maps }}
   {{ if not ( in $exclude $item.ModuleStatus ) }}
+    {{ $trimmedModuleStatus := replace $item.ModuleStatus "Module " "" }}
   <tr>
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.PublicRegistryReference }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">📄</a> {{ else }} {{ "n/a" }} {{ end }} {{else}} {{ "n/a" }} {{ end }} </td>
     <td>{{ $item.ModuleDisplayName }}</td>
-    <td>{{ emojify $item.ModuleStatus }}</td>
+    <td>{{ emojify $trimmedModuleStatus }}</td>
     <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
   </tr>
   {{ $hasModulesAvailable = true }}

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -133,11 +133,12 @@
     {{ else }}
         {{ $moduleLatestVersion = "NA"}}
     {{ end }}
+    {{ $trimmedModuleStatus := replace $item.ModuleStatus "Module " "" }}
   <tr>
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>
     <td>{{ $item.ModuleDisplayName }}</td>
-    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="https://mcr.microsoft.com/v2/bicep/{{ $item.ModuleName }}/tags/list"><image src="https://img.shields.io/badge/{{ emojify $item.ModuleStatus }}-{{ $moduleLatestVersion }}-blue"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $item.ModuleStatus }}-NA-blue"/></a> {{ end }}</td>
+    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="https://mcr.microsoft.com/v2/bicep/{{ $item.ModuleName }}/tags/list"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-blue"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-NA-blue"/></a> {{ end }}</td>
     <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
   </tr>
   {{ $hasModulesAvailable = true }}

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -163,20 +163,34 @@
       <th>Module Name</th>
       <th>Source Code</th>
       <th>Module Display Name</th>
-      <th>Module Status</th>
+      <th>Module Status & Versions</th>
       <th>Primary Module Owner<br>GitHub Handle<br>(& Display Name)</th>
     </tr>
   </thead>
   {{ end }}
   {{ range $item, $maps }}
   {{ if not ( in $exclude $item.ModuleStatus ) }}
+    {{ $moduleTfRegApiUrl := printf "https://registry.terraform.io/v1/modules/Azure/%s/azurerm/versions" $item.ModuleName }}
+    {{ $moduleTfRegApiData := getJSON $moduleTfRegApiUrl }}
+    {{ $moduleVersions := slice }}
+    {{ range $moduleTfRegApiData.modules }}
+      {{ range .versions }}
+        {{ $moduleVersions = $moduleVersions | append .version }}
+      {{ end }}
+    {{ end }}
+    {{ $moduleLatestVersion := "" }}
+    {{ if $moduleVersions }}
+        {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
+    {{ else }}
+        {{ $moduleLatestVersion = "NA"}}
+    {{ end }}
     {{ $trimmedModuleStatus := replace $item.ModuleStatus "Module " "" }}
   <tr>
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.PublicRegistryReference }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">📄</a> {{ else }} {{ "n/a" }} {{ end }} {{else}} {{ "n/a" }} {{ end }} </td>
     <td>{{ $item.ModuleDisplayName }}</td>
-    <td>{{ emojify $trimmedModuleStatus }}</td>
+    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="{{ $item.PublicRegistryReference }}"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-purple"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-NA-purple"/></a> {{ end }}</td>
     <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
   </tr>
   {{ $hasModulesAvailable = true }}

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -124,11 +124,15 @@
   {{ end }}
   {{ range $item, $maps }}
   {{ if not ( in $exclude $item.ModuleStatus ) }}
+    {{ $moduleMcrUrl := printf "https://mcr.microsoft.com/v2/bicep/%s/tags/list" $item.ModuleName }}
+    {{ $moduleMcrData := getJSON $moduleMcrUrl }}
+    {{ $moduleVersions := $moduleMcrData.tags }}
+    {{ $moduleLatestVersion := index $moduleVersions 0 }}
   <tr>
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>
     <td>{{ $item.ModuleDisplayName }}</td>
-    <td><a href="https://mcr.microsoft.com/v2/bicep/{{ $item.ModuleName }}/tags/list"><image src="https://img.shields.io/badge/{{ emojify $item.ModuleStatus }}-Click_on_me-blue"/></a></td>
+    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="https://mcr.microsoft.com/v2/bicep/{{ $item.ModuleName }}/tags/list"><image src="https://img.shields.io/badge/{{ emojify $item.ModuleStatus }}-{{ $moduleLatestVersion }}-blue"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $item.ModuleStatus }}-NA-blue"/></a> {{ end }}</td>
     <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
   </tr>
   {{ $hasModulesAvailable = true }}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This pull request includes changes to the Hugo site's GitHub workflow, configuration, and layout files to improve the display of module status and versions, and to schedule daily updates of dynamic information. The changes also include a modification to ignore certain logs and a change in how content is rendered in the `expand.html` layout.

GitHub Workflow:

* [`.github/workflows/hugo-site-build.yml`](diffhunk://#diff-c0ab2b56e48ec58f085acfc9dc249bc5af0e48aea2c2348e9d5c916b5ee66403L5-R12): The workflow now runs on pushes to the main branch and every day at 1 am to update dynamic information.

Configuration:

* [`docs/config.toml`](diffhunk://#diff-5fbd9920d4a0ae5420b9709cdc967f57514008cae257ca8735d7b8c02e1c77f2R5-R6): The configuration now includes `ignoreLogs = ['error-remote-getjson']` to ignore certain logs.

Layouts:

* [`docs/layouts/shortcodes/expand.html`](diffhunk://#diff-29377e6a6b4b98cd76831ecd8e372d8ebb058c249867c09365b0258223c8fb61L13-R13): The content rendering method has been changed. _**this is to bring the file in line with the latest 0.45.0 geekdocs release**_

Module Status and Versions:

* [`docs/layouts/shortcodes/moduleHistory.html`](diffhunk://#diff-7e7536021e70c5a64d6eb0e540228fb5891f13486d0c252cae244c9ee90926ddL140-R161): The "Module Status" column has been changed to "Module Status & Versions" and now includes a badge that displays the status and latest version of the module. The badge links to the list of tags for the module. [[1]](diffhunk://#diff-7e7536021e70c5a64d6eb0e540228fb5891f13486d0c252cae244c9ee90926ddL140-R161) [[2]](diffhunk://#diff-7e7536021e70c5a64d6eb0e540228fb5891f13486d0c252cae244c9ee90926ddR193-R213)
* [`docs/layouts/shortcodes/moduleNameStatusOwners.html`](diffhunk://#diff-5c3b49e6ecc5714badd3bc3c6e949da68d03c3846118a62fa5f3a71767e19200L120-R141): Similar to the changes in `moduleHistory.html`, the "Module Status" column has been changed to "Module Status & Versions" and now includes a badge that displays the status and latest version of the module. The badge links to the list of tags for the module. [[1]](diffhunk://#diff-5c3b49e6ecc5714badd3bc3c6e949da68d03c3846118a62fa5f3a71767e19200L120-R141) [[2]](diffhunk://#diff-5c3b49e6ecc5714badd3bc3c6e949da68d03c3846118a62fa5f3a71767e19200L156-R193)

![image](https://github.com/Azure/Azure-Verified-Modules/assets/41163455/ddf63863-f331-447b-9e50-695e6a6c5f0f)
![image](https://github.com/Azure/Azure-Verified-Modules/assets/41163455/55a1a24f-1ce3-4407-92ef-b6fb4242c505)


## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
