### PR TITLE
fix: BCPFR1 link to BCPFR6 fixed

### DIFF
--- a/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR1.md
+++ b/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR1.md
@@ -24,6 +24,6 @@ Module owners **MAY** cross-references other modules to build either Resource or
 
 However, they **MUST** be referenced only by a public registry reference to a pinned version e.g. `br/public:avm/[res|ptn|utl]/<publishedModuleName>:>version<`. They **MUST NOT** use local parent path references to a module e.g. `../../xxx/yyy.bicep`.
 
-The **only** exception to this rule are child modules as documented in [BCPFR6]({{% siteparam base %}}/specs-defs/includes/bicep/shared/functional/BCPFR6).
+The **only** exception to this rule are child modules as documented in [BCPFR6]({{% siteparam base %}}/spec/BCPFR6).
 
 Modules **MUST NOT** contain references to non-AVM modules.


### PR DESCRIPTION

# Overview/Summary

Fixes BCPFR1, where the link to BCPFR6 was wrong.

## This PR fixes/adds/changes/removes

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)