### PR TITLE
Feat/matebarabas/update-index-summary-tables

### DIFF
--- a/docs/layouts/partials/countModules.html
+++ b/docs/layouts/partials/countModules.html
@@ -1,0 +1,14 @@
+{{ $params := . }}
+{{ $ModuleStatusColumnId := index $params 0 }}
+{{ $rows := index $params 1 }}
+{{ $moduleStatusToCount := index $params 2 }}
+{{ $moduleCount := 0 }}
+{{ if eq $moduleStatusToCount "All" }}
+  {{ $moduleCount = sub (len $rows) 1 }}
+{{ end }}
+{{ range $row, $rows }}
+  {{ if eq (index $row $ModuleStatusColumnId) $moduleStatusToCount }}
+    {{ $moduleCount = add $moduleCount 1 }}
+  {{ end }}
+{{ end }}
+{{ return $moduleCount }}

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -119,7 +119,7 @@
       <th>Module Name</th>
       <th>Display Name</th>
       <th>Status & Versions</th>
-      <th>Primary Owner</th>
+      <th>Owner(s)</th>
     </tr>
   </thead>
   {{ end }}
@@ -161,7 +161,7 @@
     <td>{{ if $useLinks }} {{ if or (eq $item.ModuleStatus "Available :green_circle:") (eq $item.ModuleStatus "Orphaned :eyes:") }} <a href="{{ $item.RepoURL }}">{{ $item.ModuleName }}</a> {{ else }} {{ $item.ModuleName }} {{ end }} {{else}} {{ $item.ModuleName }} {{ end }} </td>
     <td>{{ $item.ModuleDisplayName }}</td>
     <td>{{ if or (eq $item.ModuleStatus "Available :green_circle:") (eq $item.ModuleStatus "Orphaned :eyes:") }}<a href="https://mcr.microsoft.com/v2/bicep/{{ $item.ModuleName }}/tags/list"><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-blue"/></a> {{ else }} <a href=""><image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-N/A-blue"/></a> {{ end }}</td>
-    <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
+    <td>{{ if ne $item.PrimaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.PrimaryModuleOwnerGHHandle }}">{{ $item.PrimaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") }} <br> ({{ $item.PrimaryModuleOwnerDisplayName }}) {{ end }} {{ end}} <br> {{ if ne $item.SecondaryModuleOwnerGHHandle ""}}<a href="https://github.com/{{ $item.SecondaryModuleOwnerGHHandle }}">{{ $item.SecondaryModuleOwnerGHHandle }}</a> {{ if and (ne $item.SecondaryModuleOwnerGHHandle "") (ne $item.SecondaryModuleOwnerDisplayName "") }} <br> ({{ $item.SecondaryModuleOwnerDisplayName }}) {{ end }} {{ end}}</td>
   </tr>
   {{ $hasModulesAvailable = true }}
   {{ end }}

--- a/docs/layouts/shortcodes/moduleStats.html
+++ b/docs/layouts/shortcodes/moduleStats.html
@@ -19,30 +19,12 @@
 
 {{ $ModuleStatusColumnId := 0 }}
 
-{{ define "countModules" }}
-  {{ $params := . }}
-  {{ $ModuleStatusColumnId := index $params 0 }}
-  {{ $rows := index $params 1 }}
-  {{ $moduleStatusToCount := index $params 2 }}
-  {{ $moduleCount := 0 }}
-  {{ if eq $moduleStatusToCount "All" }}
-    {{ $moduleCount = sub (len $rows) 1 }}
-  {{ end }}
-  {{ range $row, $rows }}
-    {{ if eq (index $row $ModuleStatusColumnId) $moduleStatusToCount }}
-      {{ $moduleCount = add $moduleCount 1 }}
-    {{ end }}
-  {{ end }}
-  {{ printf "%d" $moduleCount }}
-{{ end }}
-
 <table>
 <thead>
   <tr>
     {{ if $showLanguage }}<th>Language</th>{{ end }}
     {{ if $showClassification }}<th>Classification</th>{{ end }}
-    <th align="right">{{ emojify ("Available :green_circle:") }}</th>
-    <th align="right">{{ emojify ("Orphaned :eyes:") }}</th>
+    <th align="right">{{ emojify ("Published :green_circle: & :eyes:") }}</th>
     <th align="right">{{ emojify ("Proposed :new:") }}</th>
     <th align="right">SUM 📇</th>
   </tr>
@@ -53,10 +35,9 @@
 <tr>
   {{ if $showLanguage }}<td rowspan="3"><a href="/Azure-Verified-Modules/indexes/bicep/" style="color: inherit; text-decoration: none; background-color: transparent;">Bicep</a></td>{{ end }}
   {{ if $showClassification }}<td><a href="/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/" style="color: inherit; text-decoration: none; background-color: transparent;">Resource</a></td>{{ end }}
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Available :green_circle:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Orphaned :eyes:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/#proposed-modules---" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "Proposed :new:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/#all-modules---" style="color: inherit; text-decoration: none; background-color: transparent; font-weight: bold">{{ template "countModules" (slice $ModuleStatusColumnId $bicepResRows "All") }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ add (partial "countModules" (slice $ModuleStatusColumnId $bicepResRows "Available :green_circle:")) (partial "countModules" (slice $ModuleStatusColumnId $bicepResRows "Orphaned :eyes:")) }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/#proposed-modules---" style="color: inherit; text-decoration: none; background-color: transparent;">{{ partial "countModules" (slice $ModuleStatusColumnId $bicepResRows "Proposed :new:") }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-resource-modules/#all-modules---" style="color: inherit; text-decoration: none; background-color: transparent; font-weight: bold">{{ partial "countModules" (slice $ModuleStatusColumnId $bicepResRows "All") }}</a></td>
 </tr>
 {{ end }}
 {{ if in (slice "Pattern" "All") $moduleType }}
@@ -64,10 +45,9 @@
 <tr>
   {{ if and (eq $moduleType "Pattern") $showLanguage }}<td><a href="/Azure-Verified-Modules/indexes/bicep/" style="color: inherit; text-decoration: none; background-color: transparent;">Bicep</a></td>{{ end }}
   {{ if $showClassification }}<td><a href="/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/" style="color: inherit; text-decoration: none; background-color: transparent;">Pattern</a></td>{{ end }}
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Available :green_circle:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Orphaned :eyes:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/#proposed-modules---" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Proposed :new:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/#all-modules---" style="color: inherit; text-decoration: none; background-color: transparent; font-weight: bold">{{ template "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "All") }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ add (partial "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Available :green_circle:")) (partial "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Orphaned :eyes:")) }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/#proposed-modules---" style="color: inherit; text-decoration: none; background-color: transparent;">{{ partial "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "Proposed :new:") }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-pattern-modules/#all-modules---" style="color: inherit; text-decoration: none; background-color: transparent; font-weight: bold">{{ partial "countModules" (slice $ModuleStatusColumnId $bicepPtnRows "All") }}</a></td>
 </tr>
 {{ end }}
 {{ if in (slice "Utility" "All") $moduleType }}
@@ -75,10 +55,9 @@
 <tr>
   {{ if and (eq $moduleType "Utility") $showLanguage }}<td><a href="/Azure-Verified-Modules/indexes/bicep/" style="color: inherit; text-decoration: none; background-color: transparent;">Bicep</a></td>{{ end }}
   {{ if $showClassification }}<td><a href="/Azure-Verified-Modules/indexes/bicep/bicep-utility-modules/" style="color: inherit; text-decoration: none; background-color: transparent;">Utility</a></td>{{ end }}
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-utility-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $bicepUtlRows "Available :green_circle:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-utility-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $bicepUtlRows "Orphaned :eyes:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-utility-modules/#proposed-modules---" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $bicepUtlRows "Proposed :new:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-utility-modules/#all-modules---" style="color: inherit; text-decoration: none; background-color: transparent; font-weight: bold">{{ template "countModules" (slice $ModuleStatusColumnId $bicepUtlRows "All") }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-utility-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ add (partial "countModules" (slice $ModuleStatusColumnId $bicepUtlRows "Available :green_circle:")) (partial "countModules" (slice $ModuleStatusColumnId $bicepUtlRows "Orphaned :eyes:")) }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-utility-modules/#proposed-modules---" style="color: inherit; text-decoration: none; background-color: transparent;">{{ partial "countModules" (slice $ModuleStatusColumnId $bicepUtlRows "Proposed :new:") }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/bicep/bicep-utility-modules/#all-modules---" style="color: inherit; text-decoration: none; background-color: transparent; font-weight: bold">{{ partial "countModules" (slice $ModuleStatusColumnId $bicepUtlRows "All") }}</a></td>
 </tr>
 {{ end }}
 {{ end }}
@@ -88,10 +67,9 @@
 <tr>
   {{ if $showLanguage }}<td rowspan="3"><a href="/Azure-Verified-Modules/indexes/terraform/" style="color: inherit; text-decoration: none; background-color: transparent;">Terraform</a></td>{{ end }}
   {{ if $showClassification }}<td><a href="/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/" style="color: inherit; text-decoration: none; background-color: transparent;">Resource</a></td>{{ end }}
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Available :green_circle:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Orphaned :eyes:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/#proposed-modules---" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "Proposed :new:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/#all-modules---" style="color: inherit; text-decoration: none; background-color: transparent; font-weight: bold">{{ template "countModules" (slice $ModuleStatusColumnId $tfResRows "All") }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ add (partial "countModules" (slice $ModuleStatusColumnId $tfResRows "Available :green_circle:")) (partial "countModules" (slice $ModuleStatusColumnId $tfResRows "Orphaned :eyes:")) }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/#proposed-modules---" style="color: inherit; text-decoration: none; background-color: transparent;">{{ partial "countModules" (slice $ModuleStatusColumnId $tfResRows "Proposed :new:") }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-resource-modules/#all-modules---" style="color: inherit; text-decoration: none; background-color: transparent; font-weight: bold">{{ partial "countModules" (slice $ModuleStatusColumnId $tfResRows "All") }}</a></td>
 </tr>
 {{ end }}
 {{ if in (slice "Pattern" "All") $moduleType }}
@@ -99,10 +77,9 @@
 <tr>
   {{ if and (eq $moduleType "Pattern") $showLanguage }}<td><a href="/Azure-Verified-Modules/indexes/terraform/" style="color: inherit; text-decoration: none; background-color: transparent;">Terraform</a></td>{{ end }}
   {{ if $showClassification }}<td><a href="/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/" style="color: inherit; text-decoration: none; background-color: transparent;">Pattern</a></td>{{ end }}
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Available :green_circle:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Orphaned :eyes:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/#proposed-modules---" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Proposed :new:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/#all-modules---" style="color: inherit; text-decoration: none; background-color: transparent; font-weight: bold">{{ template "countModules" (slice $ModuleStatusColumnId $tfPtnRows "All") }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ add (partial "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Available :green_circle:")) (partial "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Orphaned :eyes:")) }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/#proposed-modules---" style="color: inherit; text-decoration: none; background-color: transparent;">{{ partial "countModules" (slice $ModuleStatusColumnId $tfPtnRows "Proposed :new:") }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-pattern-modules/#all-modules---" style="color: inherit; text-decoration: none; background-color: transparent; font-weight: bold">{{ partial "countModules" (slice $ModuleStatusColumnId $tfPtnRows "All") }}</a></td>
 </tr>
 {{ end }}
 {{ if in (slice "Utility" "All") $moduleType }}
@@ -110,10 +87,9 @@
 <tr>
   {{ if and (eq $moduleType "Utility") $showLanguage }}<td><a href="/Azure-Verified-Modules/indexes/terraform/" style="color: inherit; text-decoration: none; background-color: transparent;">Terraform</a></td>{{ end }}
   {{ if $showClassification }}<td><a href="/Azure-Verified-Modules/indexes/terraform/tf-utility-modules/" style="color: inherit; text-decoration: none; background-color: transparent;">Utility</a></td>{{ end }}
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-utility-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $tfUtlRows "Available :green_circle:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-utility-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $tfUtlRows "Orphaned :eyes:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-utility-modules/#proposed-modules---" style="color: inherit; text-decoration: none; background-color: transparent;">{{ template "countModules" (slice $ModuleStatusColumnId $tfUtlRows "Proposed :new:") }}</a></td>
-  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-utility-modules/#all-modules---" style="color: inherit; text-decoration: none; background-color: transparent; font-weight: bold">{{ template "countModules" (slice $ModuleStatusColumnId $tfUtlRows "All") }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-utility-modules/#published-modules-----" style="color: inherit; text-decoration: none; background-color: transparent;">{{ add (partial "countModules" (slice $ModuleStatusColumnId $tfUtlRows "Available :green_circle:")) (partial "countModules" (slice $ModuleStatusColumnId $tfUtlRows "Orphaned :eyes:")) }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-utility-modules/#proposed-modules---" style="color: inherit; text-decoration: none; background-color: transparent;">{{ partial "countModules" (slice $ModuleStatusColumnId $tfUtlRows "Proposed :new:") }}</a></td>
+  <td align="right"><a href="/Azure-Verified-Modules/indexes/terraform/tf-utility-modules/#all-modules---" style="color: inherit; text-decoration: none; background-color: transparent; font-weight: bold">{{ partial "countModules" (slice $ModuleStatusColumnId $tfUtlRows "All") }}</a></td>
 </tr>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This PR updates the rendered module index tables across all Bicep and TF pages.

## This PR fixes/adds/changes/removes

### 1. Module stats

Combining the columns of available and orphaned modules into a single column of published modules.

**New look:**
![image](https://github.com/user-attachments/assets/5330b48c-c53b-4557-821f-b3f648ba1fd5)

**Old look:**
![image](https://github.com/user-attachments/assets/9644ecd8-be27-46cd-9e2e-5448d0e8d985)

### 2. Index tables

Showing the GH handle and name of secondary module owners along with primary module owners

**New look:** 
![image](https://github.com/user-attachments/assets/8a894510-5389-46e8-831b-630e047c9181)

**Old look:**
![image](https://github.com/user-attachments/assets/c8cbbe14-16b0-4b7a-a941-d0b9fe31962b)

### Breaking Changes

- We'll no longer show stats for "Available" and "Orphaned" modules separately.

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
