### PR TITLE
fix: Update links to brm `utilities` folder

### DIFF
--- a/docs/content/contributing/bicep/bicep-contribution-flow/_index.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/_index.md
@@ -322,7 +322,7 @@ To get started implementing your test in the `main.test.bicep` file, we recommen
 
   {{< hint type=tip >}}
 
-  📜 [Example of test file](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utilities/tools/helper/src/src.main.test.bicep)
+  📜 [Example of test file](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/helper/src/src.main.test.bicep)
 
   {{< /hint >}}
 
@@ -349,11 +349,11 @@ Dependency file (`dependencies.bicep`) guidelines:
 
 ### Reusable assets
 
-There are a number of additional scripts and utilities available [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utilities/e2e-template-assets) that may be of use to module owners/contributors. These contain both scripts and Bicep templates that you can re-use in your test files (e.g., to deploy standadized dependencies, or to generate keys using deployment scripts).
+There are a number of additional scripts and utilities available [here](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/e2e-template-assets) that may be of use to module owners/contributors. These contain both scripts and Bicep templates that you can re-use in your test files (e.g., to deploy standadized dependencies, or to generate keys using deployment scripts).
 
 <u><b>Example:</b> Certificate creation script</u>
 
-If you need a Deployment Script to set additional non-template resources up (for example certificates/files, etc.), we recommend to store it as a file in the shared `avm/utilities/e2e-template-assets/scripts` folder and load it using the template function `loadTextContent()` (for example: `scriptContent: loadTextContent('../../../../../../utilities/e2e-template-assets/scripts/New-SSHKey.ps1')`). This approach makes it easier to test & validate the logic and further allows reusing the same logic across multiple test cases.
+If you need a Deployment Script to set additional non-template resources up (for example certificates/files, etc.), we recommend to store it as a file in the shared `utilities/e2e-template-assets/scripts` folder and load it using the template function `loadTextContent()` (for example: `scriptContent: loadTextContent('../../../../../../utilities/e2e-template-assets/scripts/New-SSHKey.ps1')`). This approach makes it easier to test & validate the logic and further allows reusing the same logic across multiple test cases.
 
 <u><b>Example:</b> Diagnostic Settings dependencies</u>
 

--- a/docs/content/contributing/bicep/bicep-contribution-flow/enable-or-disable-workflows.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/enable-or-disable-workflows.md
@@ -19,7 +19,7 @@ To limit those workflow runs, you can manually disable each pipeline you do not 
 ---
 # Location
 
-You can find the script under [`avm/utilities/pipelines/platform/Switch-WorkflowState.ps1)`](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utilities/pipelines/platform/Switch-WorkflowState.ps1)
+You can find the script under [`utilities/pipelines/platform/Switch-WorkflowState.ps1)`](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/pipelines/platform/Switch-WorkflowState.ps1)
 You can find the workflow under [`.github/workflows/platform.toggle-avm-workflows.yml`](https://github.com/Azure/bicep-registry-modules/blob/main/.github/workflows/platform.toggle-avm-workflows.yml)
 
 # How it works

--- a/docs/content/contributing/bicep/bicep-contribution-flow/generate-bicep-module-files.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/generate-bicep-module-files.md
@@ -20,13 +20,13 @@ To ease maintenance, you can run the utility with a `Recurse` flag from the root
 ---
 # Location
 
-You can find the script under [`avm/utilities/tools/Set-AVMModule.ps1`](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utilities/tools/Set-AVMModule.ps1)
+You can find the script under [`utilities/tools/Set-AVMModule.ps1`](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1)
 
 # How it works
 
 Using the provided template path, the script
 1. validates the module's folder structure
-    - To do so, it searches for any required folder path / file missing and adds them. For several files, it will also provide some default content to get you started. The sources files for this action can be found [here](https://github.com/Azure/bicep-registry-modules/tree/main/avm/utilities/tools/helper/src)
+    - To do so, it searches for any required folder path / file missing and adds them. For several files, it will also provide some default content to get you started. The sources files for this action can be found [here](https://github.com/Azure/bicep-registry-modules/tree/main/utilities/tools/helper/src)
 1. compiles its bicep template
 1. updates the readme (recursively, specified)
     1. If the intended readMe file does not yet exist in the expected path, it is generated with a skeleton (with e.g., a generated header name)

--- a/docs/content/contributing/bicep/bicep-contribution-flow/validate-bicep-module-locally.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/validate-bicep-module-locally.md
@@ -11,7 +11,7 @@ Use this script to test a module from your PC locally, without a CI environment.
 ---
 # Location
 
-You can find the script under [`avm/utilities/tools/Test-ModuleLocally.ps1`](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utilities/tools/Test-ModuleLocally.ps1)
+You can find the script under [`utilities/tools/Test-ModuleLocally.ps1`](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Test-ModuleLocally.ps1)
 
 # How it works
 

--- a/docs/content/help-support/issue-triage/avm-issue-triage.md
+++ b/docs/content/help-support/issue-triage/avm-issue-triage.md
@@ -179,7 +179,7 @@ Once the **Orphaned Module issue** was closed, it **MUST remain closed**. If the
 5. Place an information notice as per the below guidelines:
     - In case of a Bicep module:
       - Place the information notice - with the text below - in an `ORPHANED.md` file, in the module's root.
-      - Run the [`avm/utilities/tools/Set-AVMModule.ps1`](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utilities/tools/Set-AVMModule.ps1) utility with the module path as an input. This re-generates the module’s `README.md` file, so that the `README.md` file will also contain the same notice in its header.
+      - Run the [`utilities/tools/Set-AVMModule.ps1`](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility with the module path as an input. This re-generates the module’s `README.md` file, so that the `README.md` file will also contain the same notice in its header.
       - Make sure the content of the `ORPHANED.md` file is displayed in the `README.md` in its header (right after the title).
     - In case of a Terraform module, place the information notice - with the text below - in the `README.md` file, in the module's root.
     - Once the information notice is placed, submit a Pull Request.
@@ -222,7 +222,7 @@ To look for Orphaned Modules:
 5. Remove the information notice (i.e., the file that states that `⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️, etc.` ):
     - In case of a Bicep module:
       - Delete the `ORPHANED.md` file from the module's root.
-      - Run the [`avm/utilities/tools/Set-AVMModule.ps1`](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utilities/tools/Set-AVMModule.ps1) utility with the module path as an input. This re-generates the module’s `README.md` file, so that it will no longer contain the orphaned module notice in its header.
+      - Run the [`utilities/tools/Set-AVMModule.ps1`](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility with the module path as an input. This re-generates the module’s `README.md` file, so that it will no longer contain the orphaned module notice in its header.
       - Double check the previous steps was successful and the `README.md` file no longer has the information notice in its header (right after the title).
     - In case of a Terraform module, remove the information notice from the `README.md` file in the module's root.
     - Once the information notice is removed, submit a Pull Request.

--- a/docs/content/specs-defs/includes/shared/shared/functional/SFR3.md
+++ b/docs/content/specs-defs/includes/shared/shared/functional/SFR3.md
@@ -39,7 +39,7 @@ To highlight that AVM modules use telemetry, an information notice **MUST** be i
 {{< hint type=note >}}
 The following information notice is automatically added at the bottom of the `README.md` file of the module when
 
-- **Bicep:** Using the [`avm/utilities/tools/Set-AVMModule.ps1`](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utilities/tools/Set-AVMModule.ps1) utility
+- **Bicep:** Using the [`utilities/tools/Set-AVMModule.ps1`](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility
 - **Terraform:** Executing the `make docs` command with the note and header `## Data Collection` being placed in the module's `_footer.md` beforehand
 {{< /hint >}}
 

--- a/docs/static/includes/avm.workflow.template.yml
+++ b/docs/static/includes/avm.workflow.template.yml
@@ -33,8 +33,8 @@ on:
       - ".github/workflows/avm.[res|ptn|utl].[provider-namespace].[resource-type].yml"
         # >>> UPDATE to for example "avm/res/key-vault/vault/**" and remove this comment
       - "avm/[res|ptn|utl]/[provider-namespace]/[resource-type]/**"
-      - "avm/utilities/pipelines/**"
-      - "!avm/utilities/pipelines/platform/**"
+      - "utilities/pipelines/**"
+      - "!utilities/pipelines/platform/**"
       - "!*/**/README.md"
 
 env:

--- a/docs/static/scripts/sample-localtest-helper.ps1
+++ b/docs/static/scripts/sample-localtest-helper.ps1
@@ -7,8 +7,8 @@ $folder = "<your directory>/bicep-registry-modules"
 
 # Dot source functions
 
-. $folder/avm/utilities/tools/Set-AVMModule.ps1
-. $folder/avm/utilities/tools/Test-ModuleLocally.ps1
+. $folder/utilities/tools/Set-AVMModule.ps1
+. $folder/utilities/tools/Test-ModuleLocally.ps1
 
 # Variables
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace `avm/utilities` occurrences with `utilities`. Fixes broken links.

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
