### PR TITLE
Fix TF Lint Excluding Rules File names

### DIFF
--- a/docs/content/contributing/terraform/testing.md
+++ b/docs/content/contributing/terraform/testing.md
@@ -109,8 +109,8 @@ We use a custom ruleset for TFLint to check for AVM compliance: <https://github.
 If you need to exclude a rule from TFLint, you can do so by creating one of the following in the root of your module:
 
 - `avm.tflint.override.hcl` - to override the rules for the root module
-- `avm.tflint.override_module.hcl` - to override the rules for submodules
-- `avm.tflint.override_example.hcl` - to override the rules for examples
+- `avm.tflint.override.module.hcl` - to override the rules for submodules
+- `avm.tflint.override.example.hcl` - to override the rules for examples
 
 These files are HCL files that contain the rules that you want to override.
 Here is some example syntax:

--- a/docs/content/contributing/terraform/testing.md
+++ b/docs/content/contributing/terraform/testing.md
@@ -109,8 +109,8 @@ We use a custom ruleset for TFLint to check for AVM compliance: <https://github.
 If you need to exclude a rule from TFLint, you can do so by creating one of the following in the root of your module:
 
 - `avm.tflint.override.hcl` - to override the rules for the root module
-- `avm.tflint.override.module.hcl` - to override the rules for submodules
-- `avm.tflint.override.example.hcl` - to override the rules for examples
+- `avm.tflint_module.override.hcl` - to override the rules for submodules
+- `avm.tflint_example.override.hcl` - to override the rules for examples
 
 These files are HCL files that contain the rules that you want to override.
 Here is some example syntax:


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

The file names are incorrect here: [Excluding rules](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/testing/#excluding-rules). As per [run-tflint.sh](https://github.com/Azure/tfmod-scaffold/blob/010b3885c813448b944791263c9edfb0a448d8bc/avm_scripts/run-tflint.sh#L27) the filenames should be:

avm.tflint_module.override.hcl
avm.tflint_example.override.hcl

Fixes #2249

## This PR fixes/adds/changes/removes

1. Documentation fix to point to the correct TF Lint Excluded files.

### Breaking Changes

none

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
