### PR TITLE
adding guidance for using the needs core team label

### DIFF
--- a/docs/content/contributing/bicep/bicep-contribution-flow/_index.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/_index.md
@@ -321,6 +321,12 @@ Finally, once you are satisfied with your contribution and validated it, open a 
 
     <img src="../../../img/contribution/pipelineBadge.png" alt="Status Badge" height="400">
 
+{{< hint type=note >}}
+
+If you're the **sole owner of the module**, the **AVM core team must review and approve the PR**. To indicate that your PR needs the core team's attention, **apply the** "<mark style="background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>" **label on it!**
+
+{{< /hint >}}
+
 <!--
 ## Publishing to the Registry
 

--- a/docs/content/contributing/bicep/bicep-contribution-flow/owner-contribution-flow.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/owner-contribution-flow.md
@@ -52,6 +52,11 @@ Once the teams have been created the AVM Core Team will review the team name and
 
 2. Add teams to `CODEOWNERS` file as outlined in [SNFR20](/Azure-Verified-Modules/specs/shared/#id-snfr20---category-contributionsupport---github-teams-only).
 3. Ensure your module has been tested before raising a PR. You can do this your own or in another module contributor's environment - if any. Also, once a PR is raised, a GitHub workflow pipeline is required to be run successfully before the PR can be merged. This is to ensure that the module is working as expected and is compliant with the AVM specifications.
+{{< hint type=note >}}
+
+If you're the **sole owner of the module**, the **AVM core team must review and approve the PR**. To indicate that your PR needs the core team's attention, **apply the** "<mark style="background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>" **label on it!**
+
+{{< /hint >}}
 4. Ensure that the module(s) you own are compliant with the AVM specifications and are working as expected. While all specifications are to be followed, pay special attention to the following ones as in these, the `Owner` is mentioned explicitly:
 | ID | Specification
 |---------------|-----------------------|
@@ -172,5 +177,11 @@ This checklist can be used in the development of AVM Bicep Modules.
     {{< /expand >}}
 
 7. Create a PR and reference the status badge of your pipeline run - [see here](/Azure-Verified-Modules/contributing/bicep/bicep-contribution-flow/#6-create-a-pull-request-to-the-public-bicep-registry).
+{{< hint type=note >}}
+
+If you're the **sole owner of the module**, the **AVM core team must review and approve the PR**. To indicate that your PR needs the core team's attention, **apply the** "<mark style="background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>" **label on it!**
+
+{{< /hint >}}
+
 8. After a pull request has been created, it is important to update the [AVM module proposal](https://aka.ms/AVM/ModuleProposals) issue associated with your module, with a link to the pull request you created in BRM and mention the person who helped triage your module or the `@Azure/avm-core-team-technical-bicep` team.
 9. Once your BRM pull request has been approved and merged into main update the [AVM module proposal](https://aka.ms/AVM/ModuleProposals) issue associated with your module, with a **Merged** comment and mention the person who helped triage your module, or the `@Azure/avm-core-team-technical-bicep` team.

--- a/docs/content/contributing/bicep/bicep-contribution-flow/owner-contribution-flow.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/owner-contribution-flow.md
@@ -140,11 +140,11 @@ GitHub will use the following email addresses to Cc you if you're subscribed to 
 
 | Type of Notification | GitHub Email Address | Notification Reason |
 | --- | --- | --- |
-| @Mentions | mention@noreply.github.com | You were mentioned on an issue or pull request. |
-| @Team Mention | team_mention@noreply.github.com | A team you belong to was mentioned on an issue or pull request |
-| Subscribed | subscribed@noreply.github.com | There was an update in a repository you're watching. |
-| Assign | assign@noreply.github.com | You were assigned to an issue or pull request. |
-| Comment | comment@noreply.github.com | You commented on an issue or pull request. |
+| @Mentions | <mention@noreply.github.com> | You were mentioned on an issue or pull request. |
+| @Team Mention | <team_mention@noreply.github.com> | A team you belong to was mentioned on an issue or pull request |
+| Subscribed | <subscribed@noreply.github.com> | There was an update in a repository you're watching. |
+| Assign | <assign@noreply.github.com> | You were assigned to an issue or pull request. |
+| Comment | <comment@noreply.github.com> | You commented on an issue or pull request. |
 
 For a full list of GitHub notification types, see [Filtering Email Notifications](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#filtering-email-notifications).
 

--- a/docs/content/contributing/bicep/bicep-contribution-flow/owner-contribution-flow.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/owner-contribution-flow.md
@@ -58,7 +58,7 @@ If you're the **sole owner of the module**, the **AVM core team must review and 
 
 {{< /hint >}}
 4. Ensure that the module(s) you own are compliant with the AVM specifications and are working as expected. While all specifications are to be followed, pay special attention to the following ones as in these, the `Owner` is mentioned explicitly:
-| ID | Specification
+| ID | Specification |
 |---------------|-----------------------|
 | [SFR1](/Azure-Verified-Modules/specs/shared/#id-sfr1---category-composition---preview-services) | Composition - Preview Services |
 | [SNFR2](/Azure-Verified-Modules/specs/shared/#id-snfr2---category-testing---e2e-testing) | Testing - E2E Testing |
@@ -76,7 +76,7 @@ If you're the **sole owner of the module**, the **AVM core team must review and 
 | [RMFR7](/Azure-Verified-Modules/specs/shared/#id-rmfr7---category-outputs---minimum-required-outputs) | Outputs - Minimum Required Outputs |
 
 5. Watch Pull Request (PR) activity for your module(s) in the [BRM](https://github.com/Azure/bicep-registry-modules) repository (Bicep Registry Modules repository - where all Bicep AVM modules are published) and ensure that PRs are reviewed and merged in a timely manner as outlined in [SNFR11](/Azure-Verified-Modules/specs/shared/#id-snfr11---category-contributionsupport---issues-response-times).
-6å. Watch AVM module issue and AVM question/feedback activity for your module(s) in the [BRM](https://github.com/Azure/bicep-registry-modules) repository.
+6. Watch AVM module issue and AVM question/feedback activity for your module(s) in the [BRM](https://github.com/Azure/bicep-registry-modules) repository.
 
 ---
 
@@ -139,7 +139,7 @@ GitHub will use the following email addresses to Cc you if you're subscribed to 
 {{< /hint >}}
 
 | Type of Notification | GitHub Email Address | Notification Reason |
-|-|-|-|
+| --- | --- | --- |
 | @Mentions | mention@noreply.github.com | You were mentioned on an issue or pull request. |
 | @Team Mention | team_mention@noreply.github.com | A team you belong to was mentioned on an issue or pull request |
 | Subscribed | subscribed@noreply.github.com | There was an update in a repository you're watching. |

--- a/docs/content/help-support/issue-triage/brm-issue-triage.md
+++ b/docs/content/help-support/issue-triage/brm-issue-triage.md
@@ -81,6 +81,28 @@ If the issue was opened as a misplaced module proposal, mention the `@Azure/AVM-
 
 <br>
 
+### Triaging a Module PR
+
+1. If the **PR is submitted by the module owner** and the **module is owned by a single person**, **the AVM core team must review and approve the PR**, (as the module owner can't approve their on PR).
+    - To indicate that the PR needs the core team's attention, apply the "<mark style="background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>" label.
+2. If the **PR is submitted by a contributor** (other than the module owner), or the **module is owned by at least 2 people**, **one of the module owners should review and approve the PR**.
+3. Apply relevant labels
+    - Make sure the PR is categorized using one of the following type labels:
+      - "<mark style="background-color:#A2EEEF;">Type: Feature Request ➕</mark>"
+      - "<mark style="background-color:#D73A4A;color:white;">Type: Bug 🐛</mark>"
+      - "<mark style="background-color:#FFFF00;">Type: Security Bug 🔒</mark>"
+    - For module classification (resource/pattern): "<mark style="background-color:#D3D3D3;">Class: Resource Module 📦</mark>" or "<mark style="background-color:#A9A9A9;">Class: Pattern Module 📦</mark>"
+4. If the module is orphaned (has no owner), make sure the related Orphaned module issue (in the AVM repository) is associated to the PR in a comment, so the new owner can easily identify all related issues and PRs when taking ownership.
+5. Remove the "<mark style="background-color:#FBCA04;">Needs: Triage 🔍</mark>" label.
+
+{{< hint type=tip title="Give your PR a meaningful title" >}}
+
+- **Prefix**: Start with one of the allowed keywords - `fix:` or `feat:` is the most common for module related changes.
+- **Description**: Add a few words, describing the nature of the change.
+- **Module name**: Add the module's full name between backticks ( ` ) to make it pop.
+
+{{< /hint >}}
+
 ## General Question/Feedback and other standard issues
 
 An issue is considered to be an "AVM Question/Feedback" if

--- a/docs/content/help-support/issue-triage/issue-triage-automation.md
+++ b/docs/content/help-support/issue-triage/issue-triage-automation.md
@@ -592,6 +592,20 @@ Remove the "<mark style="background-color:#EDEDED;">Status: In PR 👉</mark>" l
 
 ---
 
+### ITA25
+
+Inform module owners that they need to add the "<mark style="background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>" label to their PR if they're the sole owner of their module.
+
+**Trigger criteria:**
+
+- A PR is opened.
+
+**Action(s):**
+
+Inform module owners that they need to add the "<mark style="background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>" label to their PR if they're the sole owner of their module.
+
+---
+
 ## Where to apply these rules?
 
 The below table details which repositories the above rules are applied to.
@@ -631,3 +645,4 @@ The below table details which repositories the above rules are applied to.
 | [ITA21](#ita21)             |                     |       ✔️       |        ✔️       |
 | [ITA22](#ita22)             |                     |       ✔️       |        ✔️       |
 | [ITA23](#ita23)             |          ✔️         |                |        ✔️       |
+| [ITA25](#ita25)             |                    |        ✔️        |               |


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This PR adds guidance as to how to use the "needs core team" label in BRM PRs.

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
