### PR TITLE
fix: fixes terraform pattern modules catalog

### DIFF
--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -313,7 +313,7 @@
     {{ $trimmedAlternativeNames = replace $trimmedAlternativeNames ", " "," }}
     {{ $trimmedAlternativeNames = replace $trimmedAlternativeNames "," ", " }}
   <tr>
-    {{- if  eq $item.ParentModule "n/a" -}}
+    {{- if or (eq $moduleType "pattern") (eq $moduleType "utility") (and (eq $moduleType "resource") (eq $item.ParentModule "n/a")) -}}
       <td style="text-align: right;"> {{/* row index */}}
         {{- printf "%02d" $i -}}
         {{- $i = add $i 1 -}}


### PR DESCRIPTION
# Overview/Summary

The Terraform Pattern module catalog does not show items.

## This PR fixes/adds/changes/removes

Closes #1804 

### Breaking Changes

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
