### PR TITLE
fix: deprecated block name for diagnostic settings in azurerm

### DIFF
--- a/docs/static/includes/interfaces/tf/int.diag.schema.tf
+++ b/docs/static/includes/interfaces/tf/int.diag.schema.tf
@@ -1,4 +1,4 @@
-variable "diagnostic_settings" {
+bledvariable "diagnostic_settings" {
   type = map(object({
     name                                     = optional(string, null)
     log_categories                           = optional(set(string), [])
@@ -69,10 +69,10 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     }
   }
 
-  dynamic "metric" {
+  dynamic "enabled_metric" {
     for_each = each.value.metric_categories
     content {
-      category = metric.value
+      category = enabled_metric.value
     }
   }
 }

--- a/docs/static/includes/interfaces/tf/int.diag.schema.tf
+++ b/docs/static/includes/interfaces/tf/int.diag.schema.tf
@@ -1,4 +1,4 @@
-bledvariable "diagnostic_settings" {
+variable "diagnostic_settings" {
   type = map(object({
     name                                     = optional(string, null)
     log_categories                           = optional(set(string), [])


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace the interface as the block has been deprecated in latest azurerm

## This PR fixes/adds/changes/removes

N/A

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
