### PR TITLE
chore: add repo creation label

### DIFF
--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -242,3 +242,12 @@ configuration:
         then:
           - removeLabel:
               label: "Status: In PR :point_right:"
+
+      - description: 'When owner is ready for repository creation, add the "Status: Ready For Repository Creation" label'
+        if:
+          - payloadType: Issue_Comment
+          - commentContains:
+              pattern: "#RFRC"
+        then:
+          - addLabel:
+              label: "Status: Ready For Repository Creation"

--- a/docs/content/contributing/terraform/terraform-contribution-flow/owner-contribution-flow.md
+++ b/docs/content/contributing/terraform/terraform-contribution-flow/owner-contribution-flow.md
@@ -37,7 +37,7 @@ Make sure module authors/contributors tested their module in their environment b
 
 Once your module has been approved and you are ready to start development, you need to request that a new repository be created for your module.
 
-You do that by adding the `Status: Ready For Repository Creation` label to the [issue](https://github.com/Azure/Azure-Verified-Modules/issues) that was created for your module. This will trigger the creation of the repository and the configuration of the repository with the required settings.
+You do that by adding a comment to the [issue](https://github.com/Azure/Azure-Verified-Modules/issues) with the `#RFRC` tag. The `Status: Ready For Repository Creation` label will then be applied. This will trigger the creation of the repository and the configuration of the repository with the required settings.
 
 {{% notice style="info" %}}
 If you need your repository to be created urgently, please message the AVM Core team in the AVM Teams channel.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

After creating the process, it came to light that module owners cannot add labels to their Issues, so we need to leverage an alternative mechanism and update the docs accordingly. This PR adds a trigger to add the label based on an issue comment.

## This PR fixes/adds/changes/removes

N/A

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
