### PR TITLE
fix: `main.json` to `CHANGELOG.md` in BCPNFR22.md

### DIFF
--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR22.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR22.md
@@ -29,7 +29,7 @@ When a module to be published (i.e., that has a `version.json` file) is changed,
 ```text
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/<ptn|res|utl>/<namespace/modulename[/submodulePath]>/main.json).
+The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/<ptn|res|utl>/<namespace/modulename[/submodulePath]>/CHANGELOG.md).
 
 ```
 
@@ -72,7 +72,7 @@ A `CHANGELOG.md` file in the module's root folder **MUST** start with the `# Cha
 ```text
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/aad/domain-service/main.json).
+The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/aad/domain-service/CHANGELOG.md).
 
 ## 0.2.1
 


### PR DESCRIPTION


<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixed references to `main.json` to `CHANGELOG.md`

## This PR fixes/adds/changes/removes

1. Fixed references to `main.json` to `CHANGELOG.md`

### Breaking Changes

1. None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
