### PR TITLE
link fixes, toc and heading updates for specs

### DIFF
--- a/.github/linters/mlc_config.json
+++ b/.github/linters/mlc_config.json
@@ -36,7 +36,7 @@
       }
     }
   ],
-  "timeout": "10s",
+  "timeout": "20s",
   "retryOn429": true,
   "retryCount": 5,
   "fallbackRetryDelay": "30s",

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -51,14 +51,14 @@
             use-verbose-mode: "yes"
             use-quiet-mode: "yes"
 
-    check-links:
-      name: runner / linkspector
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
-        - name: Run linkspector
-          uses: umbrelladocs/action-linkspector@v1
-          with:
-            github_token: ${{ secrets.github_token }}
-            reporter: github-pr-review
-            fail_level: any
+    # check-links:
+    #   name: runner / linkspector
+    #   runs-on: ubuntu-latest
+    #   steps:
+    #     - uses: actions/checkout@v4
+    #     - name: Run linkspector
+    #       uses: umbrelladocs/action-linkspector@v1
+    #       with:
+    #         github_token: ${{ secrets.github_token }}
+    #         reporter: github-pr-review
+    #         fail_level: any

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -45,8 +45,20 @@
             fetch-depth: 0
 
         - name: Check links in markdown files
-          uses: gaurav-nelson/github-action-markdown-link-check@1.0.15
+          uses: gaurav-nelson/github-action-markdown-link-check@1.0.16
           with:
             config-file: ".github/linters/mlc_config.json"
             use-verbose-mode: "yes"
             use-quiet-mode: "yes"
+
+    check-links:
+      name: runner / linkspector
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - name: Run linkspector
+          uses: umbrelladocs/action-linkspector@v1
+          with:
+            github_token: ${{ secrets.github_token }}
+            reporter: github-pr-review
+            fail_level: any

--- a/docs/content/indexes/bicep/_index.md
+++ b/docs/content/indexes/bicep/_index.md
@@ -23,8 +23,6 @@ For more details on "**What are the different ways to contribute to AVM?**", see
 
 {{% /notice %}}
 
----
-
 ## Status Badges
 
 This section gives you an overview of the latest workflow status of each AVM module in the [Public Bicep Registry repository](https://github.com/Azure/bicep-registry-modules).

--- a/docs/content/indexes/bicep/bicep-pattern-modules.md
+++ b/docs/content/indexes/bicep/bicep-pattern-modules.md
@@ -5,6 +5,14 @@ linktitle: Pattern Modules
 weight: 2
 ---
 
+
+
+## Module catalog
+
+{{% moduleStats language="Bicep" moduleType="Pattern" showLanguage=true showClassification=true %}}
+
+{{% expand title="➕ Additional information" %}}
+
 {{% notice style="info" %}}
 
 This page contains various views of the module index (catalog) for **Bicep Pattern Modules**. To see these views, **click on the expandable sections** with the "➕" sign below.
@@ -15,27 +23,13 @@ This page contains various views of the module index (catalog) for **Bicep Patte
 
 {{% /notice %}}
 
-## Module catalog
-
 {{% notice style="note" %}}
 
 Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use. For proposed modules, see the [Proposed modules]({{% siteparam base %}}/indexes/bicep/bicep-pattern-modules/#proposed-modules---) section below.
 
 {{% /notice %}}
 
-The following table shows the number of all available, orphaned and proposed **Bicep Pattern Modules**.
-
-{{% moduleStats language="Bicep" moduleType="Pattern" showLanguage=true showClassification=true %}}
-
-### Module Publication History - 📅
-
-{{% expand title="➕ Module Publication History - Module names, status and owners" expanded="false" %}}
-
-{{% moduleHistory header=true csv="/static/module-indexes/BicepPatternModules.csv" language="Bicep" moduleType="pattern" exclude="Proposed :new:" monthsToShow=9999 %}}
-
 {{% /expand %}}
-
----
 
 ### Published modules - 🟢 & 👀
 
@@ -45,8 +39,6 @@ The following table shows the number of all available, orphaned and proposed **B
 
 {{% /expand %}}
 
----
-
 ### Proposed modules - 🆕
 
 {{% expand title="➕ Proposed Modules - Module names, status and owners" expanded="false" %}}
@@ -54,8 +46,6 @@ The following table shows the number of all available, orphaned and proposed **B
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/BicepPatternModules.csv" language="Bicep" moduleType="pattern" exclude="Available :green_circle:,Orphaned :eyes:" %}}
 
 {{% /expand %}}
-
----
 
 ### All modules - 📇
 
@@ -65,7 +55,13 @@ The following table shows the number of all available, orphaned and proposed **B
 
 {{% /expand %}}
 
----
+### Module Publication History - 📅
+
+{{% expand title="➕ Module Publication History - Module names, status and owners" expanded="false" %}}
+
+{{% moduleHistory header=true csv="/static/module-indexes/BicepPatternModules.csv" language="Bicep" moduleType="pattern" exclude="Proposed :new:" monthsToShow=9999 %}}
+
+{{% /expand %}}
 
 ## For Module Owners & Contributors
 

--- a/docs/content/indexes/bicep/bicep-resource-modules.md
+++ b/docs/content/indexes/bicep/bicep-resource-modules.md
@@ -5,6 +5,12 @@ linktitle: Resource Modules
 weight: 1
 ---
 
+## Module catalog
+
+{{% moduleStats language="Bicep" moduleType="Resource" showLanguage=true showClassification=true %}}
+
+{{% expand title="➕ Additional information" %}}
+
 {{% notice style="info" %}}
 
 This page contains various views of the module index (catalog) for **Bicep Resource Modules**. To see these views, **click on the expandable sections** with the "➕" sign below.
@@ -15,27 +21,13 @@ This page contains various views of the module index (catalog) for **Bicep Resou
 
 {{% /notice %}}
 
-## Module catalog
-
 {{% notice style="note" %}}
 
 Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use. For proposed modules, see the [Proposed modules]({{% siteparam base %}}/indexes/bicep/bicep-resource-modules/#proposed-modules---) section below.
 
 {{% /notice %}}
 
-The following table shows the number of all available, orphaned and proposed **Bicep Resource Modules**.
-
-{{% moduleStats language="Bicep" moduleType="Resource" showLanguage=true showClassification=true %}}
-
-### Module Publication History - 📅
-
-{{% expand title="➕ Module Publication History - Module names, status and owners" expanded="false" %}}
-
-{{% moduleHistory header=true csv="/static/module-indexes/BicepResourceModules.csv" language="Bicep" moduleType="resource" exclude="Proposed :new:" monthsToShow=9999 %}}
-
 {{% /expand %}}
-
----
 
 ### Published modules - 🟢 & 👀
 
@@ -45,8 +37,6 @@ The following table shows the number of all available, orphaned and proposed **B
 
 {{% /expand %}}
 
----
-
 ### Proposed modules - 🆕
 
 {{% expand title="➕ Proposed Modules - Module names, status and owners" expanded="false" %}}
@@ -54,8 +44,6 @@ The following table shows the number of all available, orphaned and proposed **B
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/BicepResourceModules.csv" language="Bicep" moduleType="resource" exclude="Available :green_circle:,Orphaned :eyes:" %}}
 
 {{% /expand %}}
-
----
 
 ### All modules - 📇
 
@@ -65,7 +53,13 @@ The following table shows the number of all available, orphaned and proposed **B
 
 {{% /expand %}}
 
----
+### Module Publication History - 📅
+
+{{% expand title="➕ Module Publication History - Module names, status and owners" expanded="false" %}}
+
+{{% moduleHistory header=true csv="/static/module-indexes/BicepResourceModules.csv" language="Bicep" moduleType="resource" exclude="Proposed :new:" monthsToShow=9999 %}}
+
+{{% /expand %}}
 
 ## For Module Owners & Contributors
 

--- a/docs/content/indexes/bicep/bicep-utility-modules.md
+++ b/docs/content/indexes/bicep/bicep-utility-modules.md
@@ -5,6 +5,12 @@ linktitle: Utility Modules
 weight: 3
 ---
 
+## Module catalog
+
+{{% moduleStats language="Bicep" moduleType="Utility" showLanguage=true showClassification=true %}}
+
+{{% expand title="➕ Additional information" %}}
+
 {{% notice style="info" %}}
 
 This page contains various views of the module index (catalog) for **Bicep Utility Modules**. To see these views, **click on the expandable sections** with the "➕" sign below.
@@ -15,17 +21,13 @@ This page contains various views of the module index (catalog) for **Bicep Utili
 
 {{% /notice %}}
 
-## Module catalog
-
 {{% notice style="note" %}}
 
 Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use. For proposed modules, see the [Proposed modules]({{% siteparam base %}}/indexes/bicep/bicep-utility-modules/#proposed-modules---) section below.
 
 {{% /notice %}}
 
-The following table shows the number of all available, orphaned and proposed **Bicep Utility Modules**.
-
-{{% moduleStats language="Bicep" moduleType="Utility" showLanguage=true showClassification=true %}}
+{{% /expand %}}
 
 ### Module Publication History - 📅
 
@@ -35,8 +37,6 @@ The following table shows the number of all available, orphaned and proposed **B
 
 {{% /expand %}}
 
----
-
 ### Published modules - 🟢 & 👀
 
 {{% expand title="➕ Published Modules - Module names, status and owners" expanded="true" %}}
@@ -44,8 +44,6 @@ The following table shows the number of all available, orphaned and proposed **B
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/BicepUtilityModules.csv" language="Bicep" moduleType="utility" exclude="Proposed :new:" %}}
 
 {{% /expand %}}
-
----
 
 ### Proposed modules - 🆕
 
@@ -55,8 +53,6 @@ The following table shows the number of all available, orphaned and proposed **B
 
 {{% /expand %}}
 
----
-
 ### All modules - 📇
 
 {{% expand title="➕ All Modules - Module names, status and owners" expanded="false" %}}
@@ -64,8 +60,6 @@ The following table shows the number of all available, orphaned and proposed **B
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/BicepUtilityModules.csv" language="Bicep" moduleType="utility" %}}
 
 {{% /expand %}}
-
----
 
 ## For Module Owners & Contributors
 

--- a/docs/content/indexes/bicep/bicep-utility-modules.md
+++ b/docs/content/indexes/bicep/bicep-utility-modules.md
@@ -29,14 +29,6 @@ Modules listed below that aren't shown with the status of **`Module Available �
 
 {{% /expand %}}
 
-### Module Publication History - 📅
-
-{{% expand title="➕ Module Publication History - Module names, status and owners" expanded="false" %}}
-
-{{% moduleHistory header=true csv="/static/module-indexes/BicepUtilityModules.csv" language="Bicep" moduleType="utility" exclude="Proposed :new:" monthsToShow=9999 %}}
-
-{{% /expand %}}
-
 ### Published modules - 🟢 & 👀
 
 {{% expand title="➕ Published Modules - Module names, status and owners" expanded="true" %}}
@@ -58,6 +50,14 @@ Modules listed below that aren't shown with the status of **`Module Available �
 {{% expand title="➕ All Modules - Module names, status and owners" expanded="false" %}}
 
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/BicepUtilityModules.csv" language="Bicep" moduleType="utility" %}}
+
+{{% /expand %}}
+
+### Module Publication History - 📅
+
+{{% expand title="➕ Module Publication History - Module names, status and owners" expanded="false" %}}
+
+{{% moduleHistory header=true csv="/static/module-indexes/BicepUtilityModules.csv" language="Bicep" moduleType="utility" exclude="Proposed :new:" monthsToShow=9999 %}}
 
 {{% /expand %}}
 

--- a/docs/content/indexes/terraform/tf-pattern-modules.md
+++ b/docs/content/indexes/terraform/tf-pattern-modules.md
@@ -5,6 +5,12 @@ linktitle: Pattern Modules
 weight: 2
 ---
 
+## Module catalog
+
+{{% moduleStats language="Terraform" moduleType="Pattern" showLanguage=true showClassification=true %}}
+
+{{% expand title="➕ Additional information" %}}
+
 {{% notice style="info" %}}
 
 This page contains various views of the module index (catalog) for **Terraform Pattern Modules**. To see these views, **click on the expandable sections** with the "➕" sign below.
@@ -15,17 +21,13 @@ This page contains various views of the module index (catalog) for **Terraform P
 
 {{% /notice %}}
 
-## Module catalog
-
 {{% notice style="note" %}}
 
 Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use. For proposed modules, see the [Proposed modules]({{% siteparam base %}}/indexes/terraform/tf-pattern-modules/#proposed-modules---) section below.
 
 {{% /notice %}}
 
-The following table shows the number of all available, orphaned and proposed **Terraform Pattern Modules**.
-
-{{% moduleStats language="Terraform" moduleType="Pattern" showLanguage=true showClassification=true %}}
+{{% /expand %}}
 
 ### Module Publication History - 📅
 
@@ -35,8 +37,6 @@ The following table shows the number of all available, orphaned and proposed **T
 
 {{% /expand %}}
 
----
-
 ### Published modules - 🟢 & 👀
 
 {{% expand title="➕ Published Modules - Module names, status and owners" expanded="true" %}}
@@ -44,8 +44,6 @@ The following table shows the number of all available, orphaned and proposed **T
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/TerraformPatternModules.csv" language="Terraform" moduleType="pattern" exclude="Proposed :new:" %}}
 
 {{% /expand %}}
-
----
 
 ### Proposed modules - 🆕
 
@@ -55,8 +53,6 @@ The following table shows the number of all available, orphaned and proposed **T
 
 {{% /expand %}}
 
----
-
 ### All modules - 📇
 
 {{% expand title="➕ All Modules - Module names, status and owners" expanded="false" %}}
@@ -64,8 +60,6 @@ The following table shows the number of all available, orphaned and proposed **T
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/TerraformPatternModules.csv" language="Terraform" moduleType="pattern" %}}
 
 {{% /expand %}}
-
----
 
 ## For Module Owners & Contributors
 

--- a/docs/content/indexes/terraform/tf-pattern-modules.md
+++ b/docs/content/indexes/terraform/tf-pattern-modules.md
@@ -29,14 +29,6 @@ Modules listed below that aren't shown with the status of **`Module Available �
 
 {{% /expand %}}
 
-### Module Publication History - 📅
-
-{{% expand title="➕ Module Publication History - Module names, status and owners" expanded="false" %}}
-
-{{% moduleHistory header=true csv="/static/module-indexes/TerraformPatternModules.csv" language="Terraform" moduleType="pattern" exclude="Proposed :new:" monthsToShow=9999 %}}
-
-{{% /expand %}}
-
 ### Published modules - 🟢 & 👀
 
 {{% expand title="➕ Published Modules - Module names, status and owners" expanded="true" %}}
@@ -58,6 +50,14 @@ Modules listed below that aren't shown with the status of **`Module Available �
 {{% expand title="➕ All Modules - Module names, status and owners" expanded="false" %}}
 
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/TerraformPatternModules.csv" language="Terraform" moduleType="pattern" %}}
+
+{{% /expand %}}
+
+### Module Publication History - 📅
+
+{{% expand title="➕ Module Publication History - Module names, status and owners" expanded="false" %}}
+
+{{% moduleHistory header=true csv="/static/module-indexes/TerraformPatternModules.csv" language="Terraform" moduleType="pattern" exclude="Proposed :new:" monthsToShow=9999 %}}
 
 {{% /expand %}}
 

--- a/docs/content/indexes/terraform/tf-resource-modules.md
+++ b/docs/content/indexes/terraform/tf-resource-modules.md
@@ -5,6 +5,12 @@ linktitle: Resource Modules
 weight: 1
 ---
 
+## Module catalog
+
+{{% moduleStats language="Terraform" moduleType="Resource" showLanguage=true showClassification=true %}}
+
+{{% expand title="➕ Additional information" %}}
+
 {{% notice style="info" %}}
 
 This page contains various views of the module index (catalog) for **Terraform Resource Modules**. To see these views, **click on the expandable sections** with the "➕" sign below.
@@ -15,17 +21,13 @@ This page contains various views of the module index (catalog) for **Terraform R
 
 {{% /notice %}}
 
-## Module catalog
-
 {{% notice style="note" %}}
 
 Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use. For proposed modules, see the [Proposed modules]({{% siteparam base %}}/indexes/terraform/tf-resource-modules/#proposed-modules---) section below.
 
 {{% /notice %}}
 
-The following table shows the number of all available, orphaned and proposed **Terraform Resource Modules**.
-
-{{% moduleStats language="Terraform" moduleType="Resource" showLanguage=true showClassification=true %}}
+{{% /expand %}}
 
 ### Module Publication History - 📅
 
@@ -35,8 +37,6 @@ The following table shows the number of all available, orphaned and proposed **T
 
 {{% /expand %}}
 
----
-
 ### Published modules - 🟢 & 👀
 
 {{% expand title="➕ Published Modules - Module names, status and owners" expanded="true" %}}
@@ -44,8 +44,6 @@ The following table shows the number of all available, orphaned and proposed **T
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/TerraformResourceModules.csv" language="Terraform" moduleType="resource" exclude="Proposed :new:" %}}
 
 {{% /expand %}}
-
----
 
 ### Proposed modules - 🆕
 
@@ -55,8 +53,6 @@ The following table shows the number of all available, orphaned and proposed **T
 
 {{% /expand %}}
 
----
-
 ### All modules - 📇
 
 {{% expand title="➕ All Modules - Module names, status and owners" expanded="false" %}}
@@ -64,8 +60,6 @@ The following table shows the number of all available, orphaned and proposed **T
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/TerraformResourceModules.csv" language="Terraform" moduleType="resource" %}}
 
 {{% /expand %}}
-
----
 
 ## For Module Owners & Contributors
 

--- a/docs/content/indexes/terraform/tf-resource-modules.md
+++ b/docs/content/indexes/terraform/tf-resource-modules.md
@@ -29,14 +29,6 @@ Modules listed below that aren't shown with the status of **`Module Available �
 
 {{% /expand %}}
 
-### Module Publication History - 📅
-
-{{% expand title="➕ Module Publication History - Module names, status and owners" expanded="false" %}}
-
-{{% moduleHistory header=true csv="/static/module-indexes/TerraformResourceModules.csv" language="Terraform" moduleType="resource" exclude="Proposed :new:" monthsToShow=9999 %}}
-
-{{% /expand %}}
-
 ### Published modules - 🟢 & 👀
 
 {{% expand title="➕ Published Modules - Module names, status and owners" expanded="true" %}}
@@ -58,6 +50,14 @@ Modules listed below that aren't shown with the status of **`Module Available �
 {{% expand title="➕ All Modules - Module names, status and owners" expanded="false" %}}
 
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/TerraformResourceModules.csv" language="Terraform" moduleType="resource" %}}
+
+{{% /expand %}}
+
+### Module Publication History - 📅
+
+{{% expand title="➕ Module Publication History - Module names, status and owners" expanded="false" %}}
+
+{{% moduleHistory header=true csv="/static/module-indexes/TerraformResourceModules.csv" language="Terraform" moduleType="resource" exclude="Proposed :new:" monthsToShow=9999 %}}
 
 {{% /expand %}}
 

--- a/docs/content/indexes/terraform/tf-utility-modules.md
+++ b/docs/content/indexes/terraform/tf-utility-modules.md
@@ -29,14 +29,6 @@ Modules listed below that aren't shown with the status of **`Module Available �
 
 {{% /expand %}}
 
-### Module Publication History - 📅
-
-{{% expand title="➕ Module Publication History - Module names, status and owners" expanded="false" %}}
-
-{{% moduleHistory header=true csv="/static/module-indexes/TerraformUtilityModules.csv" language="Terraform" moduleType="utility" exclude="Proposed :new:" monthsToShow=9999 %}}
-
-{{% /expand %}}
-
 ### Published modules - 🟢 & 👀
 
 {{% expand title="➕ Published Modules - Module names, status and owners" expanded="true" %}}
@@ -58,6 +50,14 @@ Modules listed below that aren't shown with the status of **`Module Available �
 {{% expand title="➕ All Modules - Module names, status and owners" expanded="false" %}}
 
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/TerraformUtilityModules.csv" language="Terraform" moduleType="utility" %}}
+
+{{% /expand %}}
+
+### Module Publication History - 📅
+
+{{% expand title="➕ Module Publication History - Module names, status and owners" expanded="false" %}}
+
+{{% moduleHistory header=true csv="/static/module-indexes/TerraformUtilityModules.csv" language="Terraform" moduleType="utility" exclude="Proposed :new:" monthsToShow=9999 %}}
 
 {{% /expand %}}
 

--- a/docs/content/indexes/terraform/tf-utility-modules.md
+++ b/docs/content/indexes/terraform/tf-utility-modules.md
@@ -5,6 +5,12 @@ linktitle: Utility Modules
 weight: 3
 ---
 
+## Module catalog
+
+{{% moduleStats language="Terraform" moduleType="Utility" showLanguage=true showClassification=true %}}
+
+{{% expand title="➕ Additional information" %}}
+
 {{% notice style="info" %}}
 
 This page contains various views of the module index (catalog) for **Terraform Utility Modules**. To see these views, **click on the expandable sections** with the "➕" sign below.
@@ -15,17 +21,13 @@ This page contains various views of the module index (catalog) for **Terraform U
 
 {{% /notice %}}
 
-## Module catalog
-
 {{% notice style="note" %}}
 
 Modules listed below that aren't shown with the status of **`Module Available 🟢`**, are currently in development and are not yet available for use. For proposed modules, see the [Proposed modules]({{% siteparam base %}}/indexes/terraform/tf-utility-modules/#proposed-modules---) section below.
 
 {{% /notice %}}
 
-The following table shows the number of all available, orphaned and proposed **Terraform Utility Modules**.
-
-{{% moduleStats language="Terraform" moduleType="Utility" showLanguage=true showClassification=true %}}
+{{% /expand %}}
 
 ### Module Publication History - 📅
 
@@ -35,8 +37,6 @@ The following table shows the number of all available, orphaned and proposed **T
 
 {{% /expand %}}
 
----
-
 ### Published modules - 🟢 & 👀
 
 {{% expand title="➕ Published Modules - Module names, status and owners" expanded="true" %}}
@@ -44,8 +44,6 @@ The following table shows the number of all available, orphaned and proposed **T
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/TerraformUtilityModules.csv" language="Terraform" moduleType="utility" exclude="Proposed :new:" %}}
 
 {{% /expand %}}
-
----
 
 ### Proposed modules - 🆕
 
@@ -55,8 +53,6 @@ The following table shows the number of all available, orphaned and proposed **T
 
 {{% /expand %}}
 
----
-
 ### All modules - 📇
 
 {{% expand title="➕ All Modules - Module names, status and owners" expanded="false" %}}
@@ -64,8 +60,6 @@ The following table shows the number of all available, orphaned and proposed **T
 {{% moduleNameStatusOwners header=true csv="/static/module-indexes/TerraformUtilityModules.csv" language="Terraform" moduleType="utility" %}}
 
 {{% /expand %}}
-
----
 
 ## For Module Owners & Contributors
 

--- a/docs/content/specs-defs/includes/bicep/resource/non-functional/BCPRMNFR1.md
+++ b/docs/content/specs-defs/includes/bicep/resource/non-functional/BCPRMNFR1.md
@@ -16,11 +16,11 @@ tags: [
 priority: 13010
 ---
 
-#### ID: BCPRMNFR1 - Category: Testing - Expected Test Directories
+## ID: BCPRMNFR1 - Category: Testing - Expected Test Directories
 
 Module owners **MUST** create the `defaults`, `waf-aligned` folders within their `/tests/e2e/` directory in their resource module source code and **SHOULD** create a `max` folder also. Module owners **CAN** create additional folders as required. Each folder will be used as described for various test cases.
 
-##### Defaults tests (**MUST**)
+### Defaults tests (**MUST**)
 
 The `defaults` folder contains a test instance that deploys the module with the minimum set of required parameters.
 
@@ -28,7 +28,7 @@ This includes input parameters of type `Required` plus input parameters of type 
 
 This instance has heavy reliance on the default values for other input parameters. Parameters of type `Optional` **SHOULD NOT** be used.
 
-##### WAF aligned tests (**MUST**)
+### WAF aligned tests (**MUST**)
 
 The `waf-aligned` folder contains a test instance that deploys the module in alignment with the best-practices of the Azure Well-Architected Framework.
 
@@ -36,7 +36,7 @@ This includes input parameters of type `Required`, parameters of type `Condition
 
 Parameters and dependencies which are not needed for WAF compliance, **SHOULD NOT** be included.
 
-##### Max tests (**SHOULD**)
+### Max tests (**SHOULD**)
 
 The `max` folder contains a test instance that deploys the module using a large parameter set, enabling most of the modules' features.
 
@@ -48,7 +48,7 @@ Please note that this test is not mandatory to have, but recommended for bulk pa
 
 {{% /notice %}}
 
-##### Additional tests (**CAN**)
+### Additional tests (**CAN**)
 
 Additional folders `CAN` be created by module owners as required.
 

--- a/docs/content/specs-defs/includes/bicep/resource/non-functional/BCPRMNFR2.md
+++ b/docs/content/specs-defs/includes/bicep/resource/non-functional/BCPRMNFR2.md
@@ -16,7 +16,7 @@ tags: [
 priority: 13010
 ---
 
-#### ID: BCPRMNFR2 - User-defined types - AVM-Common-Types
+## ID: BCPRMNFR2 - User-defined types - AVM-Common-Types
 
 When implementing any of the [shared]({{% siteparam base %}}/specs/shared/interfaces) or [Bicep-specific]({{% siteparam base %}}/specs/bicep/interfaces) AVM interface variants you MUST import their User-defined type (UDT) via the published [AVM-Common-Types](https://github.com/Azure/bicep-registry-modules/tree/main/avm/utl/types/avm-common-types) module.
 

--- a/docs/content/specs-defs/includes/bicep/resource/non-functional/BCPRMNFR2.md
+++ b/docs/content/specs-defs/includes/bicep/resource/non-functional/BCPRMNFR2.md
@@ -13,7 +13,7 @@ tags: [
   Lifecycle-BAU, # SINGLE VALUE: this can be "Lifecycle-Initial" OR "Lifecycle-BAU" OR "Lifecycle-EOL"
   Validation-Manual # SINGLE VALUE: this can be "Validation-Manual" OR "Validation-CI/Informational" OR "CI/Enforced"
 ]
-priority: 13010
+priority: 13020
 ---
 
 ## ID: BCPRMNFR2 - User-defined types - AVM-Common-Types

--- a/docs/content/specs-defs/includes/bicep/resource/non-functional/BCPRMNFR3.md
+++ b/docs/content/specs-defs/includes/bicep/resource/non-functional/BCPRMNFR3.md
@@ -16,7 +16,7 @@ tags: [
 priority: 13010
 ---
 
-#### ID: BCPRMNFR3 - Implementing child resources
+## ID: BCPRMNFR3 - Implementing child resources
 
 Child resource modules **MUST** be stored in a subfolder of their parent resource module and named after the child resource's singular name ([ref]({{% siteparam base %}}/specs-defs/includes/shared/pattern/non-functional/PMNFR1)), so that the path to the child resource folder is consistent with the hierarchy of its resource type.
 For example, `Microsoft.Sql/servers` may have dedicated child resources of type `Microsoft.Sql/servers/databases`. Hence, the SQL server database child module is stored in a `database` subfolder of the `server` parent folder.

--- a/docs/content/specs-defs/includes/bicep/resource/non-functional/BCPRMNFR3.md
+++ b/docs/content/specs-defs/includes/bicep/resource/non-functional/BCPRMNFR3.md
@@ -13,7 +13,7 @@ tags: [
   Lifecycle-BAU, # SINGLE VALUE: this can be "Lifecycle-Initial" OR "Lifecycle-BAU" OR "Lifecycle-EOL"
   Validation-TBD # SINGLE VALUE: this can be "Validation-BCP/Manual" OR "Validation-BCP/CI/Informational" OR "Validation-BCP/CI/Enforced"
 ]
-priority: 13010
+priority: 13030
 ---
 
 ## ID: BCPRMNFR3 - Implementing child resources

--- a/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR1.md
+++ b/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR1.md
@@ -17,7 +17,7 @@ tags: [
 priority: 10010
 ---
 
-#### ID: BCPFR1 - Category: Composition - Cross-Referencing Modules
+## ID: BCPFR1 - Category: Composition - Cross-Referencing Modules
 
 Module owners **MAY** cross-references other modules to build either Resource or Pattern modules.
 

--- a/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR2.md
+++ b/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR2.md
@@ -17,7 +17,7 @@ tags: [
 priority: 10020
 ---
 
-#### ID: BCPFR2 - Category: Composition - Role Assignments Role Definition Mapping
+## ID: BCPFR2 - Category: Composition - Role Assignments Role Definition Mapping
 
 Module owners **MAY** define common RBAC Role Definition names and IDs within a variable to allow consumers to define a RBAC Role Definition by their name rather than their ID, this should be self contained within the module themselves.
 

--- a/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR4.md
+++ b/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR4.md
@@ -17,7 +17,7 @@ tags: [
 priority: 10030
 ---
 
-#### ID: BCPFR4 - Category: Composition - Telemetry Enablement
+## ID: BCPFR4 - Category: Composition - Telemetry Enablement
 
 To comply with specifications outlined in [SFR3]({{% siteparam base %}}/spec/SFR3) & [SFR4]({{% siteparam base %}}/spec/SFR4) you **MUST** incorporate the following code snippet into your modules. Place this code sample in the "top level" `main.bicep` file; it is not necessary to include it in any nested Bicep files (child modules).
 

--- a/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR5.md
+++ b/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR5.md
@@ -17,7 +17,7 @@ tags: [
 priority: 10040
 ---
 
-#### ID: BCPFR5 - Category: Inputs - Availability Zones Implementation
+## ID: BCPFR5 - Category: Inputs - Availability Zones Implementation
 
 To implement requirement [SFR5]({{% siteparam base %}}/spec/SFR5), the following convention **SHOULD** apply:
 

--- a/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR6.md
+++ b/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR6.md
@@ -14,7 +14,7 @@ tags: [
   Lifecycle-BAU, # SINGLE VALUE: this can be "Lifecycle-Initial" OR "Lifecycle-BAU" OR "Lifecycle-EOL"
   Validation-TBD # SINGLE VALUE: this can be "Validation-BCP/Manual" OR "Validation-BCP/CI/Informational" OR "Validation-BCP/CI/Enforced"
 ]
-priority: 10010
+priority: 10050
 ---
 
 ## ID: BCPFR6 - Cross-Referencing Child-Modules

--- a/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR6.md
+++ b/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR6.md
@@ -17,7 +17,7 @@ tags: [
 priority: 10010
 ---
 
-#### ID: BCPFR6 - Cross-Referencing Child-Modules
+## ID: BCPFR6 - Cross-Referencing Child-Modules
 
 Parent templates **MUST** reference all their direct child-templates to allow for an end-to-end deployment experience.
 For example, the SQL server template must reference its child database module and encapsulate it in a loop to allow for the deployment of multiple databases.

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR1.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR1.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11010
 ---
 
-#### ID: BCPNFR1 - Inputs - User-defined types - General
+## ID: BCPNFR1 - Inputs - User-defined types - General
 
 To simplify the consumption experience for module consumers when interacting with complex data types input parameters, mainly objects and arrays, the Bicep feature of [User-Defined Types](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/user-defined-data-types) **MUST** be used and declared.
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR10.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR10.md
@@ -17,6 +17,6 @@ tags: [
 priority: 11100
 ---
 
-#### ID: BCPNFR10 - Category: Testing - Test Bicep File Naming
+## ID: BCPNFR10 - Category: Testing - Test Bicep File Naming
 
 Module owners **MUST** name their test `.bicep` files in the `/tests/e2e/<defaults/waf-aligned/max/etc.>` directories: `main.test.bicep` as the test framework (CI) relies upon this name.

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR11.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR11.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11110
 ---
 
-#### ID: BCPNFR11 - Category: Testing - Test Tooling
+## ID: BCPNFR11 - Category: Testing - Test Tooling
 
 Module owners **MUST** use the below tooling for unit/linting/static/security analysis tests. These are also used in the AVM Compliance Tests.
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR12.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR12.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11120
 ---
 
-#### ID: BCPNFR12 - Category: Testing - Deployment Test Naming
+## ID: BCPNFR12 - Category: Testing - Deployment Test Naming
 
 Module owners **MUST** invoke the module in their test using the syntax:
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR13.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR13.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11130
 ---
 
-#### ID: BCPNFR13 - Category: Testing - Test file metadata
+## ID: BCPNFR13 - Category: Testing - Test file metadata
 
 By default, the ReadMe-generating utility will create usage examples headers based on each `e2e` folder's name.
 Module owners **MAY** provide a custom name & description by specifying the metadata blocks `name` & `description` in their `main.test.bicep` test files.

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR14.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR14.md
@@ -18,7 +18,7 @@ tags: [
 priority: 11090
 ---
 
-#### ID: BCPNFR14 - Category: Composition - Versioning
+## ID: BCPNFR14 - Category: Composition - Versioning
 
 To meet [SNFR17]({{% siteparam base %}}/spec/SNFR17) and depending on the changes you make, you may need to bump the version in the `version.json` file.
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR15.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR15.md
@@ -16,7 +16,7 @@ tags: [
 priority: 11140
 ---
 
-#### ID: BCPNFR15 - Category: Contribution/Support - AVM Module Issue template file
+## ID: BCPNFR15 - Category: Contribution/Support - AVM Module Issue template file
 
 As part of the "initial Pull Request" (that publishes the first version of the module), module owners **MUST** add an entry to the `AVM Module Issue template` file in the BRM repository ([here](https://github.com/Azure/bicep-registry-modules/blob/main/.github/ISSUE_TEMPLATE/avm_module_issue.yml)).
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR16.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR16.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11150
 ---
 
-#### ID: BCPNFR16 - Category: Testing - Post-deployment tests
+## ID: BCPNFR16 - Category: Testing - Post-deployment tests
 
 For each test case in the `e2e` folder, you can optionally add post-deployment Pester tests that are executed once the corresponding deployment completed and before the removal logic kicks in.
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR17.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR17.md
@@ -17,13 +17,13 @@ tags: [
 priority: 11160
 ---
 
-#### ID: BCPNFR17 - Category: Composition - Code Styling - Type casting
+## ID: BCPNFR17 - Category: Composition - Code Styling - Type casting
 
 To improve the usability of primitive module properties declared as strings, you **SHOULD** declare them using a type which better represents them, and apply any required casting in the module on behalf of the user.
 
 For reference, please refer to the following examples:
 
-#### Boolean as String
+### Boolean as String
 
 {{< tabs title="Boolean as String" >}}
 {{% tab title="Before" %}}
@@ -61,7 +61,7 @@ For reference, please refer to the following examples:
 
 {{< /tabs >}}
 
-#### Integer Array as String Array
+### Integer Array as String Array
 
 {{< tabs title="Integer Array as String Array" >}}
 {{% tab title="Before" %}}

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR18.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR18.md
@@ -14,7 +14,7 @@ tags: [
   Lifecycle-BAU, # SINGLE VALUE: this can be "Lifecycle-Initial" OR "Lifecycle-BAU" OR "Lifecycle-EOL"
   Validation-TBD # SINGLE VALUE: this can be "Validation-Manual" OR "Validation-CI/Informational" OR "CI/Enforced"
 ]
-priority: 11010
+priority: 11012
 ---
 
 ## ID: BCPNFR18 - User-defined types - Specification

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR18.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR18.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11010
 ---
 
-#### ID: BCPNFR18 - User-defined types - Specification
+## ID: BCPNFR18 - User-defined types - Specification
 
 User-defined types (UDTs) MUST always be singular and non-nullable. The configuration of either should instead be done directly at the parameter or output that uses the type.
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR19.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR19.md
@@ -18,7 +18,7 @@ tags: [
 priority: 11010
 ---
 
-#### ID: BCPNFR19 - User-defined types - Naming
+## ID: BCPNFR19 - User-defined types - Naming
 
 User-defined types (UDTs) MUST always end with the suffix `(...)Type` to make them obvious to users. In addition it is recommended to extend the suffix to `(...)OutputType` if a UDT is exclusively used for outputs.
 ```bicep

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR19.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR19.md
@@ -15,7 +15,7 @@ tags: [
   Lifecycle-BAU, # SINGLE VALUE: this can be "Lifecycle-Initial" OR "Lifecycle-BAU" OR "Lifecycle-EOL"
   Validation-TBD # SINGLE VALUE: this can be "Validation-Manual" OR "Validation-CI/Informational" OR "CI/Enforced"
 ]
-priority: 11010
+priority: 11013
 ---
 
 ## ID: BCPNFR19 - User-defined types - Naming

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR2.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR2.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11030
 ---
 
-#### ID: BCPNFR2 - Category: Documentation - Module Documentation Generation
+## ID: BCPNFR2 - Category: Documentation - Module Documentation Generation
 
 {{% notice style="note" %}}
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR20.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR20.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11010
 ---
 
-#### ID: BCPNFR20 - User-defined types - Export
+## ID: BCPNFR20 - User-defined types - Export
 
 User-defined types (UDTs) SHOULD always be exported via the `@export()` annotation in every template they're implemented in.
 ```bicep

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR20.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR20.md
@@ -14,7 +14,7 @@ tags: [
   Lifecycle-BAU, # SINGLE VALUE: this can be "Lifecycle-Initial" OR "Lifecycle-BAU" OR "Lifecycle-EOL"
   Validation-TBD # SINGLE VALUE: this can be "Validation-Manual" OR "Validation-CI/Informational" OR "CI/Enforced"
 ]
-priority: 11010
+priority: 11014
 ---
 
 ## ID: BCPNFR20 - User-defined types - Export

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR21.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR21.md
@@ -14,7 +14,7 @@ tags: [
   Lifecycle-BAU, # SINGLE VALUE: this can be "Lifecycle-Initial" OR "Lifecycle-BAU" OR "Lifecycle-EOL"
   Validation-TBD # SINGLE VALUE: this can be "Validation-Manual" OR "Validation-CI/Informational" OR "CI/Enforced"
 ]
-priority: 11010
+priority: 11015
 ---
 
 ## ID: BCPNFR21 - User-defined types - Decorators

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR21.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR21.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11010
 ---
 
-#### ID: BCPNFR21 - User-defined types - Decorators
+## ID: BCPNFR21 - User-defined types - Decorators
 
 Similar to [BCPNFR9]({{% siteparam base %}}/spec/BCPNFR9), User-defined types (UDTs) MUST implement [decorators](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/parameters#use-decorators) such as `description` & `secure` (if sensitive). This is true for every property of the UDT, as well as the UDT itself.
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR3.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR3.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11040
 ---
 
-#### ID: BCPNFR3 - Category: Documentation - Usage Example formats
+## ID: BCPNFR3 - Category: Documentation - Usage Example formats
 
 Usage examples for Bicep modules **MUST** be provided in the following formats:
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR4.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR4.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11050
 ---
 
-#### ID: BCPNFR4 - Category: Documentation - Parameter Input Examples
+## ID: BCPNFR4 - Category: Documentation - Parameter Input Examples
 
 Bicep modules **MAY** provide parameter input examples for parameters using the `metadata.example` property via the `@metadata()` decorator.
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR5.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR5.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11060
 ---
 
-#### ID: BCPNFR5 - Category: Composition - Role Assignments Role Definition Mapping Limits
+## ID: BCPNFR5 - Category: Composition - Role Assignments Role Definition Mapping Limits
 
 As per [BCPFR2]({{% siteparam base %}}/spec/BCPFR2), module owners **MAY** define common RBAC Role Definition names and IDs within a variable to allow consumers to define a RBAC Role Definition by their name rather than their ID.
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR6.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR6.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11070
 ---
 
-#### ID: BCPNFR6 - Category: Composition - Role Assignments Role Definition Mapping Compulsory Roles
+## ID: BCPNFR6 - Category: Composition - Role Assignments Role Definition Mapping Compulsory Roles
 
 Module owners **MUST** include the following roles in the variable for RBAC Role Definition names:
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR7.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR7.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11020
 ---
 
-#### ID: BCPNFR7 - Category: Inputs - Parameter Requirement Types
+## ID: BCPNFR7 - Category: Inputs - Parameter Requirement Types
 
 Modules will have lots of parameters that will differ in their requirement type (required, optional, etc.). To help consumers understand what each parameter's requirement type is, module owners **MUST** add the requirement type to the beginning of each parameter's description. Below are the requirement types with a definition and example for the description decorator:
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR8.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR8.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11080
 ---
 
-#### ID: BCPNFR8 - Category: Composition - Code Styling - lower camelCasing
+## ID: BCPNFR8 - Category: Composition - Code Styling - lower camelCasing
 
 Module owners **SHOULD** use [lower camelCasing](https://wikipedia.org/wiki/Camel_case) for naming the following:
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR9.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR9.md
@@ -17,7 +17,7 @@ tags: [
 priority: 11010
 ---
 
-#### ID: BCPNFR9 - Inputs - Decorators
+## ID: BCPNFR9 - Inputs - Decorators
 
 Similar to [BCPNFR21]({{% siteparam base %}}/spec/BCPNFR21), input parameters MUST implement [decorators](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/parameters#use-decorators) such as `description` & `secure` (if sensitive).
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR9.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR9.md
@@ -14,7 +14,7 @@ tags: [
   Lifecycle-BAU, # SINGLE VALUE: this can be "Lifecycle-Initial" OR "Lifecycle-BAU" OR "Lifecycle-EOL"
   Validation-TBD # SINGLE VALUE: this can be "Validation-Manual" OR "Validation-CI/Informational" OR "CI/Enforced"
 ]
-priority: 11010
+priority: 11011
 ---
 
 ## ID: BCPNFR9 - Inputs - Decorators

--- a/docs/content/specs-defs/includes/shared/pattern/functional/PMFR1.md
+++ b/docs/content/specs-defs/includes/shared/pattern/functional/PMFR1.md
@@ -17,6 +17,6 @@ tags: [
 priority: 4010
 ---
 
-#### ID: PMFR1 - Category: Composition - Resource Group Creation
+## ID: PMFR1 - Category: Composition - Resource Group Creation
 
 A Pattern Module **MAY** create Resource Group(s).

--- a/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR1.md
+++ b/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR1.md
@@ -16,11 +16,11 @@ tags: [
 priority: 4020
 ---
 
-#### ID: PMNFR1 - Category: Naming - Module Naming
+## ID: PMNFR1 - Category: Naming - Module Naming
 
 Pattern Modules **MUST** follow the below naming conventions (all lower case):
 
-##### Bicep Pattern Module Naming
+### Bicep Pattern Module Naming
 
 - Naming convention: `avm/ptn/<hyphenated grouping/category name>/<hyphenated pattern module name>`
 - Example: `avm/ptn/compute/app-tier-vmss` or `avm/ptn/avd-lza/management-plane` or `avm/ptn/3-tier/web-app`
@@ -32,7 +32,7 @@ Pattern Modules **MUST** follow the below naming conventions (all lower case):
     - architecture, e.g., `3-tier`
   - `<hyphenated pattern module name>` is a term describing the module’s function, with each word separated by dashes, e.g., `app-tier-vmss` = Application Tier VMSS; `management-plane` = Azure Virtual Desktop Landing Zone Accelerator Management Plane
 
-##### Terraform Pattern Module Naming
+### Terraform Pattern Module Naming
 
 - Naming convention:
   - `avm-ptn-<pattern module name>` (Module name for registry)

--- a/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR2.md
+++ b/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR2.md
@@ -17,7 +17,7 @@ tags: [
 priority: 4030
 ---
 
-#### ID: PMNFR2 - Category: Composition - Use Resource Modules to Build a Pattern Module
+## ID: PMNFR2 - Category: Composition - Use Resource Modules to Build a Pattern Module
 
 A Pattern Module **SHOULD** be built from AVM Resources Modules to establish a standardized code base and improve maintainability. If a valid reason exists, a pattern module **MAY** contain native resources ("vanilla" code) where it's necessary. A Pattern Module **MUST NOT** contain references to non-AVM modules.
 

--- a/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR3.md
+++ b/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR3.md
@@ -17,6 +17,6 @@ tags: [
 priority: 4040
 ---
 
-#### ID: PMNFR3 - Category: Composition - Use other Pattern Modules to Build a Pattern Module
+## ID: PMNFR3 - Category: Composition - Use other Pattern Modules to Build a Pattern Module
 
 A Pattern Module **MAY** contain and be built using other AVM Pattern Modules. A Pattern Module **MUST NOT** contain references to non-AVM modules.

--- a/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR4.md
+++ b/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR4.md
@@ -17,7 +17,7 @@ tags: [
 priority: 4050
 ---
 
-#### ID: PMNFR4 - Category: Hygiene - Missing Resource Module(s)
+## ID: PMNFR4 - Category: Hygiene - Missing Resource Module(s)
 
 An item **MUST** be logged onto as an issue on the [AVM Central Repo (`Azure/Azure-Verified-Modules`)](https://github.com/Azure/Azure-Verified-Modules/issues) if a Resource Module does not exist for resources deployed by the pattern module.
 

--- a/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR5.md
+++ b/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR5.md
@@ -17,6 +17,6 @@ tags: [
 priority: 4050
 ---
 
-#### ID: PMNFR5 - Category: Inputs - Parameter/Variable Naming
+## ID: PMNFR5 - Category: Inputs - Parameter/Variable Naming
 
 Parameter/variable input names **SHOULD** contain the resource to which they pertain. E.g., `virtualMachineSku`/`virtualmachine_sku`

--- a/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR5.md
+++ b/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR5.md
@@ -14,7 +14,7 @@ tags: [
   Lifecycle-BAU, # SINGLE VALUE: this can be "Lifecycle-Initial" OR "Lifecycle-BAU" OR "Lifecycle-EOL"
   Validation-TBD # SINGLE VALUE (PER LANGUAGE): for Bicep, this can be "Validation-BCP/Manual" OR "Validation-BCP/CI/Informational" OR "Validation-BCP/CI/Enforced" and for Terraform, this can be "Validation-TF/Manual" OR "Validation-TF/CI/Informational" OR "Validation-TF/CI/Enforced"
 ]
-priority: 4050
+priority: 4060
 ---
 
 ## ID: PMNFR5 - Category: Inputs - Parameter/Variable Naming

--- a/docs/content/specs-defs/includes/shared/resource/functional/RMFR1.md
+++ b/docs/content/specs-defs/includes/shared/resource/functional/RMFR1.md
@@ -17,7 +17,7 @@ tags: [
 priority: 2010
 ---
 
-#### ID: RMFR1 - Category: Composition - Single Resource Only
+## ID: RMFR1 - Category: Composition - Single Resource Only
 
 A resource module **MUST** only deploy a single instance of the primary resource, e.g., one virtual machine per instance.
 

--- a/docs/content/specs-defs/includes/shared/resource/functional/RMFR2.md
+++ b/docs/content/specs-defs/includes/shared/resource/functional/RMFR2.md
@@ -16,6 +16,6 @@ tags: [
 priority: 2020
 ---
 
-#### ID: RMFR2 - Category: Composition - No Resource Wrapper Modules
+## ID: RMFR2 - Category: Composition - No Resource Wrapper Modules
 
 A resource module **MUST** add value by including additional features on top of the primary resource.

--- a/docs/content/specs-defs/includes/shared/resource/functional/RMFR3.md
+++ b/docs/content/specs-defs/includes/shared/resource/functional/RMFR3.md
@@ -17,7 +17,7 @@ tags: [
 priority: 2030
 ---
 
-#### ID: RMFR3 - Category: Composition - Resource Groups
+## ID: RMFR3 - Category: Composition - Resource Groups
 
 A resource module **MUST NOT** create a Resource Group **for resources that require them.**
 

--- a/docs/content/specs-defs/includes/shared/resource/functional/RMFR4.md
+++ b/docs/content/specs-defs/includes/shared/resource/functional/RMFR4.md
@@ -17,7 +17,7 @@ tags: [
 priority: 2040
 ---
 
-#### ID: RMFR4 - Category: Composition - AVM Consistent Feature & Extension Resources Value Add
+## ID: RMFR4 - Category: Composition - AVM Consistent Feature & Extension Resources Value Add
 
 Resource modules support the following optional features/extension resources, as specified, if supported by the primary resource. The top-level variable/parameter names **MUST** be:
 

--- a/docs/content/specs-defs/includes/shared/resource/functional/RMFR5.md
+++ b/docs/content/specs-defs/includes/shared/resource/functional/RMFR5.md
@@ -17,7 +17,7 @@ tags: [
 priority: 2050
 ---
 
-#### ID: RMFR5 - Category: Composition - AVM Consistent Feature & Extension Resources Value Add Interfaces/Schemas
+## ID: RMFR5 - Category: Composition - AVM Consistent Feature & Extension Resources Value Add Interfaces/Schemas
 
 Resource modules **MUST** implement a common interface, e.g. the input's data structures and properties within them (objects/arrays/dictionaries/maps), for the optional features/extension resources:
 

--- a/docs/content/specs-defs/includes/shared/resource/functional/RMFR6.md
+++ b/docs/content/specs-defs/includes/shared/resource/functional/RMFR6.md
@@ -17,7 +17,7 @@ tags: [
 priority: 2070
 ---
 
-#### ID: RMFR6 - Category: Inputs - Parameter/Variable Naming
+## ID: RMFR6 - Category: Inputs - Parameter/Variable Naming
 
 Parameters/variables that pertain to the primary resource **MUST NOT** use the resource type in the name.
 

--- a/docs/content/specs-defs/includes/shared/resource/functional/RMFR7.md
+++ b/docs/content/specs-defs/includes/shared/resource/functional/RMFR7.md
@@ -17,7 +17,7 @@ tags: [
 priority: 2080
 ---
 
-#### ID: RMFR7 - Category: Outputs - Minimum Required Outputs
+## ID: RMFR7 - Category: Outputs - Minimum Required Outputs
 
 Module owners **MUST** output the following outputs as a minimum in their modules:
 

--- a/docs/content/specs-defs/includes/shared/resource/functional/RMFR8.md
+++ b/docs/content/specs-defs/includes/shared/resource/functional/RMFR8.md
@@ -17,7 +17,7 @@ tags: [
 priority: 2060
 ---
 
-#### ID: RMFR8 - Category: Composition - Dependency on child and other resources
+## ID: RMFR8 - Category: Composition - Dependency on child and other resources
 
 A resource module **MAY** contain references to other resource modules, however **MUST NOT** contain references to non-AVM modules nor AVM pattern modules.
 

--- a/docs/content/specs-defs/includes/shared/resource/functional/RMFR9.md
+++ b/docs/content/specs-defs/includes/shared/resource/functional/RMFR9.md
@@ -17,7 +17,7 @@ tags: [
 priority: 2090
 ---
 
-#### ID: RMFR9 - Category: Composition - End-of-life resource versions
+## ID: RMFR9 - Category: Composition - End-of-life resource versions
 
 When a given version of an Azure resource used in a resource module reaches its end-of-life (EOL) and is no longer supported by Microsoft, the module owner **SHOULD** ensure that:
 

--- a/docs/content/specs-defs/includes/shared/resource/non-functional/RMNFR1.md
+++ b/docs/content/specs-defs/includes/shared/resource/non-functional/RMNFR1.md
@@ -16,7 +16,7 @@ tags: [
 priority: 3010
 ---
 
-#### ID: RMNFR1 - Category: Naming - Module Naming
+## ID: RMNFR1 - Category: Naming - Module Naming
 
 {{% notice style="note" %}}
 
@@ -28,7 +28,7 @@ This will be updated quarterly, or ad-hoc as new RPs/ Resources are created and 
 
 Resource modules **MUST** follow the below naming conventions (all lower case):
 
-##### Bicep Resource Module Naming
+### Bicep Resource Module Naming
 
 - Naming convention: `avm/res/<hyphenated resource provider name>/<hyphenated ARM resource type>` (module name for registry)
 - Example: `avm/res/compute/virtual-machine` or `avm/res/managed-identity/user-assigned-identity`
@@ -37,7 +37,7 @@ Resource modules **MUST** follow the below naming conventions (all lower case):
   - `<hyphenated resource provider name>` is the resource provider’s name after the `Microsoft` part, with each word starting with a capital letter separated by dashes, e.g., `Microsoft.Compute` = `compute`, `Microsoft.ManagedIdentity` = `managed-identity`.
   - `<hyphenated ARM resource type>` is the **singular** version of the word after the resource provider, with each word starting with a capital letter separated by dashes, e.g., `Microsoft.Compute/virtualMachines` = `virtual-machine`, **BUT** `Microsoft.Network/trafficmanagerprofiles` = `trafficmanagerprofile` - since `trafficmanagerprofiles` is all lower case as per the ARM API definition.
 
-##### Terraform Resource Module Naming
+### Terraform Resource Module Naming
 
 - Naming convention:
   - `avm-res-<resource provider>-<ARM resource type>` (module name for registry)

--- a/docs/content/specs-defs/includes/shared/resource/non-functional/RMNFR2.md
+++ b/docs/content/specs-defs/includes/shared/resource/non-functional/RMNFR2.md
@@ -17,7 +17,7 @@ tags: [
 priority: 3020
 ---
 
-#### ID: RMNFR2 - Category: Inputs - Parameter/Variable Naming
+## ID: RMNFR2 - Category: Inputs - Parameter/Variable Naming
 
 A resource module **MUST** use the following standard inputs:
 

--- a/docs/content/specs-defs/includes/shared/resource/non-functional/RMNFR3.md
+++ b/docs/content/specs-defs/includes/shared/resource/non-functional/RMNFR3.md
@@ -16,7 +16,7 @@ tags: [
 priority: 3030
 ---
 
-#### ID: RMNFR3 - Category: Composition - RP Collaboration
+## ID: RMNFR3 - Category: Composition - RP Collaboration
 
 Module owners (Microsoft FTEs) **SHOULD** reach out to the respective Resource Provider teams to build a partnership and collaboration on the modules creation, existence and long term maintenance.
 

--- a/docs/content/specs-defs/includes/shared/shared/functional/SFR1.md
+++ b/docs/content/specs-defs/includes/shared/shared/functional/SFR1.md
@@ -17,7 +17,7 @@ tags: [
 priority: 10
 ---
 
-#### ID: SFR1 - Category: Composition - Preview Services
+## ID: SFR1 - Category: Composition - Preview Services
 
 Modules **MAY** create/adopt public preview services and features at their discretion.
 

--- a/docs/content/specs-defs/includes/shared/shared/functional/SFR2.md
+++ b/docs/content/specs-defs/includes/shared/shared/functional/SFR2.md
@@ -17,7 +17,7 @@ tags: [
 priority: 20
 ---
 
-#### ID: SFR2 - Category: Composition - WAF Aligned
+## ID: SFR2 - Category: Composition - WAF Aligned
 
 Modules **SHOULD** set defaults in input parameters/variables to align to **high** priority/impact/severity recommendations, where appropriate and applicable, in the following frameworks and resources:
 

--- a/docs/content/specs-defs/includes/shared/shared/functional/SFR3.md
+++ b/docs/content/specs-defs/includes/shared/shared/functional/SFR3.md
@@ -17,7 +17,7 @@ tags: [
 priority: 30
 ---
 
-#### ID: SFR3 - Category: Telemetry - Deployment/Usage Telemetry
+## ID: SFR3 - Category: Telemetry - Deployment/Usage Telemetry
 
 {{% notice style="important" %}}
 
@@ -31,7 +31,7 @@ Modules **MUST** provide the capability to collect deployment/usage telemetry as
 
 To highlight that AVM modules use telemetry, an information notice **MUST** be included in the footer of each module's `README.md` file with the below content. (See more details on this requirement, [here](https://docs.opensource.microsoft.com/releasing/general-guidance/telemetry/).)
 
-##### Telemetry Information Notice
+### Telemetry Information Notice
 
 {{% notice style="note" %}}
 
@@ -44,12 +44,12 @@ The following information notice is automatically added at the bottom of the `RE
 
 {{< highlight lineNos="false" type="markdown" wrap="true" title="" >}}
 
-##### Data Collection
+### Data Collection
 
 {{% include file="/static/includes/telemetry-information-notice.md" %}}
 {{< /highlight >}}
 
-##### Bicep
+### Bicep
 
 The ARM deployment name used for the telemetry **MUST** follow the pattern and **MUST** be no longer than 64 characters in length: `46d3xbcp.<res/ptn>.<(short) module name>.<version>.<uniqueness>`
 

--- a/docs/content/specs-defs/includes/shared/shared/functional/SFR4.md
+++ b/docs/content/specs-defs/includes/shared/shared/functional/SFR4.md
@@ -17,7 +17,7 @@ tags: [
 priority: 40
 ---
 
-#### ID: SFR4 - Category: Telemetry - Telemetry Enablement Flexibility
+## ID: SFR4 - Category: Telemetry - Telemetry Enablement Flexibility
 
 The telemetry enablement **MUST** be on/enabled by default, however this **MUST** be able to be disabled by a module consumer by setting the below parameter/variable value to `false`:
 

--- a/docs/content/specs-defs/includes/shared/shared/functional/SFR5.md
+++ b/docs/content/specs-defs/includes/shared/shared/functional/SFR5.md
@@ -17,7 +17,7 @@ tags: [
 priority: 50
 ---
 
-#### ID: SFR5 - Category: Composition - Availability Zones
+## ID: SFR5 - Category: Composition - Availability Zones
 
 Modules that deploy ***zone-redundant*** resources **MUST** enable the spanning across as many zones as possible by default, typically all 3.
 

--- a/docs/content/specs-defs/includes/shared/shared/functional/SFR6.md
+++ b/docs/content/specs-defs/includes/shared/shared/functional/SFR6.md
@@ -17,7 +17,7 @@ tags: [
 priority: 60
 ---
 
-#### ID: SFR6 - Category: Composition - Data Redundancy
+## ID: SFR6 - Category: Composition - Data Redundancy
 
 Modules that deploy resources or patterns that support data redundancy **SHOULD** enable this to the highest possible value by default, e.g. `RA-GZRS`. When a resource or pattern doesn't provide the ability to specify data redundancy as a simple property, e.g. `GRS` etc., then the modules **MUST** provide the ability to enable data redundancy for the resources or pattern via parameters/variables.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR1.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR1.md
@@ -18,6 +18,6 @@ tags: [
 priority: 1020
 ---
 
-#### ID: SNFR1 - Category: Testing - Prescribed Tests
+## ID: SNFR1 - Category: Testing - Prescribed Tests
 
 Modules **MUST** use the prescribed tooling and testing frameworks defined in the language specific specs.

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR10.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR10.md
@@ -17,6 +17,6 @@ tags: [
 priority: 1130
 ---
 
-#### ID: SNFR10 - Category: Contribution/Support - MIT Licensing
+## ID: SNFR10 - Category: Contribution/Support - MIT Licensing
 
 A module **MUST** be published with the MIT License in the Azure GitHub organization.

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR11.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR11.md
@@ -18,6 +18,6 @@ tags: [
 priority: 1140
 ---
 
-#### ID: SNFR11 - Category: Contribution/Support - Issues Response Times
+## ID: SNFR11 - Category: Contribution/Support - Issues Response Times
 
 A module owner **MUST** respond to logged issues within 3 business days. See [Module Support]({{% siteparam base %}}/help-support/module-support/) for more information.

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR12.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR12.md
@@ -17,7 +17,7 @@ tags: [
 priority: 1150
 ---
 
-#### ID: SNFR12 - Category: Contribution/Support - Versions Supported
+## ID: SNFR12 - Category: Contribution/Support - Versions Supported
 
 Only the latest released version of a module **MUST** be supported.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR14.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR14.md
@@ -18,7 +18,7 @@ tags: [
 priority: 1170
 ---
 
-#### ID: SNFR14 - Category: Inputs - Data Types
+## ID: SNFR14 - Category: Inputs - Data Types
 
 A module **SHOULD** use either: simple data types. e.g., string, int, bool.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR15.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR15.md
@@ -18,6 +18,6 @@ tags: [
 priority: 1190
 ---
 
-#### ID: SNFR15 - Category: Documentation - Automatic Documentation Generation
+## ID: SNFR15 - Category: Documentation - Automatic Documentation Generation
 
 README documentation **MUST** be automatically/programmatically generated. **MUST** include the sections as defined in the language specific requirements [BCPNFR2]({{% siteparam base %}}/spec/BCPNFR2), [TFNFR2]({{% siteparam base %}}/spec/TFNFR2).

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR16.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR16.md
@@ -18,6 +18,6 @@ tags: [
 priority: 1200
 ---
 
-#### ID: SNFR16 - Category: Documentation - Examples/E2E
+## ID: SNFR16 - Category: Documentation - Examples/E2E
 
 An examples/e2e directory **MUST** exist to provide named scenarios for module deployment.

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR17.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR17.md
@@ -19,7 +19,7 @@ tags: [
 priority: 1210
 ---
 
-#### ID: SNFR17 - Category: Release - Semantic Versioning
+## ID: SNFR17 - Category: Release - Semantic Versioning
 
 {{% notice style="important" %}}
 
@@ -37,7 +37,7 @@ For example all modules should be released using a semantic version that matches
 - `Y` == Minor Version
 - `Z` == Patch Version
 
-##### Module versioning before first Major version release `1.0.0`
+### Module versioning before first Major version release `1.0.0`
 
 - Initially modules MUST be released as version `0.1.0` and incremented via Minor and Patch versions only until the AVM Core Team are confident the AVM specifications are mature enough and appropriate CI test coverage is in place, plus the module owner is happy the module has been "road tested" and is now stable enough for its first Major release of version `1.0.0`.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR18.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR18.md
@@ -18,7 +18,7 @@ tags: [
 priority: 1220
 ---
 
-#### ID: SNFR18 - Category: Release - Breaking Changes
+## ID: SNFR18 - Category: Release - Breaking Changes
 
 A module **SHOULD** avoid breaking changes, e.g., deprecating inputs vs. removing. If you need to implement changes that cause a breaking change, the major version should be increased.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR19.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR19.md
@@ -18,7 +18,7 @@ tags: [
 priority: 1230
 ---
 
-#### ID: SNFR19 - Category: Publishing - Registries Targeted
+## ID: SNFR19 - Category: Publishing - Registries Targeted
 
 Modules **MUST** be published to their respective language public registries.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR2.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR2.md
@@ -18,7 +18,7 @@ tags: [
 priority: 1030
 ---
 
-#### ID: SNFR2 - Category: Testing - E2E Testing
+## ID: SNFR2 - Category: Testing - E2E Testing
 
 Modules **MUST** implement end-to-end (deployment) testing that create actual resources to validate that module deployments work. In Bicep tests are sourced from the directories in `/tests/e2e`. In Terraform, these are in `/examples`.
 
@@ -35,7 +35,7 @@ To see a directory and file structure for a module, see the language specific co
 
 {{% /notice %}}
 
-##### Required Resources/Dependencies Required for E2E Tests
+### Resources/Dependencies Required for E2E Tests
 
 It is likely that to complete E2E tests, a number of resources will be required as dependencies to enable the tests to pass successfully. Some examples:
 
@@ -52,7 +52,7 @@ Module owners **MUST**:
 
 {{% expand title="➕ Terraform & Bicep Log Analytics Workspace examples using simple/native declarations for use in E2E tests" expanded="false" %}}
 
-###### Terraform
+#### Terraform
 
 ```terraform
 resource "azurerm_resource_group" "example" {
@@ -69,7 +69,7 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 ```
 
-###### Bicep
+#### Bicep
 
 ```bicep
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-12-01-preview' = {

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
@@ -17,7 +17,7 @@ tags: [
 priority: 1110
 ---
 
-#### ID: SNFR20 - Category: Contribution/Support - GitHub Teams Only
+## ID: SNFR20 - Category: Contribution/Support - GitHub Teams Only
 
 All GitHub repositories that AVM module are published from and hosted within **MUST** only assign GitHub repository permissions to GitHub teams only.
 
@@ -41,7 +41,7 @@ The `@Azure` prefix in the last column of the tables linked above represents the
 Non-FTE / external contributors (subject matter experts that aren't Microsoft employees) can't be members of the teams described in this chapter, hence, they won't gain any extra permissions on AVM repositories, therefore, they need to work in forks.
 {{% /notice %}}
 
-##### Naming Convention
+### Naming Convention
 
 The naming convention for the GitHub teams **MUST** follow the below pattern:
 
@@ -65,7 +65,7 @@ Examples:
 - `avm-res-compute-virtualmachine-module-owners-bicep`
 - `avm-res-compute-virtualmachine-module-contributors-tf`
 
-##### Add Team Members
+### Add Team Members
 
 All officially documented module owner(s) **MUST** be added to the `-module-owners-` team. The `-module-owners-` team **MUST NOT** have any other members.
 
@@ -73,9 +73,9 @@ Any additional module contributors whom the module owner(s) agreed to work with 
 
 Unless explicitly requested and agreed, members of the AVM core team or any PG teams **MUST NOT** be added to the `-module-owners-` or `-module-contributors-` teams as permissions for them are granted through the teams described in [SNFR9]({{% siteparam base %}}/spec/SNFR9).
 
-##### Grant Permissions - Bicep
+### Grant Permissions - Bicep
 
-##### Team memberships
+### Team memberships
 
 {{% notice style="note" %}}
 
@@ -107,7 +107,7 @@ Fill in the values as follows:
 - **Team notifications**: `Enabled`
 {{% /notice %}}
 
-##### CODEOWNERS file
+### CODEOWNERS file
 
 As part of the "initial Pull Request" (that publishes the first version of the module), module owners **MUST** add an entry to the `CODEOWNERS` file in the BRM repository ([here](https://github.com/Azure/bicep-registry-modules/blob/main/.github/CODEOWNERS)).
 
@@ -125,7 +125,7 @@ Example - `CODEOWNERS` entry for the Bicep resource module of Azure Virtual Netw
 
 - `/avm/res/network/virtual-network/ @Azure/avm-res-network-virtualnetwork-module-owners-bicep @Azure/avm-module-reviewers-bicep`
 
-##### Grant Permissions - Terraform
+### Grant Permissions - Terraform
 
 Module owners **MUST** assign the `-module-owners-`and `-module-contributors-` teams the necessary permissions on their Terraform module repository per the guidance below.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR21.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR21.md
@@ -18,6 +18,6 @@ tags: [
 priority: 1240
 ---
 
-#### ID: SNFR21 - Category: Publishing - Cross Language Collaboration
+## ID: SNFR21 - Category: Publishing - Cross Language Collaboration
 
 When the module owners of the same Resource or Pattern AVM module are not the same individual or team for all languages, each languages team **SHOULD** collaborate with their sibling language team for the same module to ensure consistency where possible.

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR22.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR22.md
@@ -18,7 +18,7 @@ tags: [
 priority: 1180
 ---
 
-#### ID: SNFR22 - Category: Inputs - Parameters/Variables for Resource IDs
+## ID: SNFR22 - Category: Inputs - Parameters/Variables for Resource IDs
 
 A module parameter/variable that requires a full Azure Resource ID as an input value, e.g. `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{keyVaultName}`, **MUST** contain `ResourceId/resource_id` in its parameter/variable name to assist users in knowing what value to provide at a glance of the parameter/variable name.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR23.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR23.md
@@ -17,7 +17,7 @@ tags: [
 priority: 1160
 ---
 <!-- markdownlint-disable -->
-#### ID: SNFR23 - Category: Contribution/Support - GitHub Repo Labels
+## ID: SNFR23 - Category: Contribution/Support - GitHub Repo Labels
 
 GitHub repositories where modules are held **MUST** use the below labels and **SHOULD** not use any additional labels:
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR24.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR24.md
@@ -18,7 +18,7 @@ tags: [
 priority: 1090
 ---
 
-#### ID: SNFR24 - Category: Testing - Testing Child, Extension & Interface Resources
+## ID: SNFR24 - Category: Testing - Testing Child, Extension & Interface Resources
 
 Module owners **MUST** test that child and extension resources and those [Bicep]({{% siteparam base %}}/specs/bcp/interfaces/) or [Terreform]({{% siteparam base %}}/specs/tf/interfaces/) interface resources that are supported by their modules, are validated in E2E tests as per [SNFR2]({{% siteparam base %}}/spec/SNFR2) to ensure they deploy and are configured correctly.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR25.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR25.md
@@ -17,7 +17,7 @@ tags: [
 priority: 1010
 ---
 
-#### ID: SNFR25 - Category: Composition - Resource Naming
+## ID: SNFR25 - Category: Composition - Resource Naming
 
 Module owners **MUST** set the default resource name prefix for child, extension, and interface resources to the associated abbreviation for the specific resource as documented in the following CAF article [Abbreviation examples for Azure resources](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations), if specified and documented. This reduces the amount of input values a module consumer **MUST** provide by default when using the module.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR3.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR3.md
@@ -18,7 +18,7 @@ tags: [
 priority: 1040
 ---
 
-#### ID: SNFR3 - Category: Testing - AVM Compliance Tests
+## ID: SNFR3 - Category: Testing - AVM Compliance Tests
 
 Modules **MUST** pass all tests that ensure compliance to AVM specifications. These tests **MUST** pass before a module version can be published.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR4.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR4.md
@@ -18,7 +18,7 @@ tags: [
 priority: 1050
 ---
 
-#### ID: SNFR4 - Category: Testing - Unit Tests
+## ID: SNFR4 - Category: Testing - Unit Tests
 
 Modules **SHOULD** implement unit testing to ensure logic and conditions within parameters/variables/locals are performing correctly. These tests **MUST** pass before a module version can be published.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR5.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR5.md
@@ -18,6 +18,6 @@ tags: [
 priority: 1060
 ---
 
-#### ID: SNFR5 - Category: Testing - Upgrade Tests
+## ID: SNFR5 - Category: Testing - Upgrade Tests
 
 Modules **SHOULD** implement upgrade testing to ensure new features are implemented in a non-breaking fashion on non-major releases.

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR6.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR6.md
@@ -18,7 +18,7 @@ tags: [
 priority: 1070
 ---
 
-#### ID: SNFR6 - Category: Testing - Static Analysis/Linting Tests
+## ID: SNFR6 - Category: Testing - Static Analysis/Linting Tests
 
 Modules **MUST** use static analysis, e.g., linting, security scanning (PSRule, tflint, etc.). These tests **MUST** pass before a module version can be published.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR7.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR7.md
@@ -18,7 +18,7 @@ tags: [
 priority: 1080
 ---
 
-#### ID: SNFR7 - Category: Testing - Idempotency Tests
+## ID: SNFR7 - Category: Testing - Idempotency Tests
 
 Modules **MUST** implement idempotency end-to-end (deployment) testing. E.g. deploying the module twice over the top of itself.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR8.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR8.md
@@ -17,7 +17,7 @@ tags: [
 priority: 1100
 ---
 
-#### ID: SNFR8 - Category: Contribution/Support - Module Owner(s) GitHub
+## ID: SNFR8 - Category: Contribution/Support - Module Owner(s) GitHub
 
 A module **MUST** have an owner that is defined and managed by a GitHub Team in the Azure GitHub organization.
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR9.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR9.md
@@ -17,11 +17,11 @@ tags: [
 priority: 1120
 ---
 
-#### ID: SNFR9 - Category: Contribution/Support - AVM & PG Teams GitHub Repo Permissions
+## ID: SNFR9 - Category: Contribution/Support - AVM & PG Teams GitHub Repo Permissions
 
 A module owner **MUST** make the following GitHub teams in the Azure GitHub organization admins on the GitHub repo of the module in question:
 
-##### Bicep
+### Bicep
 
 - [`@Azure/avm-core-team-technical-bicep`](https://github.com/orgs/Azure/teams/avm-core-team-technical-bicep) = AVM Core Team
 - [`@Azure/bicep-admins`](https://github.com/orgs/Azure/teams/bicep-admins) = Bicep PG team
@@ -30,7 +30,7 @@ A module owner **MUST** make the following GitHub teams in the Azure GitHub orga
 These required GitHub teams are already associated to the [BRM](https://aka.ms/BRM) repository and have the required permissions.
 {{% /notice %}}
 
-##### Terraform
+### Terraform
 
 - [`@Azure/avm-core-team-technical-terraform`](https://github.com/orgs/Azure/teams/avm-core-team-technical-terraform) = AVM Core Team
 - [`@Azure/terraform-avm`](https://github.com/orgs/Azure/teams/terraform-avm) = Terraform PG

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR1.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR1.md
@@ -17,7 +17,7 @@ tags: [
 priority: 20010
 ---
 
-#### ID: TFFR1 - Category: Composition - Cross-Referencing Modules
+## ID: TFFR1 - Category: Composition - Cross-Referencing Modules
 
 Module owners **MAY** cross-references other modules to build either Resource or Pattern modules. However, they **MUST** be referenced only by a HashiCorp Terraform registry reference to a pinned version e.g.,
 

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR2.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR2.md
@@ -17,7 +17,7 @@ tags: [
 priority: 20020
 ---
 
-#### ID: TFFR2 - Category: Outputs - Additional Terraform Outputs
+## ID: TFFR2 - Category: Outputs - Additional Terraform Outputs
 
 Authors **SHOULD NOT** output entire resource objects as these may contain sensitive outputs and the schema can change with API or provider versions.
 Instead, authors **SHOULD** output the *computed* attributes of the resource as discreet outputs.

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR3.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR3.md
@@ -18,7 +18,7 @@ tags: [
 priority: 20030
 ---
 
-#### ID: TFFR3 - Category: Providers - Permitted Versions
+## ID: TFFR3 - Category: Providers - Permitted Versions
 
 Authors **MUST** only use the following Azure providers, and versions, in their modules:
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR1.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR1.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21010
 ---
 
-#### ID: TFNFR1 - Category: Documentation - Descriptions
+## ID: TFNFR1 - Category: Documentation - Descriptions
 
 Where descriptions for variables and outputs spans multiple lines. The description **MAY** provide variable input examples for each variable using the HEREDOC format and embedded markdown.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR10.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR10.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21100
 ---
 
-#### ID: TFNFR10 - Category: Code Style - No Double Quotes in ignore_changes
+## ID: TFNFR10 - Category: Code Style - No Double Quotes in ignore_changes
 
 The `ignore_changes` attribute **MUST NOT** be enclosed in double quotes.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR11.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR11.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21110
 ---
 
-#### ID: TFNFR11 - Category: Code Style - Null Comparison Toggle
+## ID: TFNFR11 - Category: Code Style - Null Comparison Toggle
 
 Sometimes we need to ensure that the resources created are compliant to some rules at a minimum extent, for example a `subnet` has to be connected to at least one `network_security_group`. The user **SHOULD** pass in a `security_group_id` and ask us to make a connection to an existing `security_group`, or want us to create a new security group.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR12.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR12.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21120
 ---
 
-#### ID: TFNFR12 - Category: Code Style - Dynamic for Optional Nested Objects
+## ID: TFNFR12 - Category: Code Style - Dynamic for Optional Nested Objects
 
 An example from the community:
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR13.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR13.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21130
 ---
 
-#### ID: TFNFR13 - Category: Code Style - Default Values with coalesce/try
+## ID: TFNFR13 - Category: Code Style - Default Values with coalesce/try
 
 The following example shows how `"${var.subnet_name}-nsg"` **SHOULD** be used when `var.new_network_security_group_name` is `null` or `""`
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR14.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR14.md
@@ -17,6 +17,6 @@ tags: [
 priority: 21140
 ---
 
-#### ID: TFNFR14 - Category: Inputs - Not allowed variables
+## ID: TFNFR14 - Category: Inputs - Not allowed variables
 
 Since Terraform 0.13, `count`, `for_each` and `depends_on` are introduced for modules, module development is significantly simplified. Module's owners **MUST NOT** add variables like `enabled` or `module_depends_on` to control the entire module's operation. Boolean feature toggles are acceptable however.

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR15.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR15.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21150
 ---
 
-#### ID: TFNFR15 - Category: Code Style - Variable Definition Order
+## ID: TFNFR15 - Category: Code Style - Variable Definition Order
 
 Input variables **SHOULD** follow this order:
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR16.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR16.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21160
 ---
 
-#### ID: TFNFR16 - Category: Code Style - Variable Naming Rules
+## ID: TFNFR16 - Category: Code Style - Variable Naming Rules
 
 The naming of a `variable` **SHOULD** follow [HashiCorp's naming rule](https://www.terraform.io/docs/extend/best-practices/naming.html).
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR17.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR17.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21170
 ---
 
-#### ID: TFNFR17 - Category: Code Style - Variables with Descriptions
+## ID: TFNFR17 - Category: Code Style - Variables with Descriptions
 
 The target audience of `description` is the module users.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR18.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR18.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21180
 ---
 
-#### ID: TFNFR18 - Category: Code Style - Variables with Types
+## ID: TFNFR18 - Category: Code Style - Variables with Types
 
 `type` **MUST** be defined for every `variable`. `type` **SHOULD** be as precise as possible, `any` **MAY** only be defined with adequate reasons.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR19.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR19.md
@@ -17,6 +17,6 @@ tags: [
 priority: 21190
 ---
 
-#### ID: TFNFR19 - Category: Code Style - Sensitive Data Variables
+## ID: TFNFR19 - Category: Code Style - Sensitive Data Variables
 
 If `variable`'s `type` is `object` and contains one or more fields that would be assigned to a `sensitive` argument, then this whole `variable` **SHOULD** be declared as `sensitive = true`, otherwise you **SHOULD** extract sensitive field into separated variable block with `sensitive = true`.

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR2.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR2.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21020
 ---
 
-#### ID: TFNFR2 - Category: Documentation - Module Documentation Generation
+## ID: TFNFR2 - Category: Documentation - Module Documentation Generation
 
 Terraform modules documentation **MUST** be automatically generated via [Terraform Docs](https://github.com/terraform-docs/terraform-docs).
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR20.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR20.md
@@ -17,6 +17,6 @@ tags: [
 priority: 21200
 ---
 
-#### ID: TFNFR20 - Category: Code Style - Non-Nullable Defaults for collection values
+## ID: TFNFR20 - Category: Code Style - Non-Nullable Defaults for collection values
 
 Nullable **SHOULD** be set to `false` for collection values (e.g. sets, maps, lists) when using them in loops. However for scalar values like string and number, a null value **MAY** have a semantic meaning and as such these values are allowed.

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR21.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR21.md
@@ -17,6 +17,6 @@ tags: [
 priority: 21210
 ---
 
-#### ID: TFNFR21 - Category: Code Style - Discourage Nullability by Default
+## ID: TFNFR21 - Category: Code Style - Discourage Nullability by Default
 
 `nullable = true` **MUST** be avoided.

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR22.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR22.md
@@ -17,6 +17,6 @@ tags: [
 priority: 21220
 ---
 
-#### ID: TFNFR22 - Category: Code Style - Avoid sensitive = false
+## ID: TFNFR22 - Category: Code Style - Avoid sensitive = false
 
 `sensitive = false` **MUST** be avoided.

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR23.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR23.md
@@ -17,6 +17,6 @@ tags: [
 priority: 21230
 ---
 
-#### ID: TFNFR23 - Category: Code Style - Sensitive Default Value Conditions
+## ID: TFNFR23 - Category: Code Style - Sensitive Default Value Conditions
 
 A default value **MUST NOT** be set for a sensitive input - e.g., a default password.

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR24.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR24.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21240
 ---
 
-#### ID: TFNFR24 - Category: Code Style - Handling Deprecated Variables
+## ID: TFNFR24 - Category: Code Style - Handling Deprecated Variables
 
 Sometimes we will find names for some `variable` are not suitable anymore, or a change **SHOULD** be made to the data type. We want to ensure forward compatibility within a major version, so direct changes are strictly forbidden. The right way to do this is move this `variable` to an independent `deprecated_variables.tf` file, then redefine the new parameter in `variable.tf` and make sure it's compatible everywhere else.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR25.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR25.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21250
 ---
 
-#### ID: TFNFR25 - Category: Code Style - Verified Modules Requirements
+## ID: TFNFR25 - Category: Code Style - Verified Modules Requirements
 
 The `terraform.tf` file **MUST** only contain one `terraform` block.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR26.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR26.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21260
 ---
 
-#### ID: TFNFR26 - Category: Code Style - Providers in required_providers
+## ID: TFNFR26 - Category: Code Style - Providers in required_providers
 
 The `terraform` block in `terraform.tf` **MUST** contain the `required_providers` block.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR27.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR27.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21270
 ---
 
-#### ID: TFNFR27 - Category: Code Style - Provider Declarations in Modules
+## ID: TFNFR27 - Category: Code Style - Provider Declarations in Modules
 
 [By rules](https://www.terraform.io/docs/language/modules/develop/providers.html), in the module code `provider` **MUST NOT** be declared. The only exception is when the module indeed need different instances of the same kind of `provider`(Eg. manipulating resources across different `location`s or accounts), you **MUST** declare `configuration_aliases` in `terraform.required_providers`. See details in this [document](https://www.terraform.io/docs/language/providers/configuration.html#alias-multiple-provider-configurations).
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR29.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR29.md
@@ -18,6 +18,6 @@ priority: 21290
 showPage: false
 ---
 
-#### ID: TFNFR29 - Category: Code Style - Sensitive Data Outputs
+## ID: TFNFR29 - Category: Code Style - Sensitive Data Outputs
 
 An `output` block that contains confidential data **MUST** be declared with `sensitive = true`.

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR3.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR3.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21030
 ---
 
-#### ID: TFNFR3 - Category: Contribution/Support - GitHub Repo Branch Protection
+## ID: TFNFR3 - Category: Contribution/Support - GitHub Repo Branch Protection
 
 Module owners **MUST** set a branch protection policy on their GitHub Repositories for AVM modules against their default branch, typically `main`, to do the following:
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR30.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR30.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21300
 ---
 
-#### ID: TFNFR30 - Category: Code Style - Handling Deprecated Outputs
+## ID: TFNFR30 - Category: Code Style - Handling Deprecated Outputs
 
 Sometimes we notice that the name of certain `output` is not appropriate anymore, however, since we have to ensure forward compatibility in the same major version, its name **MUST NOT** be changed directly. It **MUST** be moved to an independent `deprecated_outputs.tf` file, then redefine a new output in `output.tf` and make sure it's compatible everywhere else in the module.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR31.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR31.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21310
 ---
 
-#### ID: TFNFR31 - Category: Code Style - locals.tf for Locals Only
+## ID: TFNFR31 - Category: Code Style - locals.tf for Locals Only
 
 In `locals.tf`, file we could declare multiple `locals` blocks, but only `locals` blocks are allowed.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR32.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR32.md
@@ -18,7 +18,7 @@ priority: 21320
 showPage: false
 ---
 
-#### ID: TFNFR32 - Category: Code Style - Alphabetical Local Arrangement
+## ID: TFNFR32 - Category: Code Style - Alphabetical Local Arrangement
 
 Expressions in `locals` block **MUST** be arranged alphabetically.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR33.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR33.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21330
 ---
 
-#### ID: TFNFR33 - Category: Code Style - Precise Local Types
+## ID: TFNFR33 - Category: Code Style - Precise Local Types
 
 Precise local types **SHOULD** be used.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR34.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR34.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21340
 ---
 
-#### ID: TFNFR34 - Category: Code Style - Using Feature Toggles
+## ID: TFNFR34 - Category: Code Style - Using Feature Toggles
 
 A toggle variable **MUST** be used to allow users to avoid the creation of a new `resource` block by default if it is added in a minor or patch version.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR35.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR35.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21350
 ---
 
-#### ID: TFNFR35 - Category: Code Style - Reviewing Potential Breaking Changes
+## ID: TFNFR35 - Category: Code Style - Reviewing Potential Breaking Changes
 
 Potential breaking(surprise) changes introduced by `resource` block
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR36.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR36.md
@@ -17,7 +17,7 @@ tags: [
 priority: 360
 ---
 
-#### ID: TFNFR36 - Category: Code Style - Setting prevent_deletion_if_contains_resources
+## ID: TFNFR36 - Category: Code Style - Setting prevent_deletion_if_contains_resources
 
 From Terraform AzureRM 3.0, the default value of `prevent_deletion_if_contains_resources` in `provider` block is `true`. This will lead to an unstable test because the test subscription has some policies applied, and they will add some extra resources during the run, which can cause failures during destroy of resource groups.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR36.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR36.md
@@ -14,7 +14,7 @@ tags: [
   Lifecycle-BAU, # SINGLE VALUE: this can be "Lifecycle-Initial" OR "Lifecycle-BAU" OR "Lifecycle-EOL"
   Validation-TBD # SINGLE VALUE: this can be "Validation-TF/Manual" OR "Validation-TF/CI/Informational" OR "Validation-TF/CI/Enforced"
 ]
-priority: 360
+priority: 21360
 ---
 
 ## ID: TFNFR36 - Category: Code Style - Setting prevent_deletion_if_contains_resources

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR37.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR37.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21370
 ---
 
-#### ID: TFNFR37 - Category: Code Style - Tool Usage by Module Owner
+## ID: TFNFR37 - Category: Code Style - Tool Usage by Module Owner
 
 `newres` is a command-line tool that generates Terraform configuration files for a specified resource type. It automates the process of creating `variables.tf` and `main.tf` files, making it easier to get started with Terraform and reducing the time spent on manual configuration.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR4.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR4.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21040
 ---
 
-#### ID: TFNFR4 - Category: Composition - Code Styling - lower snake_casing
+## ID: TFNFR4 - Category: Composition - Code Styling - lower snake_casing
 
 Module owners **MUST** use [lower snake_casing](https://wikipedia.org/wiki/Snake_case) for naming the following:
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR5.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR5.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21050
 ---
 
-#### ID: TFNFR5 - Category: Testing - Test Tooling
+## ID: TFNFR5 - Category: Testing - Test Tooling
 
 Module owners **MUST** use the below tooling for unit/linting/static/security analysis tests. These are also used in the AVM Compliance Tests.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR6.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR6.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21060
 ---
 
-#### ID: TFNFR6 - Category: Code Style - Resource & Data Order
+## ID: TFNFR6 - Category: Code Style - Resource & Data Order
 
 For the definition of resources in the same file, the resources be depended on **SHOULD** come first, after them are the resources depending on others.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR7.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR7.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21070
 ---
 
-#### ID: TFNFR7 - Category: Code Style - count & for_each Use
+## ID: TFNFR7 - Category: Code Style - count & for_each Use
 
 We can use `count` and `for_each` to deploy multiple resources, but the improper use of `count` can lead to [anti pattern](https://github.com/Azure/terraform-robust-module-design/tree/main/looping_for_resources_or_modules/count_index_antipattern).
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR8.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR8.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21080
 ---
 
-#### ID: TFNFR8 - Category: Code Style - Resource & Data Block Orders
+## ID: TFNFR8 - Category: Code Style - Resource & Data Block Orders
 
 There are 3 types of assignment statements in a `resource` or `data` block: argument, meta-argument and nested block. The argument assignment statement is a parameter followed by `=`:
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR9.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR9.md
@@ -17,7 +17,7 @@ tags: [
 priority: 21090
 ---
 
-#### ID: TFNFR9 - Category: Code Style - Module Block Order
+## ID: TFNFR9 - Category: Code Style - Module Block Order
 
 The meta-arguments below **SHOULD** be declared on the top of a `module` block with the following order:
 

--- a/docs/content/usage/quickstart/bicep.md
+++ b/docs/content/usage/quickstart/bicep.md
@@ -69,8 +69,8 @@ Searching the Azure Verified Module indexes is the most complete way to discover
 
 1. Open the AVM website in your favorite web browser: [https://aka.ms/avm](https://aka.ms/avm).
 1. Expand the **Module Indexes** menu item and select the **Bicep** sub-menu item.
-1. Select the menu item for the module type you are searching for: [Resource]({{% siteparam base %}}/indexes/bicep/bicep-resource-modules/), [Pattern]({{% siteparam base %}}indexes/bicep/bicep-pattern-modules/), or [Utility]({{% siteparam base %}}indexes/bicep/bicep-utility-modules/).
-  {{% notice style="note" %}}Since the Key Vault module used as an example in this guide is published as an AVM resource module, it can be found under the [resource modules]({{% siteparam base %}}indexes/bicep/bicep-resource-modules/) section in the AVM Bicep module index.{{% /notice %}}
+1. Select the menu item for the module type you are searching for: [Resource]({{% siteparam base %}}/indexes/bicep/bicep-resource-modules/), [Pattern]({{% siteparam base %}}/indexes/bicep/bicep-pattern-modules/), or [Utility]({{% siteparam base %}}/indexes/bicep/bicep-utility-modules/).
+  {{% notice style="note" %}}Since the Key Vault module used as an example in this guide is published as an AVM resource module, it can be found under the [resource modules]({{% siteparam base %}}/indexes/bicep/bicep-resource-modules/) section in the AVM Bicep module index.{{% /notice %}}
 1. A detailed description of module classification types can be found under the related section [here]({{% siteparam base %}}/specs/shared/module-classifications/).
 1. Select the **Published modules** link from the table of contents at the top of the page.
 1. Use the in-page search feature of your browser. In most Windows browsers you can access it using the `CTRL` + `F` keyboard shortcut.
@@ -93,7 +93,7 @@ Explore the Key Vault module’s documentation for usage examples and to underst
 
   1. Review the [**Usage examples**](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/key-vault/vault/README.md#Usage-examples) section. AVM modules include multiple tests that can be found under the **`tests`** folder. These tests are also used as the basis of the usage examples ensuring they are always up-to-date and deployable.
 
-In this example, you will deploy a secret in a new Key Vault instance with minimal input. AVM provides default parameter values with security and reliability being core principles. These settings apply the recommendations of the [Well Architected Framework]({{% siteparam base %}}faq/#what-does-avm-mean-by-waf-aligned) where possible and appropriate.
+In this example, you will deploy a secret in a new Key Vault instance with minimal input. AVM provides default parameter values with security and reliability being core principles. These settings apply the recommendations of the [Well Architected Framework]({{% siteparam base %}}/faq/#what-does-avm-mean-by-waf-aligned) where possible and appropriate.
 
 Note how [Example 2](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/key-vault/vault#example-2-using-only-defaults) does most of what you need to achieve.
 
@@ -117,7 +117,7 @@ module myKeyVault 'br/public:avm/res/key-vault/vault:0.11.0' = {
 
   {{% notice style="note" %}}For Azure Key Vaults, the name must be globally unique. When you deploy the Key Vault, ensure you select a name that is alphanumeric, twenty-four characters or less, and unique enough to ensure no one else has used the name for their Key Vault. If the name has been previously taken, you will get an error.{{% /notice %}}
 
-After setting the values for the required properties, the module can be [deployed](#deploy-your-solution). This minimal configuration automatically applies the security and reliability recommendations of the [Well Architected Framework]({{% siteparam base %}}faq/#what-does-avm-mean-by-waf-aligned) where possible and appropriate. These settings can be overridden if needed.
+After setting the values for the required properties, the module can be [deployed](#deploy-your-solution). This minimal configuration automatically applies the security and reliability recommendations of the [Well Architected Framework]({{% siteparam base %}}/faq/#what-does-avm-mean-by-waf-aligned) where possible and appropriate. These settings can be overridden if needed.
 
 {{% notice style="note" title="Bicep-specific configuration" %}}
 

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -54,6 +54,10 @@ enableGitInfo = true
 
 [markup]
   defaultMarkdownHandler = 'goldmark'
+  [markup.tableOfContents]
+    endLevel = 6
+    ordered = false
+    startLevel = 2
 
 [markup.goldmark.renderer]
     unsafe = true

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -103,7 +103,7 @@ enableGitInfo = true
     name = 'Bicep'
     pageRef = '/indexes/bicep'
     weight = 1
-    params = { alwaysopen = false, collapsibleMenu = true }
+    params = { alwaysopen = true, collapsibleMenu = true }
 
     [[menu.defined]]
       identifier = 'bicep-resource-module-indexes'
@@ -135,7 +135,7 @@ enableGitInfo = true
     name = 'Terraform'
     pageRef = '/indexes/terraform'
     weight = 2
-    params = { alwaysopen = false, collapsibleMenu = true }
+    params = { alwaysopen = true, collapsibleMenu = true }
 
     [[menu.defined]]
       identifier = 'terraform-resource-module-indexes'


### PR DESCRIPTION
- link fixes
- update toc depth
- adjusting heading depth for all specs
- updating rendering priority of specs
- expanding Bicep and TF module index menus by default
- updates on module index pages: consolidating and changing the order of chapters