### PR TITLE
Fix module index rendering and update specifications

### DIFF
--- a/docs/content/indexes/terraform/tf-pattern-modules.md
+++ b/docs/content/indexes/terraform/tf-pattern-modules.md
@@ -78,7 +78,7 @@ Modules listed below that aren't shown with the status of **`Module Available ðŸ
 
 {{% notice style="note" %}}
 
-This section is mainly intended **for module owners and contributors** as it contains information important for module development, such as **telemetry ID prefix, and GitHub Teams for Owners & Contributors**.
+This section is mainly intended **for module owners and contributors** as it contains information about the **GitHub Teams for Owners & Contributors**.
 
 {{% /notice %}}
 

--- a/docs/content/indexes/terraform/tf-resource-modules.md
+++ b/docs/content/indexes/terraform/tf-resource-modules.md
@@ -78,7 +78,7 @@ Modules listed below that aren't shown with the status of **`Module Available ðŸ
 
 {{% notice style="note" %}}
 
-This section is mainly intended **for module owners and contributors** as it contains information important for module development, such as **telemetry ID prefix, and GitHub Teams for Owners & Contributors**.
+This section is mainly intended **for module owners and contributors** as it contains information about the **GitHub Teams for Owners & Contributors**.
 
 {{% /notice %}}
 

--- a/docs/content/indexes/terraform/tf-utility-modules.md
+++ b/docs/content/indexes/terraform/tf-utility-modules.md
@@ -78,7 +78,7 @@ Modules listed below that aren't shown with the status of **`Module Available ðŸ
 
 {{% notice style="note" %}}
 
-This section is mainly intended **for module owners and contributors** as it contains information important for module development, such as **telemetry ID prefix, and GitHub Teams for Owners & Contributors**.
+This section is mainly intended **for module owners and contributors** as it contains information about the **GitHub Teams for Owners & Contributors**.
 
 {{% /notice %}}
 

--- a/docs/content/specs-defs/specs/_index.md
+++ b/docs/content/specs-defs/specs/_index.md
@@ -19,11 +19,17 @@ This section documents all the specifications for Azure Verified Modules (AVM) a
 
 ## How to navigate the specifications?
 
-The "Module Specifications" section uses tags to dynamically render content based on the selected attributes, such as the IaC language, module classification, category, severity and more. The tags are defined in hidden header of each specification page.
+The "Module Specifications" section uses tags to dynamically render content based on the selected attributes, such as the IaC language, module classification, category, severity and more. The tags are defined in header of each specification page.
 
 To make it easier for module owners and contributors to navigate the documentation, the specifications are grouped to distinct pages by the IaC language (`Bicep` | `Terraform`) and module classification ( `resource` | `pattern` | `utility`). The specifications on each page are further ordered by the category (e.g., `Composition`, `CodeStyle`, `Testing`, etc.), severity of the requirements (`MUST` | `SHOULD` | `MAY`) and at what stage of the module's lifecycle the specification is typically applicable (`Initial` | `BAU` | `EOL`).
 
-To find what you need, simply decide which IaC language you'd like develop in, and what classification your module falls under. Then, navigate to the respective page to find the specifications that are relevant to you.
+To find what you need, simply decide which IaC language you'd like develop in and what classification your module falls under, then navigate to the respective page to find the specifications that are relevant to you.
+
+{{% notice style="info" %}}
+
+All specifications have a 4-9 character long unique ID - a combination of letters and numbers. These letters only carry legacy meaning only leveraged by the AVM core team and are no longer used to group the specifications in any visible way. The ID is used to reference the specification in the code, documentation, and discussions.
+
+{{% /notice %}}
 
 ### Specification Tags
 
@@ -58,7 +64,7 @@ When is this specification mostly relevant?
 
 - The `Initial` stage is when the module is being developed first - e.g., naming related specs are labeled with `Lifecycle-Initial` as the naming of the module only happens once: at the beginning of their life.
 - The `BAU` (business as usual) stage is at any time during the module's typical lifecycle - e.g., specs that describe coding standards are relevant throughout the module's life, for any time a new module version is released.
-- The `EOL` stage is when the module is being decommissioned - e.g., specs describing how a module should be retired are labeled with `Lifecycle-EOL`.
+- The `EOL` (end of life) stage is when the module is being decommissioned - e.g., specs describing how a module should be retired are labeled with `Lifecycle-EOL`.
 
 **Validation**
 

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -132,6 +132,7 @@
   </thead>
   {{ end }}
   {{ range $item, $maps }}
+  {{ $hasListableModules = false }}
   {{ if in $include $item.ModuleStatus }}
     {{ $moduleLatestVersion = "N/A" }}
     {{ if or (eq $item.ModuleStatus "Available") (eq $item.ModuleStatus "Orphaned") (eq $item.ModuleStatus "Deprecated") }}
@@ -171,7 +172,7 @@
         {{/* Set $moduleLatestVersion to the first element of $sortedSemVers, which is the latest version */}}
         {{ $moduleLatestVersion = index $originalSortedVersions (sub (len $originalSortedVersions) 1) }}
       {{ end }}
-    {{ end }}
+    {{ end }} {{/* end of if or (eq $item.ModuleStatus "Available") (eq $item.ModuleStatus "Orphaned") (eq $item.ModuleStatus "Deprecated") */}}
     {{ $trimmedModuleStatus := replace $item.ModuleStatus "Module " "" }}
     {{ $trimmedModuleStatus = replace $trimmedModuleStatus "Deprecated" "Deprecated :red_circle:" }}
     {{ $trimmedModuleStatus = replace $trimmedModuleStatus "Available" "Available :green_circle:" }}
@@ -235,7 +236,7 @@
           <a href="">
             <image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-N/A-blue"/>
           </a>
-        {{- end -}}
+        {{- end -}} {{/* {{- if or (eq $item.ModuleStatus "Available") (eq $item.ModuleStatus "Orphaned") (eq $item.ModuleStatus "Deprecated") -}} */}}
       </td>
       <td> {{/* module owners */}}
         {{- if ne $item.PrimaryModuleOwnerGHHandle "" -}}
@@ -245,8 +246,8 @@
           {{- if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") -}}
             <br>
             {{ $item.PrimaryModuleOwnerDisplayName }}
-          {{- end -}}
-        {{- end -}}
+          {{- end -}} {{/* {{- if and (ne $item.PrimaryModuleOwnerGHHandle "") (ne $item.PrimaryModuleOwnerDisplayName "") -}} */}}
+        {{- end -}} {{/* {{- if ne $item.PrimaryModuleOwnerGHHandle "" -}} */}}
         <br>
         {{- if ne $item.SecondaryModuleOwnerGHHandle "" -}}
           <a href="https://github.com/{{ $item.SecondaryModuleOwnerGHHandle }}">
@@ -255,14 +256,14 @@
           {{- if and (ne $item.SecondaryModuleOwnerGHHandle "") (ne $item.SecondaryModuleOwnerDisplayName "") -}}
             <br>
             {{ $item.SecondaryModuleOwnerDisplayName }}
-          {{- end -}}
-        {{- end -}}
+          {{- end -}} {{/* {{- if and (ne $item.SecondaryModuleOwnerGHHandle "") (ne $item.SecondaryModuleOwnerDisplayName "") -}}  */}}
+        {{- end -}} {{/* {{- if ne $item.SecondaryModuleOwnerGHHandle "" -}} */}}
       </td>
-    {{- end -}}
+    {{- end -}} {{/* end of if moduleType */}}
   </tr>
   {{ $hasListableModules = true }}
-  {{ end }}
-  {{ end }}
+  {{ end }} {{/* end of if in include */}}
+  {{ end }} {{/* end of range */}}
   {{ if not $hasListableModules }}
   <tr>
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
@@ -271,7 +272,7 @@
     <td>❌ None listed</td>
     <td>❌ None listed</td>
   </tr>
-  {{ end }}
+  {{ end }} {{/* end of if not hasListableModules */}}
 </table>
 <br>
 {{ else if eq $language "Terraform" }}
@@ -289,6 +290,7 @@
   </thead>
   {{ end }}
   {{ range $item, $maps }}
+  {{ $hasListableModules = false }}
   {{ if in $include $item.ModuleStatus }}
   {{ $moduleLatestVersion = "N/A" }}
     {{ if or (eq $item.ModuleStatus "Available") (eq $item.ModuleStatus "Orphaned") (eq $item.ModuleStatus "Deprecated") }}

--- a/docs/layouts/shortcodes/moduleNameTelemetryGHTeams.html
+++ b/docs/layouts/shortcodes/moduleNameTelemetryGHTeams.html
@@ -182,7 +182,6 @@
     <tr>
       <th>No.</th>
       <th>Module Name</th>
-      <th>Telemetry ID prefix</th>
       <th>GitHub Teams for Module Owners and Contributors</th>
     </tr>
   </thead>
@@ -203,9 +202,6 @@
       {{- else -}}
         {{ $item.ModuleName }}
       {{- end -}}
-    </td>
-    <td> {{/* telemetry ID prefix */}}
-      <code style="white-space:normal;">{{ $item.TelemetryIdPrefix }}</code>
     </td>
     <td> {{/* GH teams */}}
       {{- if eq $item.ParentModule "n/a" -}}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Address a bug in module index rendering for lifecycle stages, enhance Terraform indexes to display Telemetry ID prefixes, and provide additional details on specification IDs.

## This PR fixes/adds/changes/removes

1. add more deails on spec IDs
2. update TF indexes to not show TelemetryIdPrefixes
3. fix module index rendering bug (to explicitly state there are no records, when there aren't eny entries under a given module lifecycle stage)

### Breaking Changes

1. n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
