### PR TITLE
 feat: OPT2 Extend bicep CMK schema to support managedHSM keys

### DIFF
--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
@@ -39,7 +39,7 @@ resource hSMCMKKeyVault 'Microsoft.KeyVault/managedHSMs@2024-11-01' existing = i
   )
 
   resource hSMCMKKey 'keys@2024-11-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId) && !empty(customerManagedKey.?keyName)) {
-    name: customerManagedKey.?keyName
+    name: customerManagedKey.?keyName!
   }
 }
 

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
@@ -59,7 +59,9 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
       ? {
           keySource: 'Microsoft.KeyVault'
           keyVaultProperties: {
-            keyVaultUri: !isHSMKeyVault ? cMKKeyVault!.properties.vaultUri : hSMCMKKeyVault!.properties.hsmUri
+            keyVaultUri: !isHSMKeyVault
+                ? 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}${environment().suffixes.keyvaultDns}/'
+                : 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}.managedhsm.azure.net/'
             keyName: customerManagedKey!.keyName
             keyVersion: !empty(customerManagedKey.?keyVersion)
               ? customerManagedKey!.keyVersion!

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
@@ -66,10 +66,13 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
               : !isHSMKeyVault
                 ? last(split(cMKKeyVault::cMKKey!.properties.keyUriWithVersion, '/'))
                 : last(split(hSMCMKKeyVault::hSMCMKKey!.properties.keyUriWithVersion, '/'))
-            // TODO Update keyIdentifier HSM condition
             keyIdentifier: !empty(customerManagedKey.?keyVersion)
-              ? '${cMKKeyVault::cMKKey!.properties.keyUri}/${customerManagedKey!.keyVersion!}'
-              : cMKKeyVault::cMKKey!.properties.keyUriWithVersion
+              ? ( !isHSMKeyVault
+                ? '${cMKKeyVault::cMKKey!.properties.keyUri}/${customerManagedKey!.keyVersion!}'
+                : '${hSMCMKKeyVault::hSMCMKKey!.properties.keyUri}/${customerManagedKey!.keyVersion!}')
+              : ( !isHSMKeyVault
+                ? cMKKeyVault::cMKKey!.properties.keyUriWithVersion
+                : hSMCMKKeyVault::hSMCMKKey!.properties.keyUriWithVersion)
             identityClientId: !empty(customerManagedKey.?userAssignedIdentityResourceId)
               ? cMKUserAssignedIdentity!.properties.clientId
               : null


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Closes #2407

Extend bicep CMK schema to support managedHSM keys. 
Differently than OPT 1 uses string interpolation to retrieve the `keyvaulturi` property. This change avoids requiring Reader access to the parent Key Vault for the deployment identity.

TODO: update schema2 accordingly after agreement

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
