### PR TITLE
fix bug of not showing GitHub teams for pattern and utility modules on the website

### DIFF
--- a/docs/layouts/shortcodes/moduleNameTelemetryGHTeams.html
+++ b/docs/layouts/shortcodes/moduleNameTelemetryGHTeams.html
@@ -149,7 +149,7 @@
       <code style="white-space:normal;">{{ $item.TelemetryIdPrefix }}</code>
     </td>
     <td> {{/* GH teams */}}
-      {{- if eq $item.ParentModule "n/a" -}}
+      {{- if or (eq $ParentModuleColumnId 0) (eq $item.ParentModule "n/a") -}}
         <code style="white-space:normal;">{{ $item.ModuleOwnersGHTeam }}</code>
         <br>
         <code style="white-space:normal;">{{ $item.ModuleContributorsGHTeam }}</code>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

fix bug of not showing GitHub teams for pattern and utility modules on the website

## This PR fixes/adds/changes/removes

1. fix bug of not showing GitHub teams for pattern and utility modules on the website

### Breaking Changes

1. n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
