### PR TITLE
Fix module status display and remove redundant initialization

### DIFF
--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -204,13 +204,17 @@
           {{- if (eq $element.ParentModule $item.ModuleName) -}}
             {{ $child := trim (replace $element.ModuleName (print $item.ModuleName "/") "") "/" }}
             {{ if $useLinks }}
-              {{- if or (eq $element.ModuleStatus "Available") (eq $element.ModuleStatus "Orphaned") -}}
+              {{- if eq $element.ModuleStatus "Available" -}}
                 <li style="margin-left: 20px;">
-                  <a href="{{ $element.RepoURL }}" title="{{ $element.ModuleDisplayName }} | {{ $element.ModuleName }}">{{ $child }}</a>
+                  <a href="{{ $element.RepoURL }}" title="[Available 🟢] {{ $element.ModuleDisplayName }} | {{ $element.ModuleName }}">{{ $child }}</a>
+                </li>
+              {{- else if eq $element.ModuleStatus "Orphaned" -}}
+                <li style="margin-left: 20px;">
+                  <span title="[Orphaned 🟡] {{ $element.ModuleDisplayName }} ({{ $element.ModuleName }})">{{ $child }}</span>
                 </li>
               {{- else -}}
                 <li style="margin-left: 20px;">
-                  <span title="{{ $element.ModuleDisplayName }} ({{ $element.ModuleName }})">{{ $child }}</span>
+                  <span title="[Proposed ⚪] {{ $element.ModuleDisplayName }} ({{ $element.ModuleName }})">{{ $child }}</span>
                 </li>
               {{- end -}}
             {{- end -}}
@@ -349,13 +353,17 @@
           {{- if (eq $element.ParentModule $item.ModuleName) -}}
             {{ $child := trim (replace $element.ModuleName (print $item.ModuleName "/") "") "/" }}
             {{ if $useLinks }}
-              {{- if or (eq $element.ModuleStatus "Available") (eq $element.ModuleStatus "Orphaned") -}}
+              {{- if eq $element.ModuleStatus "Available" -}}
                 <li style="margin-left: 20px;">
-                  <a href="{{ $element.PublicRegistryReference }}" title="{{ $element.ModuleDisplayName }} | {{ $element.ModuleName }}">{{ $child }}</a>
+                  <a href="[Available 🟢] {{ $element.PublicRegistryReference }}" title="{{ $element.ModuleDisplayName }} | {{ $element.ModuleName }}">{{ $child }}</a>
+                </li>
+              {{- else if eq $element.ModuleStatus "Orphaned" -}}
+                <li style="margin-left: 20px;">
+                  <span title="[Orphaned 🟡] {{ $element.ModuleDisplayName }} ({{ $element.ModuleName }})">{{ $child }}</span>
                 </li>
               {{- else -}}
                 <li style="margin-left: 20px;">
-                  <span title="{{ $element.ModuleDisplayName }} ({{ $element.ModuleName }})">{{ $child }}</span>
+                  <span title="[Proposed ⚪️] {{ $element.ModuleDisplayName }} ({{ $element.ModuleName }})">{{ $child }}</span>
                 </li>
               {{- end -}}
             {{- end -}}

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -132,7 +132,6 @@
   </thead>
   {{ end }}
   {{ range $item, $maps }}
-  {{ $hasListableModules = false }}
   {{ if in $include $item.ModuleStatus }}
     {{ $moduleLatestVersion = "N/A" }}
     {{ if and (or (eq $item.ModuleStatus "Available") (eq $item.ModuleStatus "Orphaned") (eq $item.ModuleStatus "Deprecated")) (ne $item.PublicRegistryReference "n/a") }}
@@ -290,7 +289,6 @@
   </thead>
   {{ end }}
   {{ range $item, $maps }}
-  {{ $hasListableModules = false }}
   {{ if in $include $item.ModuleStatus }}
   {{ $moduleLatestVersion = "N/A" }}
     {{ if or (eq $item.ModuleStatus "Available") (eq $item.ModuleStatus "Orphaned") (eq $item.ModuleStatus "Deprecated") }}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Eliminate unnecessary initialization of `hasListableModules` in the shortcode and enhance the child module status display by adding icons for better clarity.

## This PR fixes/adds/changes/removes

1. Fix proposed module index tables by removing unnecessary initialization of `hasListableModules`
<img width="1843" height="266" alt="image" src="https://github.com/user-attachments/assets/ecf40da1-55b5-4557-b2b8-6aca414ba61d" />
2. Add child module status to the tooltip in module index tables to explicitly show when a child module is not available yet, despite the parent being available.
<img width="1747" height="778" alt="image" src="https://github.com/user-attachments/assets/a9016b29-bf1e-4e00-ba2e-1f4f25b394b6" />

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
