### PR TITLE
fix: Link in spec overview pages

### DIFF
--- a/docs/layouts/shortcodes/tagsBasedNavigationTable.html
+++ b/docs/layouts/shortcodes/tagsBasedNavigationTable.html
@@ -181,7 +181,7 @@
             {{- end -}}
           {{- end -}}
 
-          {{- $link := replaceRE "^-" "#" (index (findRE `^\s*####\s.+` $page.RawContent) 0 | anchorize) -}}
+          {{- $link := printf "%s%s%s" $baseURL "spec/" $id -}}
 
           <tr>
             <td style="text-align: right;">{{- $index -}}</td>

--- a/docs/layouts/shortcodes/tagsBasedNavigationTable.html
+++ b/docs/layouts/shortcodes/tagsBasedNavigationTable.html
@@ -181,7 +181,7 @@
             {{- end -}}
           {{- end -}}
 
-          {{- $link := printf "%s%s%s" $baseURL "spec/" $id -}}
+          {{- $link := replaceRE "^-" "#" (index (findRE `^\s*##\s.+` $page.RawContent) 0 | anchorize) -}}
 
           <tr>
             <td style="text-align: right;">{{- $index -}}</td>


### PR DESCRIPTION
# Overview/Summary

Fixes the link in the automatically generated specs aggregation pages.

## This PR fixes/adds/changes/removes

Closes #1846

### Breaking Changes

none

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
