### PR TITLE
Change heading from "Bicep" to "Terraform" on terraform module table

### DIFF
--- a/docs/content/indexes/terraform/_index.md
+++ b/docs/content/indexes/terraform/_index.md
@@ -12,7 +12,7 @@ The following table shows the number of all available, orphaned and planned **Te
 
 {{% moduleStats language="Terraform" moduleType="All" showLanguage=true showClassification=true %}}
 
-{{% notice style="tip" title="Want to contribute to AVM Bicep modules?" %}}
+{{% notice style="tip" title="Want to contribute to AVM Terraform modules?" %}}
 
 | #  | Labels | Link and description |
 | -------- | -------- | -------- |


### PR DESCRIPTION
Heading on table for Terraform modules changed from "Bicep" to "Terraform"

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

The heading on the "would you like to help with these modules?" table referenced Bicep instead of Terraform


## This PR fixes/adds/changes/removes

1. Changes table header from "AVM Bicep modules" to "AVM Terraform modules"

### Breaking Changes

None

## As part of this Pull Request I have

- [X] Read the Contribution Guide and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [X] Ensured PR tests are passing
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
