### PR TITLE
update index pages with links to modules needing owners or contributors

### DIFF
--- a/docs/content/faq/_index.md
+++ b/docs/content/faq/_index.md
@@ -225,9 +225,7 @@ You can contribute to modules:
 3. Volunteer as a co-owner or module contributor to an existing module, and work along other contributors and the (administrative) module owner.
 4. You can submit a PR with a small proposed change without officially becoming a module owner or contributor.
 
-Or you can contribute to the AVM website/documentation:
-
-- You can contribute to the [AVM website/documentation](/Azure-Verified-Modules/contributing/website/) too.
+Or you can contribute to the AVM website/documentation, by following [this guidance](/Azure-Verified-Modules/contributing/website/).
 
 {{< hint type=note >}}
 

--- a/docs/content/faq/_index.md
+++ b/docs/content/faq/_index.md
@@ -214,27 +214,52 @@ If you're not a Microsoft FTE or don't want to be a module owner, you can still 
 
 ### Are there different ways to contribute to AVM?
 
-Yes, there are multiple ways to contribute to AVM. You can:
+Yes, there are multiple ways to contribute to AVM!
 
-1. [Propose](https://aka.ms/ModuleProposal) and develop a new module (Bicep or Terraform)
-2. Become the owner of an orphaned module (mainly Bicep) - look for "orphaned module" issues [here](https://github.com/Azure/Azure-Verified-Modules/issues?q=is%3Aopen+is%3Aissue+label%3A%22Status%3A+Module+Orphaned+%3Aeyes%3A%22) or see the "Orphaned" swimlane [here](https://github.com/orgs/Azure/projects/529/views/1?filterQuery=is%3Aissue+is%3Aopen+is%3Aissue+is%3Aopen+label%3A%22Status%3A+Module+Orphaned+%3Aeyes%3A%22)
+You can contribute to modules:
 
----
+1. Become an owner (preferred):
+    - [Propose](https://aka.ms/ModuleProposal) and develop a new module (Bicep or Terraform) or pick up a module someone else proposed.
+    - Become the owner of an orphaned module (mainly Bicep) - look for "orphaned module" issues [here](https://github.com/Azure/Azure-Verified-Modules/issues?q=is%3Aopen+is%3Aissue+label%3A%22Status%3A+Module+Orphaned+%3Aeyes%3A%22) or see the "Orphaned" swimlane [here](https://github.com/orgs/Azure/projects/529/views/1?filterQuery=is%3Aissue+is%3Aopen+is%3Aissue+is%3Aopen+label%3A%22Status%3A+Module+Orphaned+%3Aeyes%3A%22)
+2. Become an administrative owner and work with other contributors or co-owners on developing and maintaining modules.
+3. Volunteer as a co-owner or module contributor to an existing module, and work along other contributors and the (administrative) module owner.
+4. You can submit a PR with a small proposed change without officially becoming a module owner or contributor.
 
-### Where can I find modules missing owners?
+Or you can contribute to the AVM website/documentation:
 
-You can find modules missing owners in the following places:
-
-1. [All Orphaned modules](https://github.com/Azure/Azure-Verified-Modules/issues?q=is%3Aopen+is%3Aissue+label%3A%22Status%3A+Module+Orphaned+%3Aeyes%3A%22) or see the "Orphaned" swimlane [here](https://github.com/orgs/Azure/projects/529/views/1?filterQuery=is%3Aissue+is%3Aopen+is%3Aissue+is%3Aopen+label%3A%22Status%3A+Module+Orphaned+%3Aeyes%3A%22)
-    - [Orphaned Bicep modules](https://github.com/Azure/Azure-Verified-Modules/issues?q=is%3Aopen+is%3Aissue+label%3A%22Status%3A+Module+Orphaned+%3Aeyes%3A%22+label%3A%22Language%3A+Bicep+%3Amuscle%3A%22+) or see the "Orphaned" swimlane [here](https://github.com/orgs/Azure/projects/529/views/1?filterQuery=is%3Aissue+is%3Aopen+is%3Aissue+is%3Aopen+label%3A%22Status%3A+Module+Orphaned+%3Aeyes%3A%22+label%3A%22Language%3A+Bicep+%3Amuscle%3A%22)
-    - [Orphaned Terraform modules](https://github.com/Azure/Azure-Verified-Modules/issues?q=is%3Aopen+is%3Aissue+label%3A%22Status%3A+Module+Orphaned+%3Aeyes%3A%22+label%3A%22Language%3A+Terraform+%3Aglobe_with_meridians%3A%22) or see the "Orphaned" swimlane [here](https://github.com/orgs/Azure/projects/529/views/1?filterQuery=is%3Aissue+is%3Aopen+is%3Aissue+is%3Aopen+label%3A%22Status%3A+Module+Orphaned+%3Aeyes%3A%22+label%3A%22Language%3A+Terraform+%3Aglobe_with_meridians%3A%22+)
-2. [All modules looking for owners](https://github.com/Azure/Azure-Verified-Modules/issues?q=is%3Aopen+is%3Aissue+label%3A%22Needs%3A+Module+Owner+%3Amega%3A%22) or see the "Looking for owners" swimlane [here](https://github.com/orgs/Azure/projects/529/views/1?filterQuery=is%3Aissue+is%3Aopen+is%3Aissue+is%3Aopen+label%3A%22Needs%3A+Module+Owner+%3Amega%3A%22+)
-    - [Bicep modules looking for owners](https://github.com/Azure/Azure-Verified-Modules/issues?q=is%3Aopen+is%3Aissue+label%3A%22Needs%3A+Module+Owner+%3Amega%3A%22+label%3A%22Language%3A+Bicep+%3Amuscle%3A%22) or see the "Looking for owners" swimlane [here](https://github.com/orgs/Azure/projects/529/views/1?filterQuery=is%3Aissue+is%3Aopen+is%3Aissue+is%3Aopen+label%3A%22Needs%3A+Module+Owner+%3Amega%3A%22+label%3A%22Language%3A+Bicep+%3Amuscle%3A%22)
-    - [Terraform modules looking for owners](https://github.com/Azure/Azure-Verified-Modules/issues?q=is%3Aissue+is%3Aopen+label%3A%22Needs%3A+Module+Owner+%3Amega%3A%22+label%3A%22Language%3A+Terraform+%3Aglobe_with_meridians%3A%22+) or see the "Looking for owners" swimlane [here](https://github.com/orgs/Azure/projects/529/views/1?filterQuery=is%3Aissue+is%3Aopen+is%3Aissue+is%3Aopen+label%3A%22Needs%3A+Module+Owner+%3Amega%3A%22+label%3A%22Language%3A+Terraform+%3Aglobe_with_meridians%3A%22)
+- You can contribute to the [AVM website/documentation](/Azure-Verified-Modules/contributing/website/) too.
 
 {{< hint type=note >}}
 
-If any of these queries don't return any results, it means that no module in the selected category is missing its owner at the moment.
+New modules can't be created and published without having a module owner assigned.
+
+{{< /hint >}}
+
+---
+
+### Where can I find modules I can contribute to?
+
+You can find modules missing owners in the following places:
+
+1. [All new modules looking for owners](https://aka.ms/AVM/NeedsModuleOwner) or see the "Looking for owners" swimlane [here](https://aka.ms/AVM/NeedsModuleOwner/Project)
+    - [New Bicep modules looking for owners](https://aka.ms/AVM/Bicep/NeedsModuleOwner) or see the "Looking for owners" swimlane [here](https://aka.ms/AVM/Bicep/NeedsModuleOwner/Project)
+    - [New Terraform modules looking for owners](https://aka.ms/AVM/TF/NeedsModuleOwner) or see the "Looking for owners" swimlane [here](https://aka.ms/AVM/TF/NeedsModuleOwner/Project)
+2. [All Orphaned modules](https://aka.ms/AVM/OrphanedModules) or see the "Orphaned" swimlane [here](https://aka.ms/AVM/OrphanedModules/Project)
+    - [Orphaned Bicep modules](https://aka.ms/AVM/Bicep/OrphanedModules) or see the "Orphaned" swimlane [here](https://aka.ms/AVM/Bicep/OrphanedModules/Project)
+    - [Orphaned Terraform modules](https://aka.ms/AVM/TF/OrphanedModules) or see the "Orphaned" swimlane [here](https://aka.ms/AVM/TF/OrphanedModules/Project)
+3. [All modules looking for contributors](https://aka.ms/AVM/NeedsModuleContributor)
+    - [Bicep modules looking for contributors](https://aka.ms/AVM/Bicep/NeedsModuleContributor)
+    - [Terraform modules looking for contributors](https://aka.ms/AVM/TF/NeedsModuleContributor)
+
+{{< hint type=tip >}}
+
+To indicate your interest in owning or contributing to a module, just leave a comment on the respective issue.
+
+{{< /hint >}}
+
+{{< hint type=note >}}
+
+If any of these queries don't return any results, it means that no module in the selected category is looking for an owner or contributor at the moment.
 
 {{< /hint >}}
 

--- a/docs/content/indexes/_index.md
+++ b/docs/content/indexes/_index.md
@@ -4,7 +4,7 @@ geekdocNav: true
 geekdocAlign: left
 geekdocAnchor: true
 ---
-
+<!--
 This section lists all Azure Verified Modules that are available or planned in **Bicep and/or Terraform languages**.
 
 - [Bicep](/Azure-Verified-Modules/indexes/bicep)
@@ -18,8 +18,22 @@ This section lists all Azure Verified Modules that are available or planned in *
 
 ---
 
-<br>
+<br> -->
 
-The following table shows the number of all available, orphaned and planned **AVM Modules**.
+The following table shows the number of all available, orphaned and planned **AVM Bicep and Terraform Modules**.
 
 {{< moduleStats language="All" moduleType="All" showLanguage=true showClassification=true >}}
+
+<br>
+
+{{< hint type=tip title="Want to contribute to AVM modules?" >}}
+
+| #  | Labels | Link and description |
+| -------- | -------- | -------- |
+| 1.   | <mark style="background-color:#ADD8E6;">Type: New Module Proposal 💡</mark> <mark style="background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark> | To become the **owner of a new module**, see [all new modules looking for owners](https://aka.ms/AVM/NeedsModuleOwner) or check out the "*Looking for owners*" swimlane [here](https://aka.ms/AVM/NeedsModuleOwner/Project).   |
+| 2.   | <mark style="background-color:#F4A460;">Status: Module Orphaned 👀</mark>    | To become the **owner of an orphaned module**, see [all orphaned modules](https://aka.ms/AVM/OrphanedModules) or check out the "*Orphaned*" swimlane [here](https://aka.ms/AVM/OrphanedModules/Project).   |
+| 3.   | <mark style="background-color:#C95474;color:white;">Needs: Module Contributor 📣</mark>  | To become a **co-owner or contribute to a module**, see [all modules looking for contributors](https://aka.ms/AVM/NeedsModuleContributor). |
+
+For more details on "**What are the different ways to contribute to AVM?**", see [here](/Azure-Verified-Modules/faq/#are-there-different-ways-to-contribute-to-avm).
+
+{{< /hint >}}

--- a/docs/content/indexes/bicep/_index.md
+++ b/docs/content/indexes/bicep/_index.md
@@ -6,7 +6,7 @@ geekdocAnchor: true
 geekdocCollapseSection: true
 ---
 
-This section lists all Azure Verified Modules that are available in or planned for the **Bicep language**.
+<!-- This section lists all Azure Verified Modules that are available in or planned for the **Bicep language**.
 
 - [Resource Modules](/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules)
 - [Pattern Modules](/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules)
@@ -14,11 +14,25 @@ This section lists all Azure Verified Modules that are available in or planned f
 
 ---
 
-<br>
+<br> -->
 
 The following table shows the number of all available, orphaned and planned **Bicep Modules**.
 
 {{< moduleStats language="Bicep" moduleType="All" showLanguage=true showClassification=true >}}
+
+<br>
+
+{{< hint type=tip title="Want to contribute to AVM Bicep modules?" >}}
+
+| #  | Labels | Link and description |
+| -------- | -------- | -------- |
+| 1.   | <mark style="background-color:#ADD8E6;">Type: New Module Proposal 💡</mark> <mark style="background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark> <br> <mark style="background-color:#1D73B3;color:white;">Language: Bicep 💪</mark>  | To become the **owner of a new Bicep module**, see [all new Bicep modules looking for owners](https://aka.ms/AVM/Bicep/NeedsModuleOwner) or check out the "*Looking for owners*" swimlane [here](https://aka.ms/AVM/Bicep/NeedsModuleOwner/Project). |
+| 2.   | <mark style="background-color:#F4A460;">Status: Module Orphaned 👀</mark> <mark style="background-color:#1D73B3;color:white;">Language: Bicep 💪</mark>   | To become the **owner of an orphaned Bicep module**, see [all orphaned Bicep modules](https://aka.ms/AVM/Bicep/OrphanedModules) or check out the "*Orphaned*" swimlane [here](https://aka.ms/AVM/Bicep/OrphanedModules/Project).   |
+| 3.   | <mark style="background-color:#C95474;color:white;">Needs: Module Contributor 📣</mark> <mark style="background-color:#1D73B3;color:white;">Language: Bicep 💪</mark> | To become a **co-owner or contribute to a Bicep module**, see [all Bicep modules looking for contributors](https://aka.ms/AVM/Bicep/NeedsModuleContributor). |
+
+For more details on "**What are the different ways to contribute to AVM?**", see [here](/Azure-Verified-Modules/faq/#are-there-different-ways-to-contribute-to-avm).
+
+{{< /hint >}}
 
 <br>
 

--- a/docs/content/indexes/terraform/_index.md
+++ b/docs/content/indexes/terraform/_index.md
@@ -6,7 +6,7 @@ geekdocAnchor: true
 geekdocCollapseSection: true
 ---
 
-This section lists all Azure Verified Modules that are available in or planned for the **Terraform language**.
+<!-- This section lists all Azure Verified Modules that are available in or planned for the **Terraform language**.
 
 - [Resource Modules](/Azure-Verified-Modules/indexes/terraform/tf-resource-modules)
 - [Pattern Modules](/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules)
@@ -14,8 +14,22 @@ This section lists all Azure Verified Modules that are available in or planned f
 
 ---
 
-<br>
+<br> -->
 
 The following table shows the number of all available, orphaned and planned **Terraform Modules**.
 
 {{< moduleStats language="Terraform" moduleType="All" showLanguage=true showClassification=true >}}
+
+<br>
+
+{{< hint type=tip title="Want to contribute to AVM Terraform modules?" >}}
+
+| #  | Labels | Link and description |
+| -------- | -------- | -------- |
+| 1.   | <mark style="background-color:#ADD8E6;">Type: New Module Proposal 💡</mark> <mark style="background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark> <br> <mark style="background-color:#7740B6;color:white;">Language: Terraform 🌐</mark>  | To become the **owner of a new Terraform module**, see [all new Terraform modules looking for owners](https://aka.ms/AVM/TF/NeedsModuleOwner) or check out the "*Looking for owners*" swimlane [here](https://aka.ms/AVM/TF/NeedsModuleOwner/Project).   |
+| 2.   | <mark style="background-color:#F4A460;">Status: Module Orphaned 👀</mark> <mark style="background-color:#7740B6;color:white;">Language: Terraform 🌐</mark>   | To become the **owner of an orphaned Terraform module**, see [all orphaned Terraform modules](https://aka.ms/AVM/TF/OrphanedModules) or check out the "*Orphaned*" swimlane [here](https://aka.ms/AVM/TF/OrphanedModules/Project).   |
+| 3.   | <mark style="background-color:#C95474;color:white;">Needs: Module Contributor 📣</mark> <mark style="background-color:#7740B6;color:white;">Language: Terraform 🌐</mark> | To become a **co-owner or contribute to a Terraform module**, see [all Terraform modules looking for contributors](https://aka.ms/AVM/TF/NeedsModuleContributor). |
+
+For more details on "**What are the different ways to contribute to AVM?**", see [here](/Azure-Verified-Modules/faq/#are-there-different-ways-to-contribute-to-avm).
+
+{{< /hint >}}

--- a/docs/static/governance/avm-standard-github-labels.csv
+++ b/docs/static/governance/avm-standard-github-labels.csv
@@ -7,6 +7,7 @@ Needs: External Changes :hammer_and_pick:,When an issue/PR requires changes that
 Needs: More Evidence :balance_scale:,We are looking for more evidence to make a decision on this,F64872
 Needs: Triage :mag:,Maintainers need to triage still,FBCA04
 Needs: Module Owner :mega:,This module needs an owner to develop or maintain it,FF0019
+Needs: Module Contributor :mega:,This module needs secondary owner(s) or contributor(s) to develop or maintain it,C95474
 Needs: Core Team :genie:,This item needs the AVM Core Team to review it,DB4503
 Status: Awaiting Release To Be Cut :scissors:,"This is fixed in the main branch but not in the latest release, will be fixed with next release cut",800080
 Status: Do Not Merge :no_entry:,Do not merge PRs with this label attached as they are not ready or aligned to future direction etc.,8B4513


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This PR updates index pages with links to modules needing owners or contributors.

## This PR fixes/adds/changes/removes

1. Updates stored GH issue queries to vanity links.
2. Adds TIP boxes to the module index pages (root, Bicep, TF) with links to module that need an owner or contributor.
3. Introduces the "Needs: Module Contributor" label

![image](https://github.com/Azure/Azure-Verified-Modules/assets/22733424/92ea7b91-2083-44e9-a50d-c73b55bc7bc1)


## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
