### PR TITLE
fix: fixes wrong spec-name

### DIFF
--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR22.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR22.md
@@ -1,7 +1,7 @@
 ---
-title: BCPNRF22 - Bicep Module Changelog
+title: BCPNFR22 - Bicep Module Changelog
 description: Module changes are written to a changelog
-url: /spec/BCPNRF22
+url: /spec/BCPNFR22
 type: default
 tags: [
   Class-Resource, # MULTIPLE VALUES: this can be "Class-Resource" AND/OR "Class-Pattern" AND/OR "Class-Utility"
@@ -20,7 +20,7 @@ tags: [
 priority: 11016
 ---
 
-## ID: BCPNRF22 - Category: Publishing - Changelog
+## ID: BCPNFR22 - Category: Publishing - Changelog
 
 When a module to be published (i.e., that has a `version.json` file) is changed, an entry **MUST** be created in the `CHANGELOG.md` file in the module folder. A link to the latest version of the changelog file has to be included at the top of the file, just below the `# Changelog` line. It is surrounded by empty lines.
 


### PR DESCRIPTION
# Overview/Summary

The spec has a typo, which is fixed.

## This PR fixes/adds/changes/removes

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
