### PR TITLE
Update module naming conventions and GitHub team requirements in specifications

### DIFF
--- a/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR1.md
+++ b/docs/content/specs-defs/includes/shared/pattern/non-functional/PMNFR1.md
@@ -19,7 +19,15 @@ priority: 4020
 
 ## ID: PMNFR1 - Category: Naming - Module Naming
 
-Pattern Modules **MUST** follow the below naming conventions (all lower case):
+Pattern Modules **MUST** follow the below naming conventions (all lower case).
+
+{{% notice style="important" %}}
+
+As part of the module proposal process, the module's approved name is captured both in the module proposal issue AND the related [module index page]({{% siteparam base %}}/indexes) (backed by the corresponding [CSV file](https://github.com/Azure/Azure-Verified-Modules/tree/main/docs/static/module-indexes)).
+
+Therefore, **module owners don't need to construct the module's name themselves, instead they need use the name prescribed in the module proposal issue or in the related CSV file, at the time of approval.**
+
+{{% /notice %}}
 
 ### Bicep Pattern Module Naming
 

--- a/docs/content/specs-defs/includes/shared/resource/non-functional/RMNFR1.md
+++ b/docs/content/specs-defs/includes/shared/resource/non-functional/RMNFR1.md
@@ -19,6 +19,16 @@ priority: 3010
 
 ## ID: RMNFR1 - Category: Naming - Module Naming
 
+Resource modules **MUST** follow the below naming conventions (all lower case).
+
+{{% notice style="important" %}}
+
+As part of the module proposal process, the module's approved name is captured both in the module proposal issue AND the related [module index page]({{% siteparam base %}}/indexes) (backed by the corresponding [CSV file](https://github.com/Azure/Azure-Verified-Modules/tree/main/docs/static/module-indexes)).
+
+Therefore, **module owners don't need to construct the module's name themselves, instead they need use the name prescribed in the module proposal issue or in the related CSV file, at the time of approval.**
+
+{{% /notice %}}
+
 {{% notice style="note" %}}
 
 We will maintain a set of CSV files in the [AVM Central Repo (`Azure/Azure-Verified-Modules`)](https://github.com/Azure/Azure-Verified-Modules/tree/main/docs/static/module-indexes) with the correct singular names for all resource types to enable checks to utilize this list to ensure repos are named correctly. To see the formatted content of these CSV files with additional information, please visit the [AVM Module Indexes]({{% siteparam base %}}/indexes) page.
@@ -26,8 +36,6 @@ We will maintain a set of CSV files in the [AVM Central Repo (`Azure/Azure-Verif
 This will be updated quarterly, or ad-hoc as new RPs/ Resources are created and highlighted via a check failure.
 
 {{% /notice %}}
-
-Resource modules **MUST** follow the below naming conventions (all lower case):
 
 ### Bicep Resource Module Naming
 

--- a/docs/content/specs-defs/includes/shared/shared/functional/SFR3.md
+++ b/docs/content/specs-defs/includes/shared/shared/functional/SFR3.md
@@ -20,14 +20,6 @@ priority: 30
 
 ## ID: SFR3 - Category: Telemetry - Deployment/Usage Telemetry
 
-{{% notice style="important" %}}
-
-We will maintain a set of CSV files in the [AVM Central Repo (`Azure/Azure-Verified-Modules`)](https://github.com/Azure/Azure-Verified-Modules/tree/main/docs/static/module-indexes) with the required TelemetryId prefixes to enable checks to utilize this list to ensure the correct IDs are used. To see the formatted content of these CSV files with additional information, please visit the [AVM Module Indexes]({{% siteparam base %}}/indexes) page.
-
-These will also be provided as a comment on the module proposal, once accepted, from the AVM core team.
-
-{{% /notice %}}
-
 Modules **MUST** provide the capability to collect deployment/usage telemetry as detailed in [Telemetry]({{% siteparam base %}}/help-support/telemetry/) further.
 
 To highlight that AVM modules use telemetry, an information notice **MUST** be included in the footer of each module's `README.md` file with the below content. (See more details on this requirement, [here](https://docs.opensource.microsoft.com/releasing/general-guidance/telemetry/).)
@@ -53,6 +45,8 @@ The following information notice is automatically added at the bottom of the `RE
 ### Bicep
 
 {{% notice style="important" %}}
+We will maintain a set of CSV files in the [AVM Central Repo (`Azure/Azure-Verified-Modules`)](https://github.com/Azure/Azure-Verified-Modules/tree/main/docs/static/module-indexes) with the required TelemetryId prefixes to enable checks to utilize this list to ensure the correct IDs are used. To see the formatted content of these CSV files with additional information, please visit the [AVM Module Indexes]({{% siteparam base %}}/indexes) page.
+
 The value you need to use for your module is defined in the related module index. You can look it up on the index pages for [Resource Modules]({{% siteparam base %}}/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners), [Pattern Modules]({{% siteparam base %}}/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners) and [Utility Modules]({{% siteparam base %}}/indexes/bicep/bicep-utility-modules/#module-name-telemetry-id-prefix-github-teams-for-owners).
 {{% /notice %}}
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
@@ -26,14 +26,19 @@ Each module **MUST** have a GitHub team assigned for module owners. This team **
 
 There **MUST NOT** be any GitHub repository permissions assigned to individual users.
 
-{{% notice style="important" %}}
+{{% notice style="info" %}}
 Non-FTE / external contributors (subject matter experts that aren't Microsoft employees) can't be members of the teams described in this chapter, hence, they won't gain any extra permissions on AVM repositories, therefore, they need to work in forks.
 {{% /notice %}}
 
 ### Bicep
 
-{{% notice style="note" %}}
-The names for the GitHub teams for each approved module are already defined in the respective [Module Indexes]({{% siteparam base %}}/indexes/). These teams **MUST** be created (and used) for each module.
+{{% notice style="important" %}}
+
+As part of the module proposal process, the name of the GitHub team for each approved module is already defined in the respective [Module Indexes]({{% siteparam base %}}/indexes/) (or [CSV file](https://github.com/Azure/Azure-Verified-Modules/tree/main/docs/static/module-indexes)). This team **MUST** be created (and used) for each module.
+
+**Module owners don't need to construct the name of the GitHub team for their module themselves, instead they need use the name prescribed in the related CSV file, at the time of approval.**
+
+For a direct link, see the list of related index pages:
 
 - [Bicep Resource Modules]({{% siteparam base %}}/indexes/bicep/bicep-resource-modules/#module-name-telemetry-id-prefix-github-teams-for-owners)
 - [Bicep Pattern Modules]({{% siteparam base %}}/indexes/bicep/bicep-pattern-modules/#module-name-telemetry-id-prefix-github-teams-for-owners)


### PR DESCRIPTION
Clarify naming conventions for pattern and resource modules, emphasizing the use of approved names from module proposals and CSV files. Update GitHub team requirements to ensure module owners utilize prescribed team names.

Closes #1621