### PR TITLE
fixing errors in new module index version feature

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -2,8 +2,6 @@ baseURL = "https://azure.github.io/Azure-Verified-Modules"
 title = "Azure Verified Modules"
 theme = "hugo-geekdoc"
 
-ignoreLogs = ['error-remote-getjson']
-
 # Required to get well formatted code blocks
 pygmentsUseClasses = true
 pygmentsCodeFences = true

--- a/docs/layouts/shortcodes/moduleHistory.html
+++ b/docs/layouts/shortcodes/moduleHistory.html
@@ -29,6 +29,7 @@
 {{ $modules := slice }}
 {{ $publicationDates := slice }}
 {{ $i := 1 }}
+{{ $moduleLatestVersion := "N/A" }}
 
 {{ if eq $moduleType "resource" }}
   {{ $ProviderNamespaceColumnId = 0 }}
@@ -144,21 +145,21 @@
   {{ end }}
   {{ range $item, $modules }}
   {{ if and (eq $item.FirstPublishedInColumnId $publicationDate) (not ( in $exclude $item.ModuleStatus )) }}
-    {{ $moduleMcrUrl := printf "https://mcr.microsoft.com/v2/bicep/%s/tags/list" $item.ModuleName }}
-    {{ $moduleMcrData := getJSON $moduleMcrUrl }}
-    {{ $moduleVersions := $moduleMcrData.tags }}
-    {{ $moduleLatestVersion := "" }}
-    {{ if $moduleVersions }}
-        {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
-    {{ else }}
-        {{ $moduleLatestVersion = "NA"}}
+    {{ $moduleLatestVersion = "N/A" }}
+    {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}
+      {{ $moduleMcrUrl := printf "https://mcr.microsoft.com/v2/bicep/%s/tags/list" $item.ModuleName }}
+      {{ $moduleMcrData := getJSON $moduleMcrUrl }}
+      {{ $moduleVersions := $moduleMcrData.tags }}
+      {{ if $moduleVersions }}
+          {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
+      {{ end }}
     {{ end }}
     {{ $trimmedModuleStatus := replace $item.ModuleStatus "Module " "" }}
   <tr>
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>
     <td>{{ $item.ModuleDisplayName }}</td>
-    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="https://mcr.microsoft.com/v2/bicep/{{ $item.ModuleName }}/tags/list"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-blue"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-NA-blue"/></a> {{ end }}</td>
+    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="https://mcr.microsoft.com/v2/bicep/{{ $item.ModuleName }}/tags/list"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-blue"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-N/A-blue"/></a> {{ end }}</td>
     <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
   </tr>
   {{ end }}
@@ -190,19 +191,19 @@
   {{ end }}
   {{ range $item, $modules }}
   {{ if and (eq $item.FirstPublishedInColumnId $publicationDate) (not ( in $exclude $item.ModuleStatus )) }}
-    {{ $moduleTfRegApiUrl := printf "https://registry.terraform.io/v1/modules/Azure/%s/azurerm/versions" $item.ModuleName }}
-    {{ $moduleTfRegApiData := getJSON $moduleTfRegApiUrl }}
-    {{ $moduleVersions := slice }}
-    {{ range $moduleTfRegApiData.modules }}
-      {{ range .versions }}
-        {{ $moduleVersions = $moduleVersions | append .version }}
+    {{ $moduleLatestVersion = "N/A" }}
+    {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}
+      {{ $moduleTfRegApiUrl := printf "https://registry.terraform.io/v1/modules/Azure/%s/azurerm/versions" $item.ModuleName }}
+      {{ $moduleTfRegApiData := getJSON $moduleTfRegApiUrl }}
+      {{ $moduleVersions := slice }}
+      {{ range $moduleTfRegApiData.modules }}
+        {{ range .versions }}
+          {{ $moduleVersions = $moduleVersions | append .version }}
+        {{ end }}
       {{ end }}
-    {{ end }}
-    {{ $moduleLatestVersion := "" }}
-    {{ if $moduleVersions }}
-        {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
-    {{ else }}
-        {{ $moduleLatestVersion = "NA"}}
+      {{ if $moduleVersions }}
+          {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
+      {{ end }}
     {{ end }}
     {{ $trimmedModuleStatus := replace $item.ModuleStatus "Module " "" }}
   <tr>
@@ -210,7 +211,7 @@
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.PublicRegistryReference }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">📄</a> {{ else }} {{ "n/a" }} {{ end }} {{else}} {{ "n/a" }} {{ end }} </td>
     <td>{{ $item.ModuleDisplayName }}</td>
-    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="{{ $item.PublicRegistryReference }}"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-purple"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-NA-purple"/></a> {{ end }}</td>
+    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="{{ $item.PublicRegistryReference }}"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-purple"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-N/A-purple"/></a> {{ end }}</td>
     <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
 
   </tr>

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -26,6 +26,7 @@
 {{ $hasModulesAvailable := false }}
 {{ $maps := slice }}
 {{ $i := 0 }}
+{{ $moduleLatestVersion := "" }}
 
 {{ if eq $moduleType "resource" }}
   {{ $ProviderNamespaceColumnId = 0 }}
@@ -124,21 +125,21 @@
   {{ end }}
   {{ range $item, $maps }}
   {{ if not ( in $exclude $item.ModuleStatus ) }}
-    {{ $moduleMcrUrl := printf "https://mcr.microsoft.com/v2/bicep/%s/tags/list" $item.ModuleName }}
-    {{ $moduleMcrData := getJSON $moduleMcrUrl }}
-    {{ $moduleVersions := $moduleMcrData.tags }}
-    {{ $moduleLatestVersion := "" }}
-    {{ if $moduleVersions }}
-        {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
-    {{ else }}
-        {{ $moduleLatestVersion = "NA"}}
+    {{ $moduleLatestVersion = "N/A" }}
+    {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}
+      {{ $moduleMcrUrl := printf "https://mcr.microsoft.com/v2/bicep/%s/tags/list" $item.ModuleName }}
+      {{ $moduleMcrData := getJSON $moduleMcrUrl }}
+      {{ $moduleVersions := $moduleMcrData.tags }}
+      {{ if $moduleVersions }}
+          {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
+      {{ end }}
     {{ end }}
     {{ $trimmedModuleStatus := replace $item.ModuleStatus "Module " "" }}
   <tr>
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>
     <td>{{ $item.ModuleDisplayName }}</td>
-    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="https://mcr.microsoft.com/v2/bicep/{{ $item.ModuleName }}/tags/list"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-blue"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-NA-blue"/></a> {{ end }}</td>
+    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="https://mcr.microsoft.com/v2/bicep/{{ $item.ModuleName }}/tags/list"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-blue"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-N/A-blue"/></a> {{ end }}</td>
     <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
   </tr>
   {{ $hasModulesAvailable = true }}
@@ -170,19 +171,19 @@
   {{ end }}
   {{ range $item, $maps }}
   {{ if not ( in $exclude $item.ModuleStatus ) }}
-    {{ $moduleTfRegApiUrl := printf "https://registry.terraform.io/v1/modules/Azure/%s/azurerm/versions" $item.ModuleName }}
-    {{ $moduleTfRegApiData := getJSON $moduleTfRegApiUrl }}
-    {{ $moduleVersions := slice }}
-    {{ range $moduleTfRegApiData.modules }}
-      {{ range .versions }}
-        {{ $moduleVersions = $moduleVersions | append .version }}
+  {{ $moduleLatestVersion = "N/A" }}
+    {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}
+      {{ $moduleTfRegApiUrl := printf "https://registry.terraform.io/v1/modules/Azure/%s/azurerm/versions" $item.ModuleName }}
+      {{ $moduleTfRegApiData := getJSON $moduleTfRegApiUrl }}
+      {{ $moduleVersions := slice }}
+      {{ range $moduleTfRegApiData.modules }}
+        {{ range .versions }}
+          {{ $moduleVersions = $moduleVersions | append .version }}
+        {{ end }}
       {{ end }}
-    {{ end }}
-    {{ $moduleLatestVersion := "" }}
-    {{ if $moduleVersions }}
-        {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
-    {{ else }}
-        {{ $moduleLatestVersion = "NA"}}
+      {{ if $moduleVersions }}
+          {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
+      {{ end }}
     {{ end }}
     {{ $trimmedModuleStatus := replace $item.ModuleStatus "Module " "" }}
   <tr>
@@ -190,7 +191,7 @@
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.PublicRegistryReference }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">📄</a> {{ else }} {{ "n/a" }} {{ end }} {{else}} {{ "n/a" }} {{ end }} </td>
     <td>{{ $item.ModuleDisplayName }}</td>
-    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="{{ $item.PublicRegistryReference }}"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-purple"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-NA-purple"/></a> {{ end }}</td>
+    <td>{{ if or (eq $item.ModuleStatus "Module Available :green_circle:") (eq $item.ModuleStatus "Module Orphaned :eyes:") }}<a href="{{ $item.PublicRegistryReference }}"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-purple"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-N/A-purple"/></a> {{ end }}</td>
     <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
   </tr>
   {{ $hasModulesAvailable = true }}


### PR DESCRIPTION
# Overview/Summary

fixing errors in new module index version feature

## This PR fixes/adds/changes/removes

Adding logic to not to attempt to pull data from the registries unless the module is available or orphaned.

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
