### PR TITLE
update documentation for retiring -module-contributors-bicep teams

### DIFF
--- a/docs/content/contributing/bicep/bicep-contribution-flow/owner-contribution-flow.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/owner-contribution-flow.md
@@ -23,27 +23,25 @@ Additional internal content for **ongoing module maintenance** available for Mic
 
 Familiarise yourself with the responsibilities as **Module Owner** outlined in [Team Definitions & RACI]({{% siteparam base %}}/specs/shared/team-definitions/#module-owners) and [Module Owner Responsibilities]({{% siteparam base %}}/help-support/issue-triage/brm-issue-triage/#module-owner-responsibilities) in the [BRM Issue Triage]({{% siteparam base %}}/help-support/issue-triage/brm-issue-triage/).
 
-1. Create GitHub teams as outlined in [SNFR20]({{% siteparam base %}}/spec/SNFR20) and add respective parent teams:
+1. Create a GitHub team as outlined in [SNFR20]({{% siteparam base %}}/spec/SNFR20) and add it to the respective parent team:
 
-    Segments:
+    Naming convention:
 
     - `avm-res-<RP>-<modulename>-module-owners-bicep`
-    - `avm-res-<RP>-<modulename>-module-contributors-bicep`
 
-    Examples:
+    Example:
 
     - `avm-res-compute-virtualmachine-module-owners-bicep` and added `avm-technical-reviewers-bicep` as parent.
-    - `avm-res-compute-virtualmachine-module-contributors-bicep` and added `avm-module-contributors-bicep` as parent.
 
-    If a secondary owner is required, add the secondary owner to the `avm-res-<RP>-<modulename>-module-owners-bicep` team.
+    If a secondary or any additional owner is required, add them to the `avm-res-<RP>-<modulename>-module-owners-bicep` team.
 
     Only fulltime Microsoft employees can be added at this time.
 
     {{% notice style="info" %}}
-Once the teams have been created the AVM Core Team will review the team name and parent team membership for accuracy. A notification will automatically be sent to the AVM Core Team to inform them that their review needs to be completed.
+Once the team have been created the AVM Core Team will review the team name and parent team membership for accuracy. A notification will automatically be sent to the AVM Core Team to inform them that their review needs to be completed.
     {{% /notice %}}
 
-2. Add teams to `CODEOWNERS` file as outlined in [SNFR20]({{% siteparam base %}}/spec/SNFR20).
+2. Add the `-owners-` team to `CODEOWNERS` file as outlined in [SNFR20]({{% siteparam base %}}/spec/SNFR20).
 3. Ensure your module has been tested before raising a PR. You can do this your own or in another module contributor's environment - if any. Also, once a PR is raised, a GitHub workflow pipeline is required to be run successfully before the PR can be merged. This is to ensure that the module is working as expected and is compliant with the AVM specifications.
 {{% notice style="note" %}}
 
@@ -59,8 +57,8 @@ If you're the **sole owner of the module**, the **AVM core team must review and 
 Under certain circumstances, you may find yourself unable to continue as the module owner. In such cases, it is advisable to designate a new module owner. The following steps outline this transition:
 
 - Leave a comment on the original module proposal, indicating that you'd like to hand the ownership over to somebody else. Mention the person who originally helped triage the issue or the `@Azure/avm-core-team-technical-bicep` team. You must wait for someone from the AVM Core Team to respond first, as the module index must be updated before you can continue handing over the ownership.
-- Add the new owner's GitHub account as a "maintainer" on your modules GitHub teams.
-- Remove your GitHub account from your module's GitHub teams.
+- Add the new owner's GitHub account as a "maintainer" on your modules GitHub team.
+- Remove your GitHub account from your module's GitHub team.
 
 If a new module owner cannot be identified then the module will need to be "Orphaned". Please follow the step outlined [when-a-module-becomes-orphaned]({{% siteparam base %}}/help-support/issue-triage/avm-issue-triage/#when-a-module-becomes-orphaned).
 

--- a/docs/content/help-support/issue-triage/avm-issue-triage.md
+++ b/docs/content/help-support/issue-triage/avm-issue-triage.md
@@ -230,7 +230,7 @@ To look for Orphaned Modules:
     - Add the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#C8E6C9;">Status: Module Available 🟢</mark>&nbsp; and &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FBEF2A;">Status: Owners Identified 🤘</mark>&nbsp; labels to the issue.
     - Move the issue into the "`Done`" column on the [AVM - Modules Triage](https://aka.ms/avm/moduletriage) GitHub Project board.
 3. Update the AVM Module Indexes, following the [process documented internally](https://dev.azure.com/CSUSolEng/Azure%20Verified%20Modules/_wiki/wikis/AVM%20Internal%20Wiki/684/Module-index-update-process).
-4. Get the new owner(s) and any new contributor(s) added to the related `-module-owners-` or `-module-contributors-` teams as applicable. See [SNFR20]({{% siteparam base %}}/spec/SNFR20) for more details.
+4. Get the new owner(s) added to the related `-module-owners-` team as applicable. See [SNFR20]({{% siteparam base %}}/spec/SNFR20) for more details.
 5. Remove the information notice (i.e., the file that states that `⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️, etc.` ):
     - In case of a Bicep module:
       - Delete the `ORPHANED.md` file from the module's root.
@@ -276,13 +276,12 @@ If a module meets the criteria described in the "[Deprecated Modules]({{% sitepa
     1. Remove the module from the [`CODEOWNERS`](https://github.com/Azure/bicep-registry-modules/blob/main/.github/CODEOWNERS) file.
     1. Submit a Pull Request
     1. For the AVM maintainers: Once the PR is merged, run the [.Platform - Publish [moduleIndex.json]](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.publish-module-index-json.yml) workflow with the `regenIndexFromBRM` flag set. This will de-list the module so that it won't show up in the VS-Code Bicep extension going forward.
-7. Delete the module's `-owners-` and `-contributors-` GitHub teams.
+7. Delete the module's `-owners-` GitHub teams.
 
 **Terraform specific steps**
 
 4. Place the information notice - with the text below - in the `README.md` file, in the module's root.
 5. Archive the module's repository on GitHub.
-6. Keep the module's `-owners-` and `-contributors-` GitHub teams, as these will keep granting access to the source code of the module.
 
 **Deprecation information notice** (to be place in the module's repository as described above)
 

--- a/docs/content/help-support/issue-triage/avm-issue-triage.md
+++ b/docs/content/help-support/issue-triage/avm-issue-triage.md
@@ -138,8 +138,8 @@ Although, it's not directly part of the module proposal triage process, to begin
 
 1. Update any Azure RBAC permissions for test tenants/subscription, if needed.
 2. In case of **Bicep modules** only:
-    - Look for the module owners confirmation on the related `[Module Proposal]` issue that they have created the required `-module-owners-` and `-module-contributors-` GitHub teams.
-    - Ensure the `-module-owners-` and `-module-contributors-` GitHub teams have been assigned to their respective parent teams as outlined [here]({{% siteparam base %}}/spec/snfr20/#grant-permissions---bicep).
+    - Look for the module owners confirmation on the related `[Module Proposal]` issue that they have created the required `-module-owners-` GitHub team.
+    - Ensure the `-module-owners-` GitHub team has been assigned to its respective parent team as outlined [here]({{% siteparam base %}}/spec/snfr20/#grant-permissions---bicep).
     - Ensure the [`CODEOWNERS`](https://github.com/Azure/bicep-registry-modules/blob/main/.github/CODEOWNERS) file in the [BRM repo](https://aka.ms/BRM) has been updated.
     - Ensure the [`AVM Module Issue template`](https://github.com/Azure/bicep-registry-modules/blob/main/.github/ISSUE_TEMPLATE/avm_module_issue.yml) file in the [BRM repo](https://aka.ms/BRM) has been updated.
 
@@ -230,7 +230,7 @@ To look for Orphaned Modules:
     - Add the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#C8E6C9;">Status: Module Available 🟢</mark>&nbsp; and &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FBEF2A;">Status: Owners Identified 🤘</mark>&nbsp; labels to the issue.
     - Move the issue into the "`Done`" column on the [AVM - Modules Triage](https://aka.ms/avm/moduletriage) GitHub Project board.
 3. Update the AVM Module Indexes, following the [process documented internally](https://dev.azure.com/CSUSolEng/Azure%20Verified%20Modules/_wiki/wikis/AVM%20Internal%20Wiki/684/Module-index-update-process).
-4. Get the new owner(s) and any new contributor(s) added to the related `-module-owners-` or `-module-contributors-` teams. See [SNFR20]({{% siteparam base %}}/spec/SNFR20) for more details.
+4. Get the new owner(s) and any new contributor(s) added to the related `-module-owners-` or `-module-contributors-` teams as applicable. See [SNFR20]({{% siteparam base %}}/spec/SNFR20) for more details.
 5. Remove the information notice (i.e., the file that states that `⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️, etc.` ):
     - In case of a Bicep module:
       - Delete the `ORPHANED.md` file from the module's root.

--- a/docs/content/indexes/bicep/bicep-pattern-modules.md
+++ b/docs/content/indexes/bicep/bicep-pattern-modules.md
@@ -80,13 +80,13 @@ Modules listed below that aren't shown with the status of **`Module Available �
 
 {{% notice style="note" %}}
 
-This section is mainly intended **for module owners and contributors** as it contains information important for module development, such as **telemetry ID prefix, and GitHub Teams for Owners & Contributors**.
+This section is mainly intended **for module owners and contributors** as it contains information important for module development, such as **telemetry ID prefix, and GitHub Teams for Owners**.
 
 {{% /notice %}}
 
-### Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors
+### Module name, Telemetry ID prefix, GitHub Teams for Owners
 
-{{% expand title="➕ All Modules - Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" expanded="false" %}}
+{{% expand title="➕ All Modules - Module name, Telemetry ID prefix, GitHub Teams for Owners" expanded="false" %}}
 
 {{% moduleNameTelemetryGHTeams header=true csv="/static/module-indexes/BicepPatternModules.csv" language="Bicep" moduleType="pattern" %}}
 

--- a/docs/content/indexes/bicep/bicep-resource-modules.md
+++ b/docs/content/indexes/bicep/bicep-resource-modules.md
@@ -78,13 +78,13 @@ Modules listed below that aren't shown with the status of **`Module Available �
 
 {{% notice style="note" %}}
 
-This section is mainly intended **for module owners and contributors** as it contains information important for module development, such as **telemetry ID prefix, and GitHub Teams for Owners & Contributors**.
+This section is mainly intended **for module owners and contributors** as it contains information important for module development, such as **telemetry ID prefix, and GitHub Teams for Owners**.
 
 {{% /notice %}}
 
-### Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors
+### Module name, Telemetry ID prefix, GitHub Teams for Owners
 
-{{% expand title="➕ All Modules - Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" expanded="false" %}}
+{{% expand title="➕ All Modules - Module name, Telemetry ID prefix, GitHub Teams for Owners" expanded="false" %}}
 
 {{% moduleNameTelemetryGHTeams header=true csv="/static/module-indexes/BicepResourceModules.csv" language="Bicep" moduleType="resource" %}}
 

--- a/docs/content/indexes/bicep/bicep-utility-modules.md
+++ b/docs/content/indexes/bicep/bicep-utility-modules.md
@@ -78,13 +78,13 @@ Modules listed below that aren't shown with the status of **`Module Available �
 
 {{% notice style="note" %}}
 
-This section is mainly intended **for module owners and contributors** as it contains information important for module development, such as **telemetry ID prefix, and GitHub Teams for Owners & Contributors**.
+This section is mainly intended **for module owners and contributors** as it contains information important for module development, such as **telemetry ID prefix, and GitHub Teams for Owners**.
 
 {{% /notice %}}
 
-### Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors
+### Module name, Telemetry ID prefix, GitHub Teams for Owners
 
-{{% expand title="➕ All Modules - Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" expanded="false" %}}
+{{% expand title="➕ All Modules - Module name, Telemetry ID prefix, GitHub Teams for Owners" expanded="false" %}}
 
 {{% moduleNameTelemetryGHTeams header=true csv="/static/module-indexes/BicepUtilityModules.csv" language="Bicep" moduleType="utility" %}}
 

--- a/docs/content/indexes/terraform/tf-pattern-modules.md
+++ b/docs/content/indexes/terraform/tf-pattern-modules.md
@@ -73,19 +73,3 @@ Modules listed below that aren't shown with the status of **`Module Available ðŸ
 {{% moduleHistory header=true csv="/static/module-indexes/TerraformPatternModules.csv" language="Terraform" moduleType="pattern" exclude="Proposed" monthsToShow=9999 %}}
 
 {{% /expand %}}
-
-## For Module Owners & Contributors
-
-{{% notice style="note" %}}
-
-This section is mainly intended **for module owners and contributors** as it contains information about the **GitHub Teams for Owners & Contributors**.
-
-{{% /notice %}}
-
-### Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors
-
-{{% expand title="âž• All Modules - Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" expanded="false" %}}
-
-{{% moduleNameTelemetryGHTeams header=true csv="/static/module-indexes/TerraformPatternModules.csv" language="Terraform" moduleType="pattern"%}}
-
-{{% /expand %}}

--- a/docs/content/indexes/terraform/tf-resource-modules.md
+++ b/docs/content/indexes/terraform/tf-resource-modules.md
@@ -73,19 +73,3 @@ Modules listed below that aren't shown with the status of **`Module Available ðŸ
 {{% moduleHistory header=true csv="/static/module-indexes/TerraformResourceModules.csv" language="Terraform" moduleType="resource" exclude="Proposed" monthsToShow=9999 %}}
 
 {{% /expand %}}
-
-## For Module Owners & Contributors
-
-{{% notice style="note" %}}
-
-This section is mainly intended **for module owners and contributors** as it contains information about the **GitHub Teams for Owners & Contributors**.
-
-{{% /notice %}}
-
-### Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors
-
-{{% expand title="âž• All Modules - Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" expanded="false" %}}
-
-{{% moduleNameTelemetryGHTeams header=true csv="/static/module-indexes/TerraformResourceModules.csv" language="Terraform" moduleType="resource" %}}
-
-{{% /expand %}}

--- a/docs/content/indexes/terraform/tf-utility-modules.md
+++ b/docs/content/indexes/terraform/tf-utility-modules.md
@@ -73,19 +73,3 @@ Modules listed below that aren't shown with the status of **`Module Available ðŸ
 {{% moduleHistory header=true csv="/static/module-indexes/TerraformUtilityModules.csv" language="Terraform" moduleType="utility" exclude="Proposed" monthsToShow=9999 %}}
 
 {{% /expand %}}
-
-## For Module Owners & Contributors
-
-{{% notice style="note" %}}
-
-This section is mainly intended **for module owners and contributors** as it contains information about the **GitHub Teams for Owners & Contributors**.
-
-{{% /notice %}}
-
-### Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors
-
-{{% expand title="âž• All Modules - Module name, Telemetry ID prefix, GitHub Teams for Owners & Contributors" expanded="false" %}}
-
-{{% moduleNameTelemetryGHTeams header=true csv="/static/module-indexes/TerraformUtilityModules.csv" language="Terraform" moduleType="utility"%}}
-
-{{% /expand %}}

--- a/docs/content/specs-defs/includes/shared/shared/functional/SFR3.md
+++ b/docs/content/specs-defs/includes/shared/shared/functional/SFR3.md
@@ -53,7 +53,7 @@ The following information notice is automatically added at the bottom of the `RE
 ### Bicep
 
 {{% notice style="important" %}}
-The value you need to use for your module is defined in the related module index. You can look it up on the index pages for [Resource Modules]({{% siteparam base %}}/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors), [Pattern Modules]({{% siteparam base %}}/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors) and [Utility Modules]({{% siteparam base %}}/indexes/bicep/bicep-utility-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors).
+The value you need to use for your module is defined in the related module index. You can look it up on the index pages for [Resource Modules]({{% siteparam base %}}/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners), [Pattern Modules]({{% siteparam base %}}/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners) and [Utility Modules]({{% siteparam base %}}/indexes/bicep/bicep-utility-modules/#module-name-telemetry-id-prefix-github-teams-for-owners).
 {{% /notice %}}
 
 The ARM deployment name used for the telemetry **MUST** follow the pattern and **MUST** be no longer than 64 characters in length: `46d3xbcp.<res/ptn>.<(short) module name>.<version>.<uniqueness>`

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
@@ -124,7 +124,7 @@ Example - `CODEOWNERS` entry for the Bicep resource module of Azure Virtual Netw
 ### Terraform
 
 {{% notice style="note" %}}
-Access management for Terraform repositories has been changed to...
+Access management for Terraform repositories now uses a single team, membership of which is managed using an internal entitlement management tool. All module owners are members of [avm-module-owners-terraform](https://github.com/orgs/Azure/teams/avm-module-owners-terraform).
 {{% /notice %}}
 
 Permissions in case of Terraform repositories are granted through...

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
@@ -22,69 +22,66 @@ priority: 1110
 
 All GitHub repositories that AVM module are published from and hosted within **MUST** only assign GitHub repository permissions to GitHub teams only.
 
-Each module **MUST** have separate GitHub teams assigned for module owners **AND** module contributors respectively. These GitHub teams **MUST** be created in the [Azure organization](https://github.com/orgs/Azure/teams) in GitHub.
+Each module **MUST** have a GitHub team assigned for module owners. This team **MUST** be created in the [Azure organization](https://github.com/orgs/Azure/teams) in GitHub.
 
 There **MUST NOT** be any GitHub repository permissions assigned to individual users.
+
+{{% notice style="important" %}}
+Non-FTE / external contributors (subject matter experts that aren't Microsoft employees) can't be members of the teams described in this chapter, hence, they won't gain any extra permissions on AVM repositories, therefore, they need to work in forks.
+{{% /notice %}}
+
+### Bicep
 
 {{% notice style="note" %}}
 The names for the GitHub teams for each approved module are already defined in the respective [Module Indexes]({{% siteparam base %}}/indexes/). These teams **MUST** be created (and used) for each module.
 
 - [Bicep Resource Modules]({{% siteparam base %}}/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners)
 - [Bicep Pattern Modules]({{% siteparam base %}}/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners)
-- [Terraform Resource Modules]({{% siteparam base %}}/indexes/terraform/tf-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners)
-- [Terraform Pattern Modules]({{% siteparam base %}}/indexes/terraform/tf-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners)
+- [Bicep Utility Modules]({{% siteparam base %}}/indexes/bicep/bicep-utility-modules/#module-name-telemetry-id-prefix-github-teams-for-owners)
 
 The `@Azure` prefix in the last column of the tables linked above represents the "Azure" GitHub organization all AVM-related repositories exist in. **DO NOT** include this segment in the team's name!
 
 {{% /notice %}}
 
-{{% notice style="important" %}}
-Non-FTE / external contributors (subject matter experts that aren't Microsoft employees) can't be members of the teams described in this chapter, hence, they won't gain any extra permissions on AVM repositories, therefore, they need to work in forks.
-{{% /notice %}}
 
-### Naming Convention
+
+#### Naming Convention
 
 The naming convention for the GitHub teams **MUST** follow the below pattern:
 
-- `<hyphenated module name>-module-owners-<bicep/tf>` - to grant permissions for module owners
-- `<hyphenated module name>-module-contributors-tf` - to grant permissions for module contributors (for Terraform modules only)
-
-{{% notice style="note" %}}
-The naming convention for Bicep modules is slightly different than the naming convention for their respective GitHub teams.
-{{% /notice %}}
+- `<hyphenated module name>-module-owners-bicep` - to grant permissions for module owners on Bicep modules
 
 Segments:
 
 - `<hyphenated module name>` == the AVM Module's name, with each segment separated by dashes, i.e., `avm-res-<resource provider>-<ARM resource type>`
   - See [RMNFR1]({{% siteparam base %}}/spec/RMNFR1) for AVM Resource Module Naming
   - See [PMNFR1]({{% siteparam base %}}/spec/PMNFR1) for AVM Pattern Module Naming
-- `module-owners` or `module-contributors` == the role the GitHub Team is assigned to
-- `<bicep/tf>` == the language the module is written in
+- `module-owners` == the role the GitHub Team is assigned to
+- `<bicep` == the language the module is written in
 
 Examples:
 
 - `avm-res-compute-virtualmachine-module-owners-bicep`
-- `avm-res-compute-virtualmachine-module-contributors-tf`
 
-### Add Team Members
+{{% notice style="note" %}}
+The naming convention for Bicep modules is slightly different than the naming convention for their respective GitHub teams.
+{{% /notice %}}
+
+#### Add Team Members
 
 All officially documented module owner(s) **MUST** be added to the `-module-owners-` team. The `-module-owners-` team **MUST NOT** have any other members.
 
-In case of Terraform modules, any additional module contributors whom the module owner(s) agreed to work with **MUST** be added to the `-module-contributors-` team.
+Unless explicitly requested and agreed, members of the AVM core team or any PG teams **MUST NOT** be added to the `-module-owners-` teams as permissions for them are granted through the teams described in [SNFR9]({{% siteparam base %}}/spec/SNFR9).
 
-Unless explicitly requested and agreed, members of the AVM core team or any PG teams **MUST NOT** be added to the `-module-owners-` or `-module-contributors-` teams as permissions for them are granted through the teams described in [SNFR9]({{% siteparam base %}}/spec/SNFR9).
-
-### Grant Permissions - Bicep
-
-### Team memberships
+#### Grant permissions through team memberships
 
 {{% notice style="note" %}}
 
-In case of Bicep modules, permissions to the [BRM](https://aka.ms/BRM) repository (the repo of the Bicep Registry) are granted via assigning the `-module-owners-` and `-module-contributors-` teams to parent teams that already have the required level access configured. While it is the module owner's responsibility to initiate the addition of their teams to the respective parents, only the AVM core team can approve this parent-child relationship.
+In case of Bicep modules, permissions to the [BRM](https://aka.ms/BRM) repository (the repo of the Bicep Registry) are granted via assigning the `-module-owners-` teams to parent teams that already have the required level access configured. While it is the module owner's responsibility to initiate the addition of their team to the respective parent, only the AVM core team can approve this parent-child relationship.
 
 {{% /notice %}}
 
-Module owners **MUST** create their `-module-owners-` team and as part of the provisioning process, they **MUST** request the addition of this team to its respective parent teams (see the table below for details).
+Module owners **MUST** create their `-module-owners-` team and as part of the provisioning process, they **MUST** request the addition of this team to its respective parent team (see the table below for details).
 
 | GitHub Team Name                                     | Description                                    | Permissions | Permissions granted through                                        | Where to work?          |
 |------------------------------------------------------|------------------------------------------------|-------------|--------------------------------------------------------------------|-------------------------|
@@ -106,7 +103,7 @@ Fill in the values as follows:
 - **Team notifications**: `Enabled`
 {{% /notice %}}
 
-### CODEOWNERS file
+#### CODEOWNERS file
 
 As part of the "initial Pull Request" (that publishes the first version of the module), module owners **MUST** add an entry to the `CODEOWNERS` file in the BRM repository ([here](https://github.com/Azure/bicep-registry-modules/blob/main/.github/CODEOWNERS)).
 
@@ -124,23 +121,10 @@ Example - `CODEOWNERS` entry for the Bicep resource module of Azure Virtual Netw
 
 - `/avm/res/network/virtual-network/ @Azure/avm-res-network-virtualnetwork-module-owners-bicep @Azure/avm-module-reviewers-bicep`
 
-### Grant Permissions - Terraform
+### Terraform
 
-Module owners **MUST** assign the `-module-owners-`and `-module-contributors-` teams the necessary permissions on their Terraform module repository per the guidance below.
-
-| GitHub Team Name                       | Description                                       | Permissions | Permissions granted through | Where to work?                                                                                |
-|----------------------------------------|---------------------------------------------------|-------------|-----------------------------|-----------------------------------------------------------------------------------------------|
-| `<module name>-module-owners-tf`       | AVM Terraform Module Owners - \<module name>       | **Admin**   | Direct assignment to repo   | Module owner can decide whether they want to work in a branch local to the repo or in a fork. |
-| `<module name>-module-contributors-tf` | AVM Terraform Module Contributors - \<module name> | **Write**   | Direct assignment to repo   | Need to work in a fork.                                                                       |
-
-{{% notice style="tip" %}}
-Direct link to create a new GitHub team: [Create new team](https://github.com/orgs/Azure/new-team)
-
-Fill in the values as follows:
-
-- **Team name**: Following the naming convention described above, use the value defined in the module indexes.
-- **Description**: Follow the guidance above (see the Description column in the table above).
-- **Parent team**: Do not assign the team to any parent team.
-- **Team visibility**: `Visible`
-- **Team notifications**: `Enabled`
+{{% notice style="note" %}}
+Access management for Terraform repositories has been changed to...
 {{% /notice %}}
+
+Permissions in case of Terraform repositories are granted through...

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
@@ -127,4 +127,4 @@ Example - `CODEOWNERS` entry for the Bicep resource module of Azure Virtual Netw
 Access management for Terraform repositories now uses a single team, membership of which is managed using an internal entitlement management tool. All module owners are members of [avm-module-owners-terraform](https://github.com/orgs/Azure/teams/avm-module-owners-terraform).
 {{% /notice %}}
 
-Permissions in case of Terraform repositories are granted through...
+Permissions in case of Terraform repositories are granted though an internal tool called Core Identity.

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
@@ -124,7 +124,7 @@ Example - `CODEOWNERS` entry for the Bicep resource module of Azure Virtual Netw
 ### Terraform
 
 {{% notice style="note" %}}
-Access management for Terraform repositories now uses a single team, membership of which is managed using an internal entitlement management tool. All module owners are members of [avm-module-owners-terraform](https://github.com/orgs/Azure/teams/avm-module-owners-terraform).
+Access management for Terraform repositories now uses a single team, membership of which is managed using an internal entitlement management tool (Core Identity).
 {{% /notice %}}
 
-Permissions in case of Terraform repositories are granted though an internal tool called Core Identity.
+All module owners **MUST** request access to the [`avm-module-owners-terraform`](https://github.com/orgs/Azure/teams/avm-module-owners-terraform) GitHub team via the `Azure Verified Module Owners Terraform` entitlement in Core Identity (Microsoft internal tool).

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
@@ -29,10 +29,10 @@ There **MUST NOT** be any GitHub repository permissions assigned to individual u
 {{% notice style="note" %}}
 The names for the GitHub teams for each approved module are already defined in the respective [Module Indexes]({{% siteparam base %}}/indexes/). These teams **MUST** be created (and used) for each module.
 
-- [Bicep Resource Modules]({{% siteparam base %}}/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
-- [Bicep Pattern Modules]({{% siteparam base %}}/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
-- [Terraform Resource Modules]({{% siteparam base %}}/indexes/terraform/tf-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
-- [Terraform Pattern Modules]({{% siteparam base %}}/indexes/terraform/tf-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners--contributors)
+- [Bicep Resource Modules]({{% siteparam base %}}/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners)
+- [Bicep Pattern Modules]({{% siteparam base %}}/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners)
+- [Terraform Resource Modules]({{% siteparam base %}}/indexes/terraform/tf-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners)
+- [Terraform Pattern Modules]({{% siteparam base %}}/indexes/terraform/tf-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners)
 
 The `@Azure` prefix in the last column of the tables linked above represents the "Azure" GitHub organization all AVM-related repositories exist in. **DO NOT** include this segment in the team's name!
 
@@ -46,8 +46,8 @@ Non-FTE / external contributors (subject matter experts that aren't Microsoft em
 
 The naming convention for the GitHub teams **MUST** follow the below pattern:
 
-- `<hyphenated module name>-module-owners-<bicep/tf>` - to be assigned as the GitHub repository's `Module Owners` team
-- `<hyphenated module name>-module-contributors-<bicep/tf>` - to be assigned as the GitHub repository's `Module Contributors` team
+- `<hyphenated module name>-module-owners-<bicep/tf>` - to grant permissions for module owners
+- `<hyphenated module name>-module-contributors-tf` - to grant permissions for module contributors (for Terraform modules only)
 
 {{% notice style="note" %}}
 The naming convention for Bicep modules is slightly different than the naming convention for their respective GitHub teams.
@@ -70,7 +70,7 @@ Examples:
 
 All officially documented module owner(s) **MUST** be added to the `-module-owners-` team. The `-module-owners-` team **MUST NOT** have any other members.
 
-Any additional module contributors whom the module owner(s) agreed to work with **MUST** be added to the `-module-contributors-` team.
+In case of Terraform modules, any additional module contributors whom the module owner(s) agreed to work with **MUST** be added to the `-module-contributors-` team.
 
 Unless explicitly requested and agreed, members of the AVM core team or any PG teams **MUST NOT** be added to the `-module-owners-` or `-module-contributors-` teams as permissions for them are granted through the teams described in [SNFR9]({{% siteparam base %}}/spec/SNFR9).
 
@@ -84,17 +84,15 @@ In case of Bicep modules, permissions to the [BRM](https://aka.ms/BRM) repositor
 
 {{% /notice %}}
 
-Module owners **MUST** create their `-module-owners-` and `-module-contributors-` teams and as part of the provisioning process, they **MUST** request the addition of these teams to their respective parent teams (see the table below for details).
+Module owners **MUST** create their `-module-owners-` team and as part of the provisioning process, they **MUST** request the addition of this team to its respective parent teams (see the table below for details).
 
 | GitHub Team Name                                     | Description                                    | Permissions | Permissions granted through                                        | Where to work?          |
 |------------------------------------------------------|------------------------------------------------|-------------|--------------------------------------------------------------------|-------------------------|
 | `<hyphenated module name>-module-owners-bicep`       | AVM Bicep Module Owners - \<module name>       | **Write**   | Assignment to the **`avm-technical-reviewers-bicep`** parent team. | Need to work in a fork. |
-| `<hyphenated module name>-module-contributors-bicep` | AVM Bicep Module Contributors - \<module name> | **Triage**  | **`avm-module-contributors-bicep`** parent team.                   | Need to work in a fork. |
 
-Examples - GitHub teams required for the Bicep resource module of Azure Virtual Network (`avm/res/network/virtual-network`):
+Example - GitHub team required for the Bicep resource module of Azure Virtual Network (`avm/res/network/virtual-network`):
 
 - `avm-res-network-virtualnetwork-module-owners-bicep` --> assign to the `avm-technical-reviewers-bicep` parent team.
-- `avm-res-network-virtualnetwork-module-contributors-bicep` --> assign to the `avm-module-contributors-bicep` parent team.
 
 {{% notice style="tip" %}}
 Direct link to create a new GitHub team and assign it to its parent: [Create new team](https://github.com/orgs/Azure/new-team)

--- a/docs/layouts/shortcodes/moduleNameTelemetryGHTeams.html
+++ b/docs/layouts/shortcodes/moduleNameTelemetryGHTeams.html
@@ -124,7 +124,7 @@
       <th>No.</th>
       <th>Module Name</th>
       <th>Telemetry ID prefix</th>
-      <th>GitHub Teams for Module Owners and Contributors</th>
+      <th>GitHub Teams for Module Owners (<code>@Azure</code> org)</th>
     </tr>
   </thead>
   {{ end }}
@@ -151,14 +151,10 @@
     <td> {{/* GH teams */}}
       {{- if or (eq $ParentModuleColumnId 0) (eq $item.ParentModule "n/a") -}}
         <code style="white-space:normal;">{{ $item.ModuleOwnersGHTeam }}</code>
-        <br>
-        <code style="white-space:normal;">{{ $item.ModuleContributorsGHTeam }}</code>
       {{- else -}}
         {{- range $element, $maps -}}
           {{- if eq $element.ModuleName $item.ParentModule -}}
             <code style="white-space:normal;">{{ $element.ModuleOwnersGHTeam }}</code>
-            <br>
-            <code style="white-space:normal;">{{ $element.ModuleContributorsGHTeam }}</code>
           {{- end -}}
         {{- end -}}
       {{- end -}}

--- a/docs/layouts/shortcodes/moduleNameTelemetryGHTeams.html
+++ b/docs/layouts/shortcodes/moduleNameTelemetryGHTeams.html
@@ -150,11 +150,13 @@
     </td>
     <td> {{/* GH teams */}}
       {{- if or (eq $ParentModuleColumnId 0) (eq $item.ParentModule "n/a") -}}
-        <code style="white-space:normal;">{{ $item.ModuleOwnersGHTeam }}</code>
+        {{- $cleanTeamName := replace $item.ModuleOwnersGHTeam "@Azure/" "" -}}
+        <code style="white-space:normal;">{{ $cleanTeamName }}</code>
       {{- else -}}
         {{- range $element, $maps -}}
           {{- if eq $element.ModuleName $item.ParentModule -}}
-            <code style="white-space:normal;">{{ $element.ModuleOwnersGHTeam }}</code>
+            {{- $cleanTeamName := replace $element.ModuleOwnersGHTeam "@Azure/" "" -}}
+            <code style="white-space:normal;">{{ $cleanTeamName }}</code>
           {{- end -}}
         {{- end -}}
       {{- end -}}
@@ -178,7 +180,7 @@
     <tr>
       <th>No.</th>
       <th>Module Name</th>
-      <th>GitHub Teams for Module Owners and Contributors</th>
+      <th>GitHub Teams for Module Owners and Contributors (<code>@Azure</code> org)</th>
     </tr>
   </thead>
   {{ end }}
@@ -201,15 +203,19 @@
     </td>
     <td> {{/* GH teams */}}
       {{- if eq $item.ParentModule "n/a" -}}
-        <code style="white-space:normal;">{{ $item.ModuleOwnersGHTeam }}</code>
+        {{- $cleanOwnersTeamName := replace $item.ModuleOwnersGHTeam "@Azure/" "" -}}
+        {{- $cleanContributorsTeamName := replace $item.ModuleContributorsGHTeam "@Azure/" "" -}}
+        <code style="white-space:normal;">{{ $cleanOwnersTeamName }}</code>
         <br>
-        <code style="white-space:normal;">{{ $item.ModuleContributorsGHTeam }}</code>
+        <code style="white-space:normal;">{{ $cleanContributorsTeamName }}</code>
       {{- else -}}
         {{- range $element, $maps -}}
           {{- if eq $element.ModuleName $item.ParentModule -}}
-            <code style="white-space:normal;">{{ $element.ModuleOwnersGHTeam }}</code>
+            {{- $cleanOwnersTeamName := replace $element.ModuleOwnersGHTeam "@Azure/" "" -}}
+            {{- $cleanContributorsTeamName := replace $element.ModuleContributorsGHTeam "@Azure/" "" -}}
+            <code style="white-space:normal;">{{ $cleanOwnersTeamName }}</code>
             <br>
-            <code style="white-space:normal;">{{ $element.ModuleContributorsGHTeam }}</code>
+            <code style="white-space:normal;">{{ $cleanContributorsTeamName }}</code>
           {{- end -}}
         {{- end -}}
       {{- end -}}

--- a/docs/layouts/shortcodes/moduleNameTelemetryGHTeams.html
+++ b/docs/layouts/shortcodes/moduleNameTelemetryGHTeams.html
@@ -202,7 +202,7 @@
       {{- end -}}
     </td>
     <td> {{/* GH teams */}}
-      {{- if eq $item.ParentModule "n/a" -}}
+      {{- if or (eq $ParentModuleColumnId 0) (eq $item.ParentModule "n/a") -}}
         {{- $cleanOwnersTeamName := replace $item.ModuleOwnersGHTeam "@Azure/" "" -}}
         {{- $cleanContributorsTeamName := replace $item.ModuleContributorsGHTeam "@Azure/" "" -}}
         <code style="white-space:normal;">{{ $cleanOwnersTeamName }}</code>


### PR DESCRIPTION
# Overview/Summary

This pull request updates documentation to simplify and clarify the management of GitHub teams for module ownership, focusing on removing references to "contributors" teams and standardizing guidance for "owners" teams only. The changes affect Bicep and Terraform documentation, as well as related process and specification files.

**Key documentation and process updates:**

### GitHub Team Management and Ownership Process

* Updated instructions to require only the creation and management of `-owners-` GitHub teams for modules, removing references to `-contributors-` teams throughout the owner contribution flow and triage documentation. This includes changes to team naming conventions, parent team assignments, and steps for transferring or orphaning module ownership. [[1]](diffhunk://#diff-56e231b00066cc282eb366066e44e1be174433ca27a7216673123b4e28468caeL26-R44) [[2]](diffhunk://#diff-56e231b00066cc282eb366066e44e1be174433ca27a7216673123b4e28468caeL62-R61) [[3]](diffhunk://#diff-6e60cc02855ddc05cb727a7e41e44eb76f6264e5de64c6266d8ebc02163764f9L141-R142) [[4]](diffhunk://#diff-6e60cc02855ddc05cb727a7e41e44eb76f6264e5de64c6266d8ebc02163764f9L233-R233) [[5]](diffhunk://#diff-6e60cc02855ddc05cb727a7e41e44eb76f6264e5de64c6266d8ebc02163764f9L279-L285)

### Module Index and Reference Documentation

* Updated all Bicep module index pages (`bicep-resource-modules.md`, `bicep-pattern-modules.md`, `bicep-utility-modules.md`) to remove references to contributor teams and focus on owner teams in section titles, notices, and expandable content. [[1]](diffhunk://#diff-f919ea76097ee2abcd414c29fccfd080be00d6346bb56ae0de355907d28e32b9L81-R87) [[2]](diffhunk://#diff-80f22d4f8de25349a6987a51af528f5eafc4a48eed9bdfaccc12b23694ec60beL83-R89) [[3]](diffhunk://#diff-43f0f7bb3efba41c5a93c0efe37c71c50884b393986eea126e76052899201feaL81-R87)
* Removed the "For Module Owners & Contributors" sections and related details from all Terraform module index pages to align with the new owner-only team approach. [[1]](diffhunk://#diff-a0247b2cfa4adfc83d6ec6f263239d191683a015a23d803e7e943d73e9d4d56aL76-L91) [[2]](diffhunk://#diff-be65f327ff5419a3385fd8af1df404d5b661706d46dfff883756e281f26b4ff5L76-L91) [[3]](diffhunk://#diff-d7480020190215b4978ce78959acd91d5a25e866f840fd39b13fe20623e6e753L76-L91)
* Updated cross-references in shared specification files to point to the new owner-centric section anchors in module index documentation.

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
