### PR TITLE
feat: Adding closure for existing issues which have been resolved via the AVM Team Linter Bot

### DIFF
--- a/utilities/pipelines/sharedScripts/teamLinter/Close-ResolvedGithubIssue.ps1
+++ b/utilities/pipelines/sharedScripts/teamLinter/Close-ResolvedGithubIssue.ps1
@@ -1,0 +1,30 @@
+function Close-ResolvedGithubIssue {
+  [CmdletBinding()]
+  [OutputType([System.String])]
+  param (
+      [Parameter(Mandatory)]
+      [string]$title
+  )
+
+  $issueList = gh issue list --limit 500 --json number,title,assignees,labels,id | ConvertFrom-Json
+  $issueDetails = $null
+
+  foreach ($issueItem in $issueList) {
+      if ($issueItem.title -eq $title) {
+          $issueDetails = "$($issueItem.number) | $($issueItem.title) | $($issueItem.assignees.login)"
+          $issueTitle = $($issueItem.title)
+          $issueNumber = $($issueItem.number)
+
+          Write-Output "Good News! Issue Found:: $($issueDetails).. Will proceed to close the issue"
+          if ($null -ne $issueDetails) {
+              gh issue close $issueNumber
+              Write-Output "Issue Closed: $($issueTitle)"
+          }
+          return $issueDetails
+      }
+  }
+
+  # If no match is found in the loop, return an empty string
+  Write-Output "No match found for: $($title)"
+  return $issueDetails
+}

--- a/utilities/pipelines/sharedScripts/teamLinter/Invoke-AvmGitHubTeamLinter.ps1
+++ b/utilities/pipelines/sharedScripts/teamLinter/Invoke-AvmGitHubTeamLinter.ps1
@@ -75,6 +75,7 @@ Function Invoke-AvmGitHubTeamLinter {
   . (Join-Path $PSScriptRoot 'Set-AvmGitHubTeamsIssue.ps1')
   . (Join-Path $PSScriptRoot 'Test-AvmGitHubTeamPermission.ps1')
   . (Join-Path $PSScriptRoot 'Find-AvmGitHubTeamOwner.ps1')
+  . (Join-Path $PSScriptRoot 'Close-ResolvedGithubIssue.ps1')
 
   if ($TeamFilter -like '*All*') {
       $validateAll = $true
@@ -108,6 +109,8 @@ Function Invoke-AvmGitHubTeamLinter {
                   $testOwner = Find-AvmGitHubTeamOwner -Organization Azure -TeamName $module.ModuleOwnersGHTeam -OwnerGitHubHandle $module.PrimaryModuleOwnerGHHandle
                   if ($testOwner -match "Success") {
                     Write-Verbose "Good News! Team: [$($ghTeam.name)] is configured with the expected owners: [$($module.PrimaryModuleOwnerGHHandle)]"
+                    Write-Verbose "Checking if an issue exists for the team: [$($ghTeam.name)]..."
+                    Close-ResolvedGithubIssue -title "[GitHub Team Issue] ``$($ghTeam.name)``"
                   }
                   else {
                     Write-Verbose "Uh-oh no incorrect owner configured for [$($ghTeam.name)]"
@@ -153,6 +156,8 @@ Function Invoke-AvmGitHubTeamLinter {
                           $repoConfiguration = Test-AvmGitHubTeamPermission -Organization Azure -TeamName $module.ModuleOwnersGHTeam -RepoName $repoName -ExpectedPermission "Admin"
                           if ($repoConfiguration -match "Success") {
                               Write-Verbose "Good News! Team: [$($module.ModuleOwnersGHTeam)] is configured with the expected permission: [admin] on Repo: [$repoName] "
+                              Write-Verbose "Checking if an issue exists for the team: [$($ghTeam.name)]..."
+                              Close-ResolvedGithubIssue -title "[GitHub Team Issue] ``$($ghTeam.name)``"
                           }
                           else {
                               Write-Verbose "Uh-oh no correct permissions configured for $($module.ModuleOwnersGHTeam) ($($module.PrimaryModuleOwnerDisplayName))"
@@ -253,6 +258,8 @@ Function Invoke-AvmGitHubTeamLinter {
                           $repoConfiguration = Test-AvmGitHubTeamPermission -Organization Azure -TeamName $module.ModuleContributorsGHTeam -RepoName $repoName -ExpectedPermission "Write"
                           if ($repoConfiguration -match "Success") {
                               Write-Verbose "Good News! Team: [$($module.ModuleOwnersGHTeam)] is configured with the expected permission: [write] on Repo: [$repoName] "
+                              Write-Verbose "Checking if an issue exists for the team: [$($ghTeam.name)]..."
+                              Close-ResolvedGithubIssue -title "[GitHub Team Issue] ``$($ghTeam.name)``"
                             }
                           else {
                               Write-Verbose "Uh-oh no correct permissions configured for $($module.ModuleContributorsGHTeam) ($($module.PrimaryModuleOwnerDisplayName))"
@@ -328,6 +335,8 @@ Function Invoke-AvmGitHubTeamLinter {
             $teamTest = Test-AvmGitHubTeamPermission -Organization Azure -TeamName $tfAdminteam -RepoName $repoName -ExpectedPermission "Admin"
             if ($teamTest -match "Success") {
               Write-Verbose "Good News! Team: [$tfAdminteam] is configured with the expected permission: [admin] on Repo: [$repoName] "
+              Write-Verbose "Checking if an issue exists for the team: [$($ghTeam.name)]..."
+              Close-ResolvedGithubIssue -title "[GitHub Team Issue] ``$($ghTeam.name)``"
             }
             else {
               Write-Verbose "Uh-oh no correct permissions configured for [$tfAdminteam]"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Ensure the `avm-team-linter` bot can close issues where module owners can't

Tested with #982 

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
