### PR TITLE
[fix] Fixed deprecated modules workflow status

### DIFF
--- a/utilities/tools/platform/helper/Get-ModulesFeatureOutline.ps1
+++ b/utilities/tools/platform/helper/Get-ModulesFeatureOutline.ps1
@@ -150,14 +150,21 @@ function Get-ModulesFeatureOutline {
     $isTopLevelModule = ($resourceTypeIdentifier -split '[\/|\\]').Count -eq 2
     if (($ColumnsToInclude -contains 'Status') -and $isTopLevelModule) {
 
-      $statusInputObject = @{
-        RepositoryName      = $RepositoryName
-        Organization        = $Organization
-        PipelineFileName    = Get-PipelineFileName -ResourceIdentifier $relativeFolderPath
-        WorkflowsFolderPath = Join-Path $ModulesRepoRootPath '.github' 'workflows'
-      }
+      $isDeprecatedModule = Test-Path -Path (Join-Path $moduleFolderPath 'DEPRECATED.md')
 
-      $moduleDataItem['Status'] = Get-PipelineStatusUrl @statusInputObject
+      if ($isDeprecatedModule) {
+        $moduleDataItem['Status'] = 'Deprecated'
+      }
+      else {
+        $statusInputObject = @{
+          RepositoryName      = $RepositoryName
+          Organization        = $Organization
+          PipelineFileName    = Get-PipelineFileName -ResourceIdentifier $relativeFolderPath
+          WorkflowsFolderPath = Join-Path $ModulesRepoRootPath '.github' 'workflows'
+        }
+
+        $moduleDataItem['Status'] = Get-PipelineStatusUrl @statusInputObject
+      }
     }
 
     # Supports RBAC


### PR DESCRIPTION
# Overview/Summary

The module overview pages display the status of the workflow run for each module. For deprecated modules, the workflow does not exist.

```markdown
| # | Module | Status |
| - | - | - |
| 1 | ptn/aca-lza<p>hosting-environment | [![avm.ptn.aca-lza.hosting-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.aca-lza.hosting-environment.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.aca-lza.hosting-environment.yml) |
| 2 | ptn/ai-ml<p>ai-foundry | [![avm.ptn.ai-ml.ai-foundry](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.ai-ml.ai-foundry.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.ai-ml.ai-foundry.yml) |
| 3 | ptn/ai-platform<p>baseline | [![avm.ptn.ai-platform.baseline](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.ai-platform.baseline.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.ai-platform.baseline.yml) |
| 4 | ptn/alz<p>empty | [![avm.ptn.alz.empty](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.alz.empty.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.alz.empty.yml) |
| 5 | ptn/app-service-lza<p>hosting-environment | [![avm.ptn.app-service-lza.hosting-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app-service-lza.hosting-environment.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app-service-lza.hosting-environment.yml) |
| 6 | ptn/app<p>container-job-toolkit | [![avm.ptn.app.container-job-toolkit.yml](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app.container-job-toolkit.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app.container-job-toolkit.yml) |
| 7 | ptn/app<p>iaas-vm-cosmosdb-tier4 | [![avm.ptn.app.iaas-vm-cosmosdb-tier4](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app.iaas-vm-cosmosdb-tier4.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app.iaas-vm-cosmosdb-tier4.yml) |
| 8 | ptn/authorization<p>pim-role-assignment | [![avm.ptn.authorization.pim-role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.pim-role-assignment.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.pim-role-assignment.yml) |
| 9 | ptn/authorization<p>policy-assignment | [![avm.ptn.authorization.policy-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-assignment.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-assignment.yml) |
| 10 | ptn/authorization<p>policy-exemption | [![avm.ptn.authorization.policy-exemption](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-exemption.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-exemption.yml) |
| 11 | ptn/authorization<p>resource-role-assignment | [![avm.ptn.authorization.resource-role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.resource-role-assignment.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.resource-role-assignment.yml) |
| 12 | ptn/authorization<p>role-assignment | [![avm.ptn.authorization.role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-assignment.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-assignment.yml) |
| 13 | ptn/authorization<p>role-definition | [![avm.ptn.authorization.role-definition](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-definition.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-definition.yml) |
| 14 | ptn/azd<p>acr-container-app | [![avm.ptn.azd.acr-container-app](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.acr-container-app.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.acr-container-app.yml) |
| 15 | ptn/azd<p>aks | [![avm.ptn.azd.aks](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks.yml) |
| 16 | ptn/azd<p>aks-automatic-cluster | [![avm.ptn.azd.aks-automatic-cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks-automatic-cluster.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks-automatic-cluster.yml) |
| 17 | ptn/azd<p>apim-api | [![avm.ptn.azd.apim-api](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.apim-api.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.apim-api.yml) |
| 18 | ptn/azd<p>container-app-upsert | [![avm.ptn.azd.container-app-upsert](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-app-upsert.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-app-upsert.yml) |
| 19 | ptn/azd<p>container-apps-stack | [![avm.ptn.azd.container-apps-stack](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-apps-stack.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-apps-stack.yml) |
| 20 | ptn/azd<p>insights-dashboard | [![avm.ptn.azd.insights-dashboard](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.insights-dashboard.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.insights-dashboard.yml) |
| 21 | ptn/azd<p>ml-ai-environment | Deprecated |
| 22 | ptn/azd<p>ml-hub-dependencies | Deprecated |
| 23 | ptn/azd<p>ml-project | Deprecated |
| 24 | ptn/azd<p>monitoring | [![avm.ptn.azd.monitoring](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.monitoring.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.monitoring.yml) |
| 25 | ptn/data<p>private-analytical-workspace | [![avm.ptn.data.private-analytical-workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.data.private-analytical-workspace.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.data.private-analytical-workspace.yml) |
| 26 | ptn/deployment-script<p>import-image-to-acr | [![avm.ptn.deployment-script.import-image-to-acr](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.deployment-script.import-image-to-acr.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.deployment-script.import-image-to-acr.yml) |
| 27 | ptn/dev-ops<p>cicd-agents-and-runners | [![avm.ptn.dev-ops.cicd-agents-and-runners](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.dev-ops.cicd-agents-and-runners.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.dev-ops.cicd-agents-and-runners.yml) |
| 28 | ptn/finops-toolkit<p>finops-hub | [![avm.ptn.finops-toolkit.finops-hub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.finops-toolkit.finops-hub.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.finops-toolkit.finops-hub.yml) |
| 29 | ptn/lz<p>sub-vending | [![avm.ptn.lz.sub-vending](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml) |
| 30 | ptn/mgmt-groups<p>subscription-placement | [![avm.ptn.mgmt-groups.subscription-placement](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.mgmt-groups.subscription-placement.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.mgmt-groups.subscription-placement.yml) |
| 31 | ptn/network<p>hub-networking | [![avm.ptn.network.hub-networking](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml) |
| 32 | ptn/network<p>private-link-private-dns-zones | [![avm.ptn.network.private-link-private-dns-zones](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.private-link-private-dns-zones.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.private-link-private-dns-zones.yml) |
| 33 | ptn/policy-insights<p>remediation | [![avm.ptn.policy-insights.remediation](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.policy-insights.remediation.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.policy-insights.remediation.yml) |
| 34 | ptn/sa<p>content-processing | [![avm.ptn.sa.content-processing](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.content-processing.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.content-processing.yml) |
| 35 | ptn/sa<p>conversation-knowledge-mining | [![avm.ptn.sa.conversation-knowledge-mining](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.conversation-knowledge-mining.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.conversation-knowledge-mining.yml) |
| 36 | ptn/sa<p>modernize-your-code | [![avm.ptn.sa.modernize-your-code](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.modernize-your-code.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.modernize-your-code.yml) |
| 37 | ptn/sa<p>multi-agent-custom-automation-engine | [![avm.ptn.sa.multi-agent-custom-automation-engine](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.multi-agent-custom-automation-engine.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.multi-agent-custom-automation-engine.yml) |
| 38 | ptn/security<p>security-center | [![avm.ptn.security.security-center](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.security.security-center.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.security.security-center.yml) |
| 39 | ptn/subscription<p>service-health-alerts | [![avm.ptn.subscription.service-health-alerts](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.subscription.service-health-alerts.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.subscription.service-health-alerts.yml) |
| 40 | ptn/virtual-machine-images<p>azure-image-builder | [![avm.ptn.virtual-machine-images.azure-image-builder](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml) |
| 41 | res/aad<p>domain-service | [![avm.res.aad.domain-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.aad.domain-service.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.aad.domain-service.yml) |
| 42 | res/alerts-management<p>action-rule | [![avm.res.alerts-management.action-rule](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.alerts-management.action-rule.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.alerts-management.action-rule.yml) |
| 43 | res/analysis-services<p>server | [![avm.res.analysis-services.server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml) |
| 44 | res/api-management<p>service | [![avm.res.api-management.service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.api-management.service.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.api-management.service.yml) |
| 45 | res/app-configuration<p>configuration-store | [![avm.res.app-configuration.configuration-store](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app-configuration.configuration-store.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app-configuration.configuration-store.yml) |
| 46 | res/app<p>container-app | [![avm.res.app.container-app](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.container-app.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.container-app.yml) |
| 47 | res/app<p>job | [![avm.res.app.job](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.job.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.job.yml) |
| 48 | res/app<p>managed-environment | [![avm.res.app.managed-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.managed-environment.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.managed-environment.yml) |
| 49 | res/app<p>session-pool | [![avm.res.app.session-pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.session-pool.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.session-pool.yml) |
| 50 | res/authorization<p>role-assignment | [![avm.res.authorization.role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.authorization.role-assignment.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.authorization.role-assignment.yml) |
| 51 | res/automation<p>automation-account | [![avm.res.automation.automation-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml) |
| 52 | res/azure-stack-hci<p>cluster | [![avm.res.azure-stack-hci.cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.cluster.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.cluster.yml) |
| 53 | res/azure-stack-hci<p>logical-network | [![avm.res.azure-stack-hci.logical-network](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.logical-network.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.logical-network.yml) |
| 54 | res/azure-stack-hci<p>marketplace-gallery-image | [![avm.res.azure-stack-hci.marketplace-gallery-image](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.marketplace-gallery-image.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.marketplace-gallery-image.yml) |
| 55 | res/azure-stack-hci<p>network-interface | [![avm.res.azure-stack-hci.network-interface](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.network-interface.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.network-interface.yml) |
| 56 | res/azure-stack-hci<p>virtual-hard-disk | [![avm.res.azure-stack-hci.virtual-hard-disk](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.virtual-hard-disk.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.virtual-hard-disk.yml) |
| 57 | res/azure-stack-hci<p>virtual-machine-instance | [![avm.res.azure-stack-hci.virtual-machine-instance](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.virtual-machine-instance.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.virtual-machine-instance.yml) |
| 58 | res/batch<p>batch-account | [![avm.res.batch.batch-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.batch.batch-account.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.batch.batch-account.yml) |
| 59 | res/cache<p>redis | [![avm.res.cache.redis](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cache.redis.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cache.redis.yml) |
| 60 | res/cache<p>redis-enterprise | [![avm.res.cache.redis-enterprise](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cache.redis-enterprise.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cache.redis-enterprise.yml) |
| 61 | res/cdn<p>profile | [![avm.res.cdn.profile](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml) |
| 62 | res/cognitive-services<p>account | [![avm.res.cognitive-services.account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml) |
| 63 | res/communication<p>communication-service | [![avm.res.communication.communication-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.communication-service.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.communication-service.yml) |
| 64 | res/communication<p>email-service | [![avm.res.communication.email-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.email-service.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.email-service.yml) |
| 65 | res/compute<p>availability-set | [![avm.res.compute.availability-set](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.availability-set.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.availability-set.yml) |
| 66 | res/compute<p>disk | [![avm.res.compute.disk](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk.yml) |
| 67 | res/compute<p>disk-encryption-set | [![avm.res.compute.disk-encryption-set](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk-encryption-set.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk-encryption-set.yml) |
| 68 | res/compute<p>gallery | [![avm.res.compute.gallery](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml) |
| 69 | res/compute<p>image | [![avm.res.compute.image](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.image.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.image.yml) |
| 70 | res/compute<p>proximity-placement-group | [![avm.res.compute.proximity-placement-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.proximity-placement-group.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.proximity-placement-group.yml) |
| 71 | res/compute<p>ssh-public-key | [![avm.res.compute.ssh-public-key](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.ssh-public-key.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.ssh-public-key.yml) |
| 72 | res/compute<p>virtual-machine | [![avm.res.compute.virtual-machine](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine.yml) |
| 73 | res/compute<p>virtual-machine-scale-set | [![avm.res.compute.virtual-machine-scale-set](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine-scale-set.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine-scale-set.yml) |
| 74 | res/consumption<p>budget | [![avm.res.consumption.budget](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.consumption.budget.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.consumption.budget.yml) |
| 75 | res/container-instance<p>container-group | [![avm.res.container-instance.container-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-instance.container-group.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-instance.container-group.yml) |
| 76 | res/container-registry<p>registry | [![avm.res.container-registry.registry](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-registry.registry.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-registry.registry.yml) |
| 77 | res/container-service<p>managed-cluster | [![avm.res.container-service.managed-cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-service.managed-cluster.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-service.managed-cluster.yml) |
| 78 | res/data-factory<p>factory | [![avm.res.data-factory.factory](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.data-factory.factory.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.data-factory.factory.yml) |
| 79 | res/data-protection<p>backup-vault | [![avm.res.data-protection.backup-vault](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.data-protection.backup-vault.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.data-protection.backup-vault.yml) |
| 80 | res/databricks<p>access-connector | [![avm.res.databricks.access-connector](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.access-connector.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.access-connector.yml) |
| 81 | res/databricks<p>workspace | [![avm.res.databricks.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.workspace.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.workspace.yml) |
| 82 | res/db-for-my-sql<p>flexible-server | [![avm.res.db-for-my-sql.flexible-server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.db-for-my-sql.flexible-server.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.db-for-my-sql.flexible-server.yml) |
| 83 | res/db-for-postgre-sql<p>flexible-server | [![avm.res.db-for-postgre-sql.flexible-server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.db-for-postgre-sql.flexible-server.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.db-for-postgre-sql.flexible-server.yml) |
| 84 | res/desktop-virtualization<p>application-group | [![avm.res.desktop-virtualization.application-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.application-group.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.application-group.yml) |
| 85 | res/desktop-virtualization<p>host-pool | [![avm.res.desktop-virtualization.host-pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.host-pool.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.host-pool.yml) |
| 86 | res/desktop-virtualization<p>scaling-plan | [![avm.res.desktop-virtualization.scaling-plan](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.scaling-plan.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.scaling-plan.yml) |
| 87 | res/desktop-virtualization<p>workspace | [![avm.res.desktop-virtualization.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.workspace.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.workspace.yml) |
| 88 | res/dev-center<p>devcenter | [![avm.res.dev-center.devcenter](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.devcenter.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.devcenter.yml) |
| 89 | res/dev-center<p>network-connection | [![avm.res.dev-center.network-connection](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.network-connection.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.network-connection.yml) |
| 90 | res/dev-center<p>project | [![avm.res.dev-center.project](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.project.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.project.yml) |
| 91 | res/dev-ops-infrastructure<p>pool | [![avm.res.dev-ops-infrastructure.pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-ops-infrastructure.pool.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-ops-infrastructure.pool.yml) |
| 92 | res/dev-test-lab<p>lab | [![avm.res.dev-test-lab.lab](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-test-lab.lab.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-test-lab.lab.yml) |
| 93 | res/digital-twins<p>digital-twins-instance | [![avm.res.digital-twins.digital-twins-instance](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.digital-twins.digital-twins-instance.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.digital-twins.digital-twins-instance.yml) |
| 94 | res/document-db<p>database-account | [![avm.res.document-db.database-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.document-db.database-account.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.document-db.database-account.yml) |
| 95 | res/document-db<p>mongo-cluster | [![avm.res.document-db.mongo-cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.document-db.mongo-cluster.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.document-db.mongo-cluster.yml) |
| 96 | res/elastic-san<p>elastic-san | [![avm.res.elastic-san.elastic-san](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.elastic-san.elastic-san.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.elastic-san.elastic-san.yml) |
| 97 | res/event-grid<p>domain | [![avm.res.event-grid.domain](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.domain.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.domain.yml) |
| 98 | res/event-grid<p>namespace | [![avm.res.event-grid.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.namespace.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.namespace.yml) |
| 99 | res/event-grid<p>system-topic | [![avm.res.event-grid.system-topic](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.system-topic.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.system-topic.yml) |
| 100 | res/event-grid<p>topic | [![avm.res.event-grid.topic](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.topic.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.topic.yml) |
| 101 | res/event-hub<p>namespace | [![avm.res.event-hub.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-hub.namespace.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-hub.namespace.yml) |
| 102 | res/fabric<p>capacity | [![avm.res.fabric.capacity](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.fabric.capacity.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.fabric.capacity.yml) |
| 103 | res/health-bot<p>health-bot | [![avm.res.health-bot.health-bot](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.health-bot.health-bot.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.health-bot.health-bot.yml) |
| 104 | res/healthcare-apis<p>workspace | [![avm.res.healthcare-apis.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.healthcare-apis.workspace.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.healthcare-apis.workspace.yml) |
| 105 | res/hybrid-compute<p>gateway | [![avm.res.hybrid-compute.gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.gateway.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.gateway.yml) |
| 106 | res/hybrid-compute<p>license | [![avm.res.hybrid-compute.license](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.license.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.license.yml) |
| 107 | res/hybrid-compute<p>machine | [![avm.res.hybrid-compute.machine](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.machine.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.machine.yml) |
| 108 | res/hybrid-container-service<p>provisioned-cluster-instance | [![avm.res.hybrid-container-service.provisioned-cluster-instance](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-container-service.provisioned-cluster-instance.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-container-service.provisioned-cluster-instance.yml) |
| 109 | res/insights<p>action-group | [![avm.res.insights.action-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.action-group.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.action-group.yml) |
| 110 | res/insights<p>activity-log-alert | [![avm.res.insights.activity-log-alert](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.activity-log-alert.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.activity-log-alert.yml) |
| 111 | res/insights<p>component | [![avm.res.insights.component](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.component.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.component.yml) |
| 112 | res/insights<p>data-collection-endpoint | [![avm.res.insights.data-collection-endpoint](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-endpoint.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-endpoint.yml) |
| 113 | res/insights<p>data-collection-rule | [![avm.res.insights.data-collection-rule](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-rule.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-rule.yml) |
| 114 | res/insights<p>diagnostic-setting | [![avm.res.insights.diagnostic-setting](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.diagnostic-setting.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.diagnostic-setting.yml) |
| 115 | res/insights<p>metric-alert | [![avm.res.insights.metric-alert](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.metric-alert.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.metric-alert.yml) |
| 116 | res/insights<p>private-link-scope | [![avm.res.insights.private-link-scope](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.private-link-scope.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.private-link-scope.yml) |
| 117 | res/insights<p>scheduled-query-rule | [![avm.res.insights.scheduled-query-rule](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.scheduled-query-rule.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.scheduled-query-rule.yml) |
| 118 | res/insights<p>webtest | [![avm.res.insights.webtest](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.webtest.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.webtest.yml) |
| 119 | res/key-vault<p>vault | [![avm.res.key-vault.vault](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml) |
| 120 | res/kubernetes-configuration<p>extension | [![avm.res.kubernetes-configuration.extension](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-configuration.extension.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-configuration.extension.yml) |
| 121 | res/kubernetes-configuration<p>flux-configuration | [![avm.res.kubernetes-configuration.flux-configuration](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-configuration.flux-configuration.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-configuration.flux-configuration.yml) |
| 122 | res/kubernetes<p>connected-cluster | [![avm.res.kubernetes.connected-cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes.connected-cluster.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes.connected-cluster.yml) |
| 123 | res/kusto<p>cluster | [![avm.res.kusto.cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kusto.cluster.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kusto.cluster.yml) |
| 124 | res/load-test-service<p>load-test | [![avm.res.load-test-service.load-test](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.load-test-service.load-test.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.load-test-service.load-test.yml) |
| 125 | res/logic<p>workflow | [![avm.res.logic.workflow](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.logic.workflow.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.logic.workflow.yml) |
| 126 | res/machine-learning-services<p>registry | [![avm.res.machine-learning-services.registry](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.machine-learning-services.registry.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.machine-learning-services.registry.yml) |
| 127 | res/machine-learning-services<p>workspace | [![avm.res.machine-learning-services.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.machine-learning-services.workspace.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.machine-learning-services.workspace.yml) |
| 128 | res/maintenance<p>configuration-assignment | [![avm.res.maintenance.configuration-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.configuration-assignment.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.configuration-assignment.yml) |
| 129 | res/maintenance<p>maintenance-configuration | [![avm.res.maintenance.maintenance-configuration](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.maintenance-configuration.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.maintenance-configuration.yml) |
| 130 | res/managed-identity<p>user-assigned-identity | [![avm.res.managed-identity.user-assigned-identity](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-identity.user-assigned-identity.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-identity.user-assigned-identity.yml) |
| 131 | res/managed-services<p>registration-definition | [![avm.res.managed-services.registration-definition](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-services.registration-definition.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-services.registration-definition.yml) |
| 132 | res/management<p>management-group | [![avm.res.management.management-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.management.management-group.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.management.management-group.yml) |
| 133 | res/maps<p>account | [![avm.res.maps.account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maps.account.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maps.account.yml) |
| 134 | res/net-app<p>net-app-account | [![avm.res.net-app.net-app-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.net-app.net-app-account.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.net-app.net-app-account.yml) |
| 135 | res/network<p>application-gateway | [![avm.res.network.application-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-gateway.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-gateway.yml) |
| 136 | res/network<p>application-gateway-web-application-firewall-policy | [![avm.res.network.application-gateway-web-application-firewall-policy](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-gateway-web-application-firewall-policy.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-gateway-web-application-firewall-policy.yml) |
| 137 | res/network<p>application-security-group | [![avm.res.network.application-security-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-security-group.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-security-group.yml) |
| 138 | res/network<p>azure-firewall | [![avm.res.network.azure-firewall](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.azure-firewall.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.azure-firewall.yml) |
| 139 | res/network<p>bastion-host | [![avm.res.network.bastion-host](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.bastion-host.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.bastion-host.yml) |
| 140 | res/network<p>connection | [![avm.res.network.connection](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.connection.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.connection.yml) |
| 141 | res/network<p>ddos-protection-plan | [![avm.res.network.ddos-protection-plan](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ddos-protection-plan.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ddos-protection-plan.yml) |
| 142 | res/network<p>dns-forwarding-ruleset | [![avm.res.network.dns-forwarding-ruleset](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-forwarding-ruleset.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-forwarding-ruleset.yml) |
| 143 | res/network<p>dns-resolver | [![avm.res.network.dns-resolver](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-resolver.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-resolver.yml) |
| 144 | res/network<p>dns-zone | [![avm.res.network.dns-zone](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-zone.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-zone.yml) |
| 145 | res/network<p>express-route-circuit | [![avm.res.network.express-route-circuit](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-circuit.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-circuit.yml) |
| 146 | res/network<p>express-route-gateway | [![avm.res.network.express-route-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-gateway.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-gateway.yml) |
| 147 | res/network<p>express-route-port | [![avm.res.network.express-route-port](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-port.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-port.yml) |
| 148 | res/network<p>firewall-policy | [![avm.res.network.firewall-policy](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.firewall-policy.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.firewall-policy.yml) |
| 149 | res/network<p>front-door | Deprecated |
| 150 | res/network<p>front-door-web-application-firewall-policy | [![avm.res.network.front-door-web-application-firewall-policy](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.front-door-web-application-firewall-policy.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.front-door-web-application-firewall-policy.yml) |
| 151 | res/network<p>ip-group | [![avm.res.network.ip-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ip-group.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ip-group.yml) |
| 152 | res/network<p>load-balancer | [![avm.res.network.load-balancer](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.load-balancer.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.load-balancer.yml) |
| 153 | res/network<p>local-network-gateway | [![avm.res.network.local-network-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.local-network-gateway.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.local-network-gateway.yml) |
| 154 | res/network<p>nat-gateway | [![avm.res.network.nat-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml) |
| 155 | res/network<p>network-interface | [![avm.res.network.network-interface](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-interface.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-interface.yml) |
| 156 | res/network<p>network-manager | [![avm.res.network.network-manager](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-manager.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-manager.yml) |
| 157 | res/network<p>network-security-group | [![avm.res.network.network-security-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-security-group.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-security-group.yml) |
| 158 | res/network<p>network-security-perimeter | [![avm.res.network.network-security-perimeter](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-security-perimeter.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-security-perimeter.yml) |
| 159 | res/network<p>network-watcher | [![avm.res.network.network-watcher](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-watcher.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-watcher.yml) |
| 160 | res/network<p>p2s-vpn-gateway | [![avm.res.network.p2s-vpn-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.p2s-vpn-gateway.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.p2s-vpn-gateway.yml) |
| 161 | res/network<p>private-dns-zone | [![avm.res.network.private-dns-zone](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-dns-zone.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-dns-zone.yml) |
| 162 | res/network<p>private-endpoint | [![avm.res.network.private-endpoint](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-endpoint.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-endpoint.yml) |
| 163 | res/network<p>private-link-service | [![avm.res.network.private-link-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-link-service.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-link-service.yml) |
| 164 | res/network<p>public-ip-address | [![avm.res.network.public-ip-address](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml) |
| 165 | res/network<p>public-ip-prefix | [![avm.res.network.public-ip-prefix](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-prefix.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-prefix.yml) |
| 166 | res/network<p>route-table | [![avm.res.network.route-table](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.route-table.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.route-table.yml) |
| 167 | res/network<p>service-endpoint-policy | [![avm.res.network.service-endpoint-policy](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.service-endpoint-policy.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.service-endpoint-policy.yml) |
| 168 | res/network<p>trafficmanagerprofile | [![avm.res.network.trafficmanagerprofile](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.trafficmanagerprofile.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.trafficmanagerprofile.yml) |
| 169 | res/network<p>virtual-hub | [![avm.res.network.virtual-hub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-hub.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-hub.yml) |
| 170 | res/network<p>virtual-network | [![avm.res.network.virtual-network](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network.yml) |
| 171 | res/network<p>virtual-network-gateway | [![avm.res.network.virtual-network-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network-gateway.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network-gateway.yml) |
| 172 | res/network<p>virtual-wan | [![avm.res.network.virtual-wan](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-wan.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-wan.yml) |
| 173 | res/network<p>vpn-gateway | [![avm.res.network.vpn-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-gateway.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-gateway.yml) |
| 174 | res/network<p>vpn-server-configuration | [![avm.res.network.vpn-server-configuration](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-server-configuration.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-server-configuration.yml) |
| 175 | res/network<p>vpn-site | [![avm.res.network.vpn-site](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-site.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-site.yml) |
| 176 | res/operational-insights<p>workspace | [![avm.res.operational-insights.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml) |
| 177 | res/operations-management<p>solution | [![avm.res.operations-management.solution](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.operations-management.solution.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.operations-management.solution.yml) |
| 178 | res/portal<p>dashboard | [![avm.res.portal.dashboard](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.portal.dashboard.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.portal.dashboard.yml) |
| 179 | res/power-bi-dedicated<p>capacity | [![avm.res.power-bi-dedicated.capacity](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.power-bi-dedicated.capacity.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.power-bi-dedicated.capacity.yml) |
| 180 | res/purview<p>account | [![avm.res.purview.account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.purview.account.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.purview.account.yml) |
| 181 | res/recovery-services<p>vault | [![avm.res.recovery-services.vault](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.recovery-services.vault.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.recovery-services.vault.yml) |
| 182 | res/relay<p>namespace | [![avm.res.relay.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.relay.namespace.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.relay.namespace.yml) |
| 183 | res/resource-graph<p>query | [![avm.res.resource-graph.query](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resource-graph.query.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resource-graph.query.yml) |
| 184 | res/resources<p>deployment-script | [![avm.res.resources.deployment-script](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.deployment-script.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.deployment-script.yml) |
| 185 | res/resources<p>resource-group | [![avm.res.resources.resource-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.resource-group.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.resource-group.yml) |
| 186 | res/search<p>search-service | [![avm.res.search.search-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.search.search-service.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.search.search-service.yml) |
| 187 | res/security-insights<p>data-connector | [![avm.res.security-insights.data-connector](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.security-insights.data-connector.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.security-insights.data-connector.yml) |
| 188 | res/security-insights<p>setting | [![avm.res.security-insights.setting](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.security-insights.setting.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.security-insights.setting.yml) |
| 189 | res/service-bus<p>namespace | [![avm.res.service-bus.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-bus.namespace.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-bus.namespace.yml) |
| 190 | res/service-fabric<p>cluster | [![avm.res.service-fabric.cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-fabric.cluster.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-fabric.cluster.yml) |
| 191 | res/service-networking<p>traffic-controller | [![avm.res.service-networking.traffic-controller](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-networking.traffic-controller.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-networking.traffic-controller.yml) |
| 192 | res/signal-r-service<p>signal-r | [![avm.res.signal-r-service.signal-r](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.signal-r.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.signal-r.yml) |
| 193 | res/signal-r-service<p>web-pub-sub | [![avm.res.signal-r-service.web-pub-sub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.web-pub-sub.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.web-pub-sub.yml) |
| 194 | res/sql<p>instance-pool | [![avm.res.sql.instance-pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.instance-pool.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.instance-pool.yml) |
| 195 | res/sql<p>managed-instance | [![avm.res.sql.managed-instance](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.managed-instance.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.managed-instance.yml) |
| 196 | res/sql<p>server | [![avm.res.sql.server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml) |
| 197 | res/storage<p>storage-account | [![avm.res.storage.storage-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml) |
| 198 | res/synapse<p>private-link-hub | [![avm.res.synapse.private-link-hub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.synapse.private-link-hub.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.synapse.private-link-hub.yml) |
| 199 | res/synapse<p>workspace | [![avm.res.synapse.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.synapse.workspace.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.synapse.workspace.yml) |
| 200 | res/virtual-machine-images<p>image-template | [![avm.res.virtual-machine-images.image-template](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.virtual-machine-images.image-template.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.virtual-machine-images.image-template.yml) |
| 201 | res/web<p>connection | [![avm.res.web.connection](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.connection.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.connection.yml) |
| 202 | res/web<p>hosting-environment | [![avm.res.web.hosting-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.hosting-environment.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.hosting-environment.yml) |
| 203 | res/web<p>serverfarm | [![avm.res.web.serverfarm](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml) |
| 204 | res/web<p>site | [![avm.res.web.site](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.site.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.site.yml) |
| 205 | res/web<p>static-site | [![avm.res.web.static-site](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.static-site.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.static-site.yml) |
| 206 | utl/types<p>avm-common-types | [![avm.utl.types.avm-common-types](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml/badge.svg?branch=main)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml) |
```

## This PR fixes/adds/changes/removes

- Replaces the workflow run state with the text `Deprecated`
- Closes #2255 

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
