### PR TITLE
Terraform Output Spec Update

### DIFF
--- a/docs/content/specs-defs/specs/terraform/_index.md
+++ b/docs/content/specs-defs/specs/terraform/_index.md
@@ -103,12 +103,12 @@ See [Module Sources](https://developer.hashicorp.com/terraform/language/modules/
 
 #### ID: TFFR2 - Category: Outputs - Additional Terraform Outputs
 
-Module owners **MUST** output the following additional outputs as a minimum in their modules:
+Module owners **MAY** output the following additional outputs in their modules:
 
-| Output                                                                                   | Terraform Output Name                                 | MUST/SHOULD |
-|------------------------------------------------------------------------------------------|-------------------------------------------------------|-------------|
-| Full Resource Output Object                                                              | `resource`                                            | MUST        |
-| Full Resource Output (map of) Object(s) of child resource/extension/associated resources | `resource_<child/extension/associated resource name>` | SHOULD      |
+| Output                                                                                   | Terraform Output Name                                 |
+|------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| Full Resource Output Object                                                              | `resource`                                            |
+| Full Resource Output (map of) Object(s) of child resource/extension/associated resources | `resource_<child/extension/associated resource name>` |
 
 <br>
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary
Output Spec Update

## This PR fixes/adds/changes/removes
Currently our [shared spec](https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-rmfr7---category-outputs---minimum-required-outputs) requires output of resource name and resource id as a MUST. Along with that our [terraform spec](https://azure.github.io/Azure-Verified-Modules/specs/terraform/#id-tffr2---category-outputs---additional-terraform-outputs) requires output of resource object and child/associated resources/extensions object as a MUST too. This creates confusion for module owner. Based on feedback received on this from a module owner and a discussion with Matt, suggest changing the output requirements in the terraform spec to MAY i.e. optional. Please share your thoughts and feedback on this PR.

### Breaking Changes

NA

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
