### PR TITLE
Update labels for proposed module owners in orphaned module template

### DIFF
--- a/.github/ISSUE_TEMPLATE/5_orphaned_module.yml
+++ b/.github/ISSUE_TEMPLATE/5_orphaned_module.yml
@@ -63,15 +63,15 @@ body:
   - type: input
     id: owner-gh-un
     attributes:
-      label: Module Owner's GitHub Username (handle)
+      label: Newly Proposed Module Owner's GitHub Username (handle)
       description: Please provide the proposed module owner's GitHub username, leave blank if unknown
     validations:
       required: false
   - type: input
     id: sec-owner-gh-un
     attributes:
-      label: (Optional) Secondary Module Owner's GitHub Username (handle)
-      description: Please provide the secondary module owner's GitHub username, leave blank if unknown!
+      label: (Optional) Newly Proposed Secondary Module Owner's GitHub Username (handle)
+      description: Please provide the proposed secondary module owner's GitHub username, leave blank if unknown!
     validations:
       required: false
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/5_orphaned_module.yml
+++ b/.github/ISSUE_TEMPLATE/5_orphaned_module.yml
@@ -63,7 +63,7 @@ body:
   - type: input
     id: owner-gh-un
     attributes:
-      label: Newly Proposed Module Owner's GitHub Username (handle)
+      label: Newly proposed Module Owner's GitHub Username (handle)
       description: Please provide the proposed module owner's GitHub username, leave blank if unknown
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/5_orphaned_module.yml
+++ b/.github/ISSUE_TEMPLATE/5_orphaned_module.yml
@@ -70,7 +70,7 @@ body:
   - type: input
     id: sec-owner-gh-un
     attributes:
-      label: (Optional) Newly Proposed Secondary Module Owner's GitHub Username (handle)
+      label: (Optional) Newly proposed Secondary Module Owner's GitHub Username (handle)
       description: Please provide the proposed secondary module owner's GitHub username, leave blank if unknown!
     validations:
       required: false


### PR DESCRIPTION
Revise the labels in the orphaned module template to clarify the input fields for proposed module owners.
<img width="552" height="136" alt="image" src="https://github.com/user-attachments/assets/c5f873a7-560a-4199-8210-caa505f245bd" />
