### PR TITLE
feat: changelog entries should start with capital letters

### DIFF
--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNRF22.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNRF22.md
@@ -40,20 +40,20 @@ For each new version, an entry **MUST** be created above all existing versions i
 
 ### Changes
 
-- this changed
-- and this also
+- This changed
+- And this also
 
 ### Breaking Changes
 
-- none
+- None
 ```
 
 Each version's entry:
 
-- **MUST** contain two sections: `Changes` and `Breaking Changes`. At least one of them must have a meaningful entry and sections must not be left empty. A `- none` may be added as content for a section.
+- **MUST** contain two sections: `Changes` and `Breaking Changes`. At least one of them must have a meaningful entry and sections must not be left empty. A `- None` may be added as content for a section.
 - **MUST** exist only once.
 
-All versions appear in decending order, which puts the most recent changes at the top.
+All versions appear in descending order, which puts the most recent changes at the top.
 
   {{% notice style="note" %}}
 
@@ -78,7 +78,7 @@ The latest version of the changelog can be found [here](/Azure/bicep-registry-mo
 
 ### Breaking Changes
 
-- none
+- None
 
 ## 0.2.0
 
@@ -100,16 +100,18 @@ The latest version of the changelog can be found [here](/Azure/bicep-registry-mo
 
 ### Breaking Changes
 
-- none
+- None
 
 ```
+
+Each bullet point should start with a capital letter.
 
 ### Manual Editing
 
 It is possible to modify the changelog content any time, e.g., to add missing versions, which will not create a new release of the module itself. Please note the following requirements in all cases:
 
-- all versions in the file, need to be valid and available as published version
-- every version needs the two sections `## Changes` and `## Breaking Changes` with content
+- All versions in the file, need to be valid and available as published version
+- Every version needs the two sections `## Changes` and `## Breaking Changes` with content
 
 {{% notice style="note" %}}
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNRF22.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNRF22.md
@@ -52,14 +52,18 @@ Each version's entry:
 
 - **MUST** contain two sections: `Changes` and `Breaking Changes`. At least one of them must have a meaningful entry and sections must not be left empty. A `- None` may be added as content for a section.
 - **MUST** exist only once.
+- All versions appear in descending order, which puts the most recent changes at the top.
 
-All versions appear in descending order, which puts the most recent changes at the top.
+What **SHOULD** be listed in the (Breaking) Changes section:
 
-  {{% notice style="note" %}}
+- Relevant changes for the module
+- Changes in tests do *not* need to be added
 
-  The versioning is following the [SNFR17 - Semantic Versioning]({{% siteparam base %}}/spec/SNFR17/) spec.
+{{% notice style="note" %}}
 
-  {{% /notice %}}
+The versioning is following the [SNFR17 - Semantic Versioning]({{% siteparam base %}}/spec/SNFR17/) spec.
+
+{{% /notice %}}
 
 ### Example content of the CHANGELOG.md
 


### PR DESCRIPTION
# Overview/Summary

Entries in Changelogs should start with a capital letter.

## This PR fixes/adds/changes/removes

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
