### PR TITLE
revise terraform output specs

### DIFF
--- a/docs/content/specs-defs/specs/shared/_index.md
+++ b/docs/content/specs-defs/specs/shared/_index.md
@@ -995,11 +995,11 @@ Another example for where RPs contain some of their name within a property, leav
 
 Module owners **MUST** output the following outputs as a minimum in their modules:
 
-| Output                                                                 | Bicep Output Name             | Terraform Output Name                                   |
-|------------------------------------------------------------------------|-------------------------------|---------------------------------------------------------|
-| Resource Name                                                          | `name`                        | n/a (not required, use `basename(resource_id)` instead) |
-| Resource ID                                                            | `resourceId`                  | `resource_id`                                           |
-| System Assigned Managed Identity Principal ID (if supported by module) | `systemAssignedMIPrincipalId` | `system_assigned_mi_principal_id`                       |
+| Output                                                                 | Bicep Output Name             | Terraform Output Name             |
+|------------------------------------------------------------------------|-------------------------------|-----------------------------------|
+| Resource Name                                                          | `name`                        | `name`                            |
+| Resource ID                                                            | `resourceId`                  | `resource_id`                     |
+| System Assigned Managed Identity Principal ID (if supported by module) | `systemAssignedMIPrincipalId` | `system_assigned_mi_principal_id` |
 
 {{< hint type=tip >}}
 

--- a/docs/content/specs-defs/specs/shared/_index.md
+++ b/docs/content/specs-defs/specs/shared/_index.md
@@ -995,11 +995,11 @@ Another example for where RPs contain some of their name within a property, leav
 
 Module owners **MUST** output the following outputs as a minimum in their modules:
 
-| Output                                                                 | Bicep Output Name             | Terraform Output Name             |
-|------------------------------------------------------------------------|-------------------------------|-----------------------------------|
-| Resource Name                                                          | `name`                        | n/a (not required)               |
-| Resource ID                                                            | `resourceId`                  | `resource_id`                     |
-| System Assigned Managed Identity Principal ID (if supported by module) | `systemAssignedMIPrincipalId` | `system_assigned_mi_principal_id` |
+| Output                                                                 | Bicep Output Name             | Terraform Output Name                                   |
+|------------------------------------------------------------------------|-------------------------------|---------------------------------------------------------|
+| Resource Name                                                          | `name`                        | n/a (not required, use `basename(resource_id)` instead) |
+| Resource ID                                                            | `resourceId`                  | `resource_id`                                           |
+| System Assigned Managed Identity Principal ID (if supported by module) | `systemAssignedMIPrincipalId` | `system_assigned_mi_principal_id`                       |
 
 {{< hint type=tip >}}
 

--- a/docs/content/specs-defs/specs/shared/_index.md
+++ b/docs/content/specs-defs/specs/shared/_index.md
@@ -997,7 +997,7 @@ Module owners **MUST** output the following outputs as a minimum in their module
 
 | Output                                                                 | Bicep Output Name             | Terraform Output Name             |
 |------------------------------------------------------------------------|-------------------------------|-----------------------------------|
-| Resource Name                                                          | `name`                        | `name`                            |
+| Resource Name                                                          | `name`                        | n/a (not required)               |
 | Resource ID                                                            | `resourceId`                  | `resource_id`                     |
 | System Assigned Managed Identity Principal ID (if supported by module) | `systemAssignedMIPrincipalId` | `system_assigned_mi_principal_id` |
 

--- a/docs/content/specs-defs/specs/terraform/_index.md
+++ b/docs/content/specs-defs/specs/terraform/_index.md
@@ -103,12 +103,37 @@ See [Module Sources](https://developer.hashicorp.com/terraform/language/modules/
 
 #### ID: TFFR2 - Category: Outputs - Additional Terraform Outputs
 
-Please see table below for additional outputs:
+Authors **SHOULD NOT** output entire resource objects as these may contain sensitive outputs and the schema can change with API or provider verisons. Instead, authors **SHOULD** output the *necessary* attributes of the resource object within another object. This kind of pattern is known as an [anti-corruption layer](https://learn.microsoft.com/en-us/azure/architecture/patterns/anti-corruption-layer).
 
-| Output                                                                                   | Terraform Output Name                                 | GUIDANCE    |
-|------------------------------------------------------------------------------------------|-------------------------------------------------------|-------------|
-| Full Resource Output Object                                                              | `resource`                                            | MAY         |
-| Full Resource Output (map of) Object(s) of child resource/extension/associated resources | `resource_<child/extension/associated resource name>` | MAY         |
+Remember, you do not need to output everything! Other attributes may be sourced by the caller using the mandatory resource id output and using a data source.
+
+E.g.
+
+```terraform
+# Resource output object, only necessary attributes and constructed to prevent breaking changes.
+output "resource" {
+  value = {
+    foo = azurerm_resource_myresource.foo
+    bar = azurerm_resource_myresource.bar
+  }
+}
+
+# Resource output object for resources that are deployed using `for_each`. Again only necessary attributes and constructed to prevent breaking changes.
+output "resource" {
+  value = {
+    for key, value in azurerm_resource_myresource : key => {
+      foo = value.foo
+      bar = value.bar
+    }
+  }
+}
+
+# Output of a sensitive attribute
+output "resource_sensitive" {
+  value     = azurerm_resource_myresource.sensitive_attribute
+  sensitive = true
+}
+```
 
 <br>
 

--- a/docs/content/specs-defs/specs/terraform/_index.md
+++ b/docs/content/specs-defs/specs/terraform/_index.md
@@ -103,7 +103,7 @@ See [Module Sources](https://developer.hashicorp.com/terraform/language/modules/
 
 #### ID: TFFR2 - Category: Outputs - Additional Terraform Outputs
 
-Authors **SHOULD NOT** output entire resource objects as these may contain sensitive outputs and the schema can change with API or provider verisons. Instead, authors **SHOULD** output the *necessary* attributes of the resource object within another object. This kind of pattern is known as an [anti-corruption layer](https://learn.microsoft.com/en-us/azure/architecture/patterns/anti-corruption-layer).
+Authors **SHOULD NOT** output entire resource objects as these may contain sensitive outputs and the schema can change with API or provider verisons. Instead, authors **SHOULD** output the *necessary* attributes of the resource object within another object. This kind of pattern is known as an [anti-corruption layer](https://learn.microsoft.com/azure/architecture/patterns/anti-corruption-layer).
 
 Remember, you do not need to output everything! Other attributes may be sourced by the caller using the mandatory resource id output and using a data source.
 

--- a/docs/content/specs-defs/specs/terraform/_index.md
+++ b/docs/content/specs-defs/specs/terraform/_index.md
@@ -103,34 +103,33 @@ See [Module Sources](https://developer.hashicorp.com/terraform/language/modules/
 
 #### ID: TFFR2 - Category: Outputs - Additional Terraform Outputs
 
-Authors **SHOULD NOT** output entire resource objects as these may contain sensitive outputs and the schema can change with API or provider verisons. Instead, authors **SHOULD** output the *necessary* attributes of the resource object within another object. This kind of pattern is known as an [anti-corruption layer](https://learn.microsoft.com/en-us/azure/architecture/patterns/anti-corruption-layer).
+Authors **SHOULD NOT** output entire resource objects as these may contain sensitive outputs and the schema can change with API or provider verisons.
+Instead, authors **SHOULD** output the *computed* attributes of the resource as discreet outputs.
+This kind of pattern protects against provider schema changes and is known as an [anti-corruption layer](https://learn.microsoft.com/en-us/azure/architecture/patterns/anti-corruption-layer).
 
-Remember, you do not need to output everything! Other attributes may be sourced by the caller using the mandatory resource id output and using a data source.
+Remember, you **SHOULD NOT** output values that are already inputs (other than `name`).
 
 E.g.
 
 ```terraform
-# Resource output object, only necessary attributes and constructed to prevent breaking changes.
-output "resource" {
-  value = {
-    foo = azurerm_resource_myresource.foo
-    bar = azurerm_resource_myresource.bar
-  }
+# Resource output, computed attribute.
+output "foo" {
+  description = "MyResource foo attribute"
+  value = azurerm_resource_myresource.foo
 }
 
-# Resource output object for resources that are deployed using `for_each`. Again only necessary attributes and constructed to prevent breaking changes.
-output "resource" {
+# Resource output for resources that are deployed using `for_each`. Again only computed attributes.
+output "childresource_foos" {
+  description = "MyResource childs' foo attributes"
   value = {
-    for key, value in azurerm_resource_myresource : key => {
-      foo = value.foo
-      bar = value.bar
-    }
+    for key, value in azurerm_resource_myresource : key => value.foo
   }
 }
 
 # Output of a sensitive attribute
-output "resource_sensitive" {
-  value     = azurerm_resource_myresource.sensitive_attribute
+output "bar" {
+  description = "MyResource bar attribute"
+  value     = azurerm_resource_myresource.bar
   sensitive = true
 }
 ```

--- a/docs/content/specs-defs/specs/terraform/_index.md
+++ b/docs/content/specs-defs/specs/terraform/_index.md
@@ -122,7 +122,7 @@ output "foo" {
 output "childresource_foos" {
   description = "MyResource childs' foo attributes"
   value = {
-    for key, value in azurerm_resource_myresource : key => value.foo
+    for key, value in azurerm_resource_mychildresource : key => value.foo
   }
 }
 

--- a/docs/content/specs-defs/specs/terraform/_index.md
+++ b/docs/content/specs-defs/specs/terraform/_index.md
@@ -103,12 +103,12 @@ See [Module Sources](https://developer.hashicorp.com/terraform/language/modules/
 
 #### ID: TFFR2 - Category: Outputs - Additional Terraform Outputs
 
-Module owners **MUST** output the following additional outputs as a minimum in their modules:
+Please see table below for additional outputs:
 
-| Output                                                                                   | Terraform Output Name                                 | MUST/SHOULD |
+| Output                                                                                   | Terraform Output Name                                 | GUIDANCE    |
 |------------------------------------------------------------------------------------------|-------------------------------------------------------|-------------|
-| Full Resource Output Object                                                              | `resource`                                            | MUST        |
-| Full Resource Output (map of) Object(s) of child resource/extension/associated resources | `resource_<child/extension/associated resource name>` | SHOULD      |
+| Full Resource Output Object                                                              | `resource`                                            | MAY         |
+| Full Resource Output (map of) Object(s) of child resource/extension/associated resources | `resource_<child/extension/associated resource name>` | MAY         |
 
 <br>
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This PR removes the hard requirement to output the full resource object in Terraform.

Rationale:

- Resource schemas can change with provider versions, therefore relying on this is brittle
- Consumers are encouraged to use data sources outside the module if they want to retrieve additional resource attributes


## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
