### PR TITLE
Fix Bicep Module Latest Version Display Ordering

### DIFF
--- a/.github/workflows/hugo-build-pr-check.yml
+++ b/.github/workflows/hugo-build-pr-check.yml
@@ -24,7 +24,7 @@ jobs:
   buildpr:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.124.1
+      HUGO_VERSION: 0.128.2
     steps:
       - name: Install Hugo CLI
         run: |
@@ -56,5 +56,6 @@ jobs:
           hugo \
             --gc \
             --minify \
+            --ignoreCache \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
         working-directory: ./docs

--- a/.github/workflows/hugo-site-build.yml
+++ b/.github/workflows/hugo-site-build.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.124.1
+      HUGO_VERSION: 0.128.2
     steps:
       - name: Install Hugo CLI
         run: |
@@ -67,6 +67,7 @@ jobs:
           hugo \
             --gc \
             --minify \
+            --ignoreCache \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
         working-directory: ./docs
 

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -124,14 +124,35 @@
   </thead>
   {{ end }}
   {{ range $item, $maps }}
-  {{ if not ( in $exclude $item.ModuleStatus ) }}
+  {{ if not (in $exclude $item.ModuleStatus) }}
     {{ $moduleLatestVersion = "N/A" }}
     {{ if or (eq $item.ModuleStatus "Available :green_circle:") (eq $item.ModuleStatus "Orphaned :eyes:") }}
       {{ $moduleMcrUrl := printf "https://mcr.microsoft.com/v2/bicep/%s/tags/list" $item.ModuleName }}
       {{ $moduleMcrData := getJSON $moduleMcrUrl }}
       {{ $moduleVersions := $moduleMcrData.tags }}
       {{ if $moduleVersions }}
-          {{ $moduleLatestVersion = index $moduleVersions (sub (len $moduleVersions) 1) }}
+        {{/* Initialize $sortedVersions as an empty slice */}}
+        {{ $sortedVersions := slice }}
+        {{ range $moduleVersions }}
+          {{ $parts := split . "." }}
+          {{ $major := printf "%03d" (index $parts 0 | int) }}
+          {{ $minor := printf "%03d" (index $parts 1 | int) }}
+          {{ $patch := printf "%03d" (index $parts 2 | int) }}
+          {{ $sortableVersion := print $major $minor $patch }}
+          {{ $sortedVersions = $sortedVersions | append (dict "sortableVersion" $sortableVersion "originalVersion" .) }}
+        {{ end }}
+
+        {{/* Sort by the sortableVersion field */}}
+        {{ $sortedVersions = sort $sortedVersions "sortableVersion" }}
+
+        {{/* Extract the original versions in sorted order */}}
+        {{ $originalSortedVersions := slice }}
+        {{ range $sortedVersions }}
+          {{ $originalSortedVersions = $originalSortedVersions | append .originalVersion }}
+        {{ end }}
+
+        {{/* Set $moduleLatestVersion to the first element of $sortedSemVers, which is the latest version */}}
+        {{ $moduleLatestVersion = index $originalSortedVersions (sub (len $originalSortedVersions) 1) }}
       {{ end }}
     {{ end }}
     {{ $trimmedModuleStatus := replace $item.ModuleStatus "Module " "" }}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixes the bicep modules latest version feature we added to ensure it always shows the latest version and not just relying on ordering of the module tags array from the MCR API, as this does not order them correctly (unlike the terraform registry - hence no changes needed for terraform)

## This PR fixes/adds/changes/removes

1. Fixes #1181

### Breaking Changes

None, just docs

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
