### PR TITLE
fix: Bicep Changelogs - Changes URL to an absolute URL

### DIFF
--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR22.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR22.md
@@ -29,7 +29,7 @@ When a module to be published (i.e., that has a `version.json` file) is changed,
 ```text
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/<ptn|res|utl>/<namespace/modulename[/submodulePath]>/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/<ptn|res|utl>/<namespace/modulename[/submodulePath]>/CHANGELOG.md).
 
 ```
 
@@ -72,7 +72,7 @@ A `CHANGELOG.md` file in the module's root folder **MUST** start with the `# Cha
 ```text
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/aad/domain-service/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/aad/domain-service/CHANGELOG.md).
 
 ## 0.2.1
 


### PR DESCRIPTION
# Overview/Summary

The Changelog URLs in the Bicep Registry Modules have been updated to use absolute URLs.

## This PR fixes/adds/changes/removes

- Changelogs reference the latest version by absolute URL

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
