### PR TITLE
feat: hint where to find the telemetry value

### DIFF
--- a/docs/content/specs-defs/includes/shared/shared/functional/SFR3.md
+++ b/docs/content/specs-defs/includes/shared/shared/functional/SFR3.md
@@ -52,6 +52,10 @@ The following information notice is automatically added at the bottom of the `RE
 
 ### Bicep
 
+{{% notice style="important" %}}
+The value you need to use for your module is defined in the related module index. You can look it up on the index pages for [Resource Modules]({{% siteparam base %}}/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors), [Pattern Modules]({{% siteparam base %}}/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors) and [Utility Modules]({{% siteparam base %}}/indexes/bicep/bicep-utility-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors).
+{{% /notice %}}
+
 The ARM deployment name used for the telemetry **MUST** follow the pattern and **MUST** be no longer than 64 characters in length: `46d3xbcp.<res/ptn>.<(short) module name>.<version>.<uniqueness>`
 
 - `<res/ptn>` == AVM Resource or Pattern Module


### PR DESCRIPTION
# Overview/Summary

Adds a hint on the specs page, where to find the telemetry identifier.

## This PR fixes/adds/changes/removes

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
