### PR TITLE
Fix: TF Private Endpoint interface naming update

### DIFF
--- a/docs/static/includes/interfaces/int.pe.schema.tf
+++ b/docs/static/includes/interfaces/int.pe.schema.tf
@@ -59,7 +59,7 @@ DESCRIPTION
 }
 
 # The PE resource when we are managing the private_dns_zone_group block:
-resource "azurerm_private_endpoint" "this" {
+resource "azurerm_private_endpoint" "this_managed_dns_zone_groups" {
   for_each                      = { for k, v in var.private_endpoints : k => v if var.private_endpoints_manage_dns_zone_group }
   name                          = each.value.name != null ? each.value.name : "pep-${var.name}"
   location                      = each.value.location != null ? each.value.location : var.location


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This PR updates the resource name for the example TF PE interface to align with the names used for conditional checks in the example.

## This PR fixes/adds/changes/removes

1. Changed resource "azurerm_private_endpoint" `this` to resource "azurerm_private_endpoint" `"this_managed_dns_zone_groups"` . This changed is needed to allow for conditional checks used in the example
### Breaking Changes

1. Resource name changes will cause a redeployment of the resource.

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
