### PR TITLE
updated triage automation notifications

### DIFF
--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -25,9 +25,6 @@ configuration:
                 > [!TIP]
                 > For additional guidance on how to triage this issue/PR, see the [AVM Issue Triage](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/avm-issue-triage/) documentation.
 
-                > [!NOTE]
-                > This label was added as per [ITA06](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita06).
-
       - description: 'ITA09 - When #RR is used in an issue, add the "Needs: Author Feedback :ear:" label'
         if:
           - or:
@@ -41,10 +38,6 @@ configuration:
         then:
           - addLabel:
               label: "Needs: Author Feedback :ear:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Needs: Author Feedback :ear:" label was added as per [ITA09](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita09).
 
       - description: 'ITA10 - When #wontfix is used in an issue, mark it by using the label of "Status: Won''t Fix :broken_heart:"'
         if:
@@ -60,10 +53,6 @@ configuration:
           - addLabel:
               label: "Status: Won't Fix :broken_heart:"
           - closeIssue
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Status: Won't Fix :broken_heart:" label was added and the issue was closed as per [ITA10](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita10).
 
       - description: 'ITA11 - When a reply from anyone to an issue occurs, remove the "Needs: Author Feedback :ear:" label and label with "Needs: Attention :wave:"'
         if:
@@ -80,10 +69,6 @@ configuration:
               label: "Needs: Author Feedback :ear:"
           - addLabel:
               label: "Needs: Attention :wave:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Needs: Author Feedback :ear:" label was removed and the "Needs: Attention :wave:" label was added as per [ITA11](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita11).
 
       - description: "ITA12 - Clean email replies on every comment"
         if:
@@ -107,10 +92,6 @@ configuration:
         then:
           - addLabel:
               label: "Language: Bicep :muscle:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Language: Bicep :muscle:" label was added as per [ITA13](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita13).
 
       - description: 'ITA14 - If the language is set to Terraform in the Module proposal, add the "Language: Terraform :globe_with_meridians:" label on the issue'
         if:
@@ -128,10 +109,6 @@ configuration:
         then:
           - addLabel:
               label: "Language: Terraform :globe_with_meridians:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Language: Terraform :globe_with_meridians:" label was added as per [ITA14](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita14).
 
       - description: 'ITA15 - remove the "Needs: Triage" label from a PR, if it already has a "Type: XYZ" label added at the time of creating it.'
         if:
@@ -159,10 +136,6 @@ configuration:
         then:
           - removeLabel:
               label: "Needs: Triage :mag:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Needs: Triage :mag:" label was removed as per [ITA15](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita15).
 
       - description: 'ITA16 - Add the "Status: Owners Identified :metal:" label when someone is assigned to a Module Proposal'
         if:
@@ -179,10 +152,6 @@ configuration:
         then:
           - addLabel:
               label: "Status: Owners Identified :metal:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Status: Owners Identified :metal:" label was added as per [ITA16](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita16).
         triggerOnOwnActions: true
 
       - description: "ITA17 - If the issue author says they want to be the module owner, assign the issue to the author and respond to them."
@@ -207,9 +176,6 @@ configuration:
                 >
                 > The AVM core team will review this module proposal and respond to you first. Thank you!
 
-                > [!NOTE]
-                > This message was posted as per [ITA17](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita17).
-
       - description: 'ITA18 - Send automatic response to the issue author if they don''t want to be module owner and don''t have any candidate in mind. Add the "Needs: Module Owner :mega:" label.'
         if:
           - payloadType: Issues
@@ -233,9 +199,6 @@ configuration:
 
                 > [!IMPORTANT]
                 > The AVM core team will review it and will try to find a module owner.
-
-                > [!NOTE]
-                > This message was posted as per [ITA18](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita18).
 
       - description: 'ITA19 - Send automatic response to the issue author if they don''t want to be module owner but have a candidate in mind. Add the "Status: Owners Identified :metal:" label.'
         if:
@@ -265,9 +228,6 @@ configuration:
                 >
                 > The AVM core team will review this module proposal and respond to you and/or the module owner first. Thank you!
 
-                > [!NOTE]
-                > This message was posted as per [ITA19](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita19).
-
       - description: 'ITA23 - Remove the "Status: In PR" label from an issue when it''s closed.'
         if:
           - payloadType: Issues
@@ -278,7 +238,3 @@ configuration:
         then:
           - removeLabel:
               label: "Status: In PR :point_right:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Status: In PR :point_right:" label was removed as per [ITA23](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita23).

--- a/.github/policies/scheduledSearches.yml
+++ b/.github/policies/scheduledSearches.yml
@@ -34,9 +34,6 @@ configuration:
                 >   - The "Status: No Recent Activity :zzz:" label must be removed.
                 >   - If applicable, the "Status: Long Term :hourglass_flowing_sand:" or the "Needs: Module Owner :mega:" label must be added.
 
-                > [!NOTE]
-                > This message was posted as per [ITA04](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita04).
-
       - description: 'ITA05A - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
         frequencies:
           - hourly:
@@ -60,9 +57,6 @@ configuration:
 
                 > [!TIP]
                 > In case this issue needs to be reopened (e.g., the author responds after the issue was closed), the "Status: No Recent Activity :zzz:" label must be removed.
-
-                > [!NOTE]
-                > This message was posted as per [ITA05](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita05).
           - closeIssue
 
       - description: 'ITA05B - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
@@ -88,9 +82,6 @@ configuration:
 
                 > [!TIP]
                 > In case this issue needs to be reopened (e.g., the author responds after the issue was closed), the "Status: No Recent Activity :zzz:" label must be removed.
-
-                > [!NOTE]
-                > This message was posted as per [ITA05](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita05).
           - closeIssue
 
       - description: 'ITA24 - Remind module owner(s) to start or continue working on this module if there was no activity on the Module Proposal issue for more than 3 weeks. "Add Needs: Attention :wave:" label.'
@@ -116,8 +107,5 @@ configuration:
 
                 > [!TIP]
                 > To silence this notification, provide an update every 3 weeks on the Module Proposal issue, or add the "Status: Long Term :hourglass_flowing_sand:" label.
-
-                > [!NOTE]
-                > This message was posted as per [ITA24](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita24).
           - addLabel:
               label: "Needs: Attention :wave:"

--- a/docs/content/help-support/issue-triage/issue-triage-automation.md
+++ b/docs/content/help-support/issue-triage/issue-triage-automation.md
@@ -283,7 +283,6 @@ If AVM or "Azure Verified Modules" is mentioned in an uncategorized issue (i.e.,
 **Action(s):**
 
 - Add the "<mark style="background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>" label.
-- Add a reply to explain the action(s).
 
 ---
 
@@ -294,7 +293,6 @@ When #RR is used in an issue, add the label of "<mark style="background-color:#C
 **Trigger criteria:**
 
 - An issue comment or PR comment contains the string of "#RR".
-- Add a reply to explain the action(s).
 
 **Action(s):**
 
@@ -314,7 +312,6 @@ When #wontfix is used in an issue, mark it by using the label of "<mark style="b
 
 - Add the "<mark style="background-color:#FFFFFF;">Status: Won't Fix 💔</mark>" label.
 - Close the issue.
-- Add a reply to explain the action(s).
 
 ---
 
@@ -330,7 +327,6 @@ When a reply from anyone to an issue occurs, remove the "<mark style="background
 **Action(s):**
 
 - Add the "<mark style="background-color:#E99695;color:white;">Needs: Attention 👋</mark>" label.
-- Add a reply to explain the action(s).
 
 ---
 
@@ -365,7 +361,6 @@ Bicep
 **Action(s):**
 
 - Add the "<mark style="background-color:#1D73B3;color:white;">Language: Bicep 💪</mark>" label.
-- Add a reply to explain the action(s).
 
 ---
 
@@ -386,7 +381,6 @@ Terraform
 **Action(s):**
 
 - Add the "<mark style="background-color:#7740B6;color:white;">Language: Terraform 🌐</mark>" label.
-- Add a reply to explain the action(s).
 
 ---
 
@@ -409,7 +403,6 @@ Remove the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" l
 **Action(s):**
 
 - Remove the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label.
-- Add a reply to explain the action(s).
 
 ---
 
@@ -426,7 +419,6 @@ Add the "<mark style="background-color:#FBEF2A;">Status: Owners Identified 🤘<
 **Action(s):**
 
 - Add the "<mark style="background-color:#FBEF2A;">Status: Owners Identified 🤘</mark>" label.
-- Add a reply to explain the action(s).
 
 ---
 
@@ -543,7 +535,6 @@ If the issue type is feature request, add the "<mark style="background-color:#A2
 **Action(s):**
 
 - Add the "<mark style="background-color:#A2EEEF;">Type: Feature Request ➕</mark>" label.
-- Add a reply to explain the action(s).
 
 ---
 
@@ -564,7 +555,6 @@ If the issue type is bug, add the "<mark style="background-color:#D73A4A;color:w
 **Action(s):**
 
 - Add the "<mark style="background-color:#D73A4A;color:white;">Type: Bug 🐛</mark>" label.
-- Add a reply to explain the action(s).
 
 ---
 
@@ -585,7 +575,6 @@ If the issue type is security bug, add the "<mark style="background-color:#FFFF0
 **Action(s):**
 
 - Add the "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>" label.
-- Add a reply to explain the action(s).
 
 ---
 
@@ -600,7 +589,6 @@ Remove the "<mark style="background-color:#EDEDED;">Status: In PR 👉</mark>" l
 **Action(s):**
 
 - Remove the "<mark style="background-color:#EDEDED;">Status: In PR 👉</mark>" label.
-- Add a reply to explain the action(s).
 
 ---
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

## This PR fixes/adds/changes/removes

This PR removes the ITA (issue triage automation) references from all messages sent by the GH policy service bot as part of our issue triage automation solution.

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
