### PR TITLE
feat: OPT 3 Extend bicep CMK schema to support managedHSM keys

### DIFF
--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
@@ -50,9 +50,9 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
             keyName: customerManagedKey!.keyName
             keyVersion: !empty(customerManagedKey.?keyVersion)
               ? customerManagedKey!.keyVersion!
-              : !isHSMManagedCMK
+              : (!isHSMManagedCMK
                 ? last(split(cMKKeyVault::cMKKey!.properties.keyUriWithVersion, '/'))
-                : fail('Managed HSM CMK encryption requires specifying the \'keyVersion\'.')
+                : fail('Managed HSM CMK encryption requires specifying the \'keyVersion\'.'))
             keyIdentifier: !empty(customerManagedKey.?keyVersion)
               ? ( !isHSMManagedCMK
                 ? '${cMKKeyVault::cMKKey!.properties.keyUri}/${customerManagedKey!.keyVersion!}'

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
@@ -39,7 +39,7 @@ resource hSMCMKKeyVault 'Microsoft.KeyVault/managedHSMs@2024-11-01' existing = i
   )
 
   resource hSMCMKKey 'keys@2024-11-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId) && !empty(customerManagedKey.?keyName)) {
-    name: customerManagedKey.?keyName
+    name: customerManagedKey.?keyName!
   }
 }
 

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
@@ -55,14 +55,14 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
               ? customerManagedKey!.keyVersion!
               : !isHSMKeyVault
                 ? last(split(cMKKeyVault::cMKKey!.properties.keyUriWithVersion, '/'))
-                : fail('Managed HSM CMK encryption requires keyVersion in input')
+                : fail('Managed HSM CMK encryption requires specifying the \'keyVersion\'.')
             keyIdentifier: !empty(customerManagedKey.?keyVersion)
               ? ( !isHSMKeyVault
                 ? 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}${environment().suffixes.keyvaultDns}/${customerManagedKey!.keyVersion!}'
                 : 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}.managedhsm.azure.net/${customerManagedKey!.keyVersion!}')
               : ( !isHSMKeyVault
                 ? cMKKeyVault::cMKKey!.properties.keyUriWithVersion
-                : fail('Managed HSM CMK encryption requires keyVersion in input'))
+                : fail('Managed HSM CMK encryption requires specifying the \'keyVersion\'.'))
             identityClientId: !empty(customerManagedKey.?userAssignedIdentityResourceId)
               ? cMKUserAssignedIdentity!.properties.clientId
               : null

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
@@ -31,18 +31,6 @@ resource cMKKeyVault 'Microsoft.KeyVault/vaults@2024-11-01' existing = if (!isHS
   }
 }
 
-resource hSMCMKKeyVault 'Microsoft.KeyVault/managedHSMs@2024-11-01' existing = if (isHSMKeyVault && !empty(customerManagedKey.?keyVaultResourceId)) {
-  name: last(split((customerManagedKey.?keyVaultResourceId!), '/'))
-  scope: resourceGroup(
-    split(customerManagedKey.?keyVaultResourceId!, '/')[2],
-    split(customerManagedKey.?keyVaultResourceId!, '/')[4]
-  )
-
-  resource hSMCMKKey 'keys@2024-11-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId) && !empty(customerManagedKey.?keyName)) {
-    name: customerManagedKey.?keyName!
-  }
-}
-
 resource cMKUserAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = if (!empty(customerManagedKey.?userAssignedIdentityResourceId)) {
   name: last(split(customerManagedKey.?userAssignedIdentityResourceId!, '/'))
   scope: resourceGroup(
@@ -59,20 +47,22 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
       ? {
           keySource: 'Microsoft.KeyVault'
           keyVaultProperties: {
-            keyVaultUri: !isHSMKeyVault ? cMKKeyVault!.properties.vaultUri : hSMCMKKeyVault!.properties.hsmUri
+            keyVaultUri: !isHSMKeyVault
+                ? 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}${environment().suffixes.keyvaultDns}/'
+                : 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}.managedhsm.azure.net/'
             keyName: customerManagedKey!.keyName
             keyVersion: !empty(customerManagedKey.?keyVersion)
               ? customerManagedKey!.keyVersion!
               : !isHSMKeyVault
                 ? last(split(cMKKeyVault::cMKKey!.properties.keyUriWithVersion, '/'))
-                : last(split(hSMCMKKeyVault::hSMCMKKey!.properties.keyUriWithVersion, '/'))
+                : fail('Managed HSM CMK encryption requires keyVersion in input')
             keyIdentifier: !empty(customerManagedKey.?keyVersion)
               ? ( !isHSMKeyVault
-                ? '${cMKKeyVault::cMKKey!.properties.keyUri}/${customerManagedKey!.keyVersion!}'
-                : '${hSMCMKKeyVault::hSMCMKKey!.properties.keyUri}/${customerManagedKey!.keyVersion!}')
+                ? 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}${environment().suffixes.keyvaultDns}/${customerManagedKey!.keyVersion!}'
+                : 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}.managedhsm.azure.net/${customerManagedKey!.keyVersion!}')
               : ( !isHSMKeyVault
                 ? cMKKeyVault::cMKKey!.properties.keyUriWithVersion
-                : hSMCMKKeyVault::hSMCMKKey!.properties.keyUriWithVersion)
+                : fail('Managed HSM CMK encryption requires keyVersion in input'))
             identityClientId: !empty(customerManagedKey.?userAssignedIdentityResourceId)
               ? cMKUserAssignedIdentity!.properties.clientId
               : null

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
@@ -46,7 +46,7 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
           keyVaultProperties: {
             keyVaultUri: !isHSMManagedCMK
                 ? cMKKeyVault.properties.vaultUri
-                : 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}.managedhsm.azure.net/'
+                : 'https://${last(split((customerManagedKey!.keyVaultResourceId), '/'))}.managedhsm.azure.net/'
             keyName: customerManagedKey!.keyName
             keyVersion: !empty(customerManagedKey.?keyVersion)
               ? customerManagedKey!.keyVersion!

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
@@ -10,10 +10,7 @@ param customerManagedKey customerManagedKeyType?
 //   Variables   //
 // ============= //
 
-var keyVaultType = !empty(customerManagedKey.?keyVaultResourceId)
-  ? split(customerManagedKey.?keyVaultResourceId!, '/')[7]
-  : ''
-var isHSMManagedCMK = contains(keyVaultType, 'managedHSMs')
+var isHSMManagedCMK = split(customerManagedKey.?keyVaultResourceId ?? '', '/')[?7] == 'managedHSMs'
 
 // ============= //
 //   Resources   //

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
@@ -66,10 +66,13 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
               : !isHSMKeyVault
                 ? last(split(cMKKeyVault::cMKKey!.properties.keyUriWithVersion, '/'))
                 : last(split(hSMCMKKeyVault::hSMCMKKey!.properties.keyUriWithVersion, '/'))
-            // TODO Update keyIdentifier HSM condition
             keyIdentifier: !empty(customerManagedKey.?keyVersion)
-              ? '${cMKKeyVault::cMKKey!.properties.keyUri}/${customerManagedKey!.keyVersion!}'
-              : cMKKeyVault::cMKKey!.properties.keyUriWithVersion
+              ? ( !isHSMKeyVault
+                ? '${cMKKeyVault::cMKKey!.properties.keyUri}/${customerManagedKey!.keyVersion!}'
+                : '${hSMCMKKeyVault::hSMCMKKey!.properties.keyUri}/${customerManagedKey!.keyVersion!}')
+              : ( !isHSMKeyVault
+                ? cMKKeyVault::cMKKey!.properties.keyUriWithVersion
+                : hSMCMKKeyVault::hSMCMKKey!.properties.keyUriWithVersion)
             identityClientId: !empty(customerManagedKey.?userAssignedIdentityResourceId)
               ? cMKUserAssignedIdentity!.properties.clientId
               : null

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema1.bicep
@@ -56,7 +56,7 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
             keyIdentifier: !empty(customerManagedKey.?keyVersion)
               ? ( !isHSMManagedCMK
                 ? '${cMKKeyVault::cMKKey!.properties.keyUri}/${customerManagedKey!.keyVersion!}'
-                : 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}.managedhsm.azure.net/keys/${customerManagedKey!.keyName!}/${customerManagedKey!.keyVersion!}')
+                : 'https://${last(split((customerManagedKey.?keyVaultResourceId), '/'))}.managedhsm.azure.net/keys/${customerManagedKey!.keyName}/${customerManagedKey!.keyVersion!}')
               : ( !isHSMManagedCMK
                 ? cMKKeyVault::cMKKey!.properties.keyUriWithVersion
                 : fail('Managed HSM CMK encryption requires specifying the \'keyVersion\'.'))

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
@@ -61,7 +61,7 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
               : (customerManagedKey.?autoRotationEnabled ?? true)
                 ? (!isHSMManagedCMK
                   ? cMKKeyVault::cMKKey!.properties.keyUri
-                  : 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}.managedhsm.azure.net/keys/${customerManagedKey!.keyName!}}')
+                  : 'https://${last(split((customerManagedKey!.keyVaultResourceId), '/'))}.managedhsm.azure.net/keys/${customerManagedKey!.keyName}}')
                 : (!isHSMManagedCMK
                   ? cMKKeyVault::cMKKey!.properties.keyUriWithVersion
                   : fail('Managed HSM CMK encryption requires either specifying the \'keyVersion\' or omitting the \'autoRotationEnabled\' property. Setting \'autoRotationEnabled\' to false without a \'keyVersion\' is not allowed.'))

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
@@ -44,7 +44,7 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
           keySource: 'Microsoft.KeyVault'
           keyVaultProperties: {
             keyVaultUri: !isHSMManagedCMK
-                ? cMKKeyVault.properties.vaultUri
+                ? cMKKeyVault!.properties.vaultUri
                 : 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}.managedhsm.azure.net/'
             keyName: customerManagedKey!.keyName
             keyversion: !empty(customerManagedKey.?keyVersion)

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
@@ -9,10 +9,12 @@ param customerManagedKey customerManagedKeyWithAutoRotateType?
 //   Variables   //
 // ============= //
 
-var keyVaultType = !empty(customerManagedKey.?keyVaultResourceId)
-  ? split(customerManagedKey.?keyVaultResourceId!, '/')[7]
-  : ''
-var isHSMManagedCMK = contains(keyVaultType, 'managedHSMs')
+// var keyVaultType = !empty(customerManagedKey.?keyVaultResourceId)
+//   ? split(customerManagedKey.?keyVaultResourceId!, '/')[7]
+//   : ''
+// var isHSMManagedCMK = contains(keyVaultType, 'managedHSMs')
+
+var isHSMManagedCMK = contains(split(customerManagedKey.?keyVaultResourceId, '/')[7] ?? '', 'managedHSMs')
 
 // ============= //
 //   Resources   //

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
@@ -9,12 +9,7 @@ param customerManagedKey customerManagedKeyWithAutoRotateType?
 //   Variables   //
 // ============= //
 
-// var keyVaultType = !empty(customerManagedKey.?keyVaultResourceId)
-//   ? split(customerManagedKey.?keyVaultResourceId!, '/')[7]
-//   : ''
-// var isHSMManagedCMK = contains(keyVaultType, 'managedHSMs')
-
-var isHSMManagedCMK = contains(split(customerManagedKey.?keyVaultResourceId, '/')[7] ?? '', 'managedHSMs')
+var isHSMManagedCMK = split(customerManagedKey.?keyVaultResourceId ?? '', '/')[?7] == 'managedHSMs'
 
 // ============= //
 //   Resources   //

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
@@ -47,7 +47,7 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
                 ? cMKKeyVault!.properties.vaultUri
                 : 'https://${last(split((customerManagedKey!.keyVaultResourceId), '/'))}.managedhsm.azure.net/'
             keyName: customerManagedKey!.keyName
-            keyversion: !empty(customerManagedKey.?keyVersion)
+            keyVersion: !empty(customerManagedKey.?keyVersion)
                 ? customerManagedKey!.keyVersion!
                 : (customerManagedKey.?autoRotationEnabled ?? true)
                     ? null

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
@@ -47,7 +47,7 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
                     ? null
                     : (!isHSMKeyVault
                         ? last(split(cMKKeyVault::cMKKey!.properties.keyUriWithVersion, '/'))
-                        : fail('Managed HSM CMK encryption requires either keyVersion in input or autorotation to be enabled'))
+                        : fail('Managed HSM CMK encryption requires either specifying the \'keyVersion\' or omitting the \'autoRotationEnabled\' property. Setting \'autoRotationEnabled\' to false without a \'keyVersion\' is not allowed.'))
             keyIdentifier: !empty(customerManagedKey.?keyVersion)
               ? (!isHSMKeyVault
                 ? 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}${environment().suffixes.keyvaultDns}/keys/${customerManagedKey!.keyName!}/${customerManagedKey!.keyVersion!}'
@@ -58,7 +58,7 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
                   : 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}.managedhsm.azure.net/keys/${customerManagedKey!.keyName!}}')
                 : (!isHSMKeyVault
                   ? cMKKeyVault::cMKKey!.properties.keyUriWithVersion
-                  : fail('Managed HSM CMK encryption requires either keyVersion in input or autorotation to be enabled'))
+                  : fail('Managed HSM CMK encryption requires either specifying the \'keyVersion\' or omitting the \'autoRotationEnabled\' property. Setting \'autoRotationEnabled\' to false without a \'keyVersion\' is not allowed.'))
             identityClientId: !empty(customerManagedKey.?userAssignedIdentityResourceId)
               ? cMKUserAssignedIdentity!.properties.clientId
               : null

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
@@ -57,7 +57,7 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
             keyIdentifier: !empty(customerManagedKey.?keyVersion)
               ? (!isHSMManagedCMK
                 ? '${cMKKeyVault::cMKKey!.properties.keyUri}/${customerManagedKey!.keyVersion!}'
-                : 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}.managedhsm.azure.net/keys/${customerManagedKey!.keyName!}/${customerManagedKey!.keyVersion!}')
+                : 'https://${last(split((customerManagedKey!.keyVaultResourceId), '/'))}.managedhsm.azure.net/keys/${customerManagedKey!.keyName}/${customerManagedKey!.keyVersion!}')
               : (customerManagedKey.?autoRotationEnabled ?? true)
                 ? (!isHSMManagedCMK
                   ? cMKKeyVault::cMKKey!.properties.keyUri

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
@@ -45,7 +45,7 @@ resource >singularMainResourceType< '>providerNamespace</>resourceType<@>apiVers
           keyVaultProperties: {
             keyVaultUri: !isHSMManagedCMK
                 ? cMKKeyVault!.properties.vaultUri
-                : 'https://${last(split((customerManagedKey.?keyVaultResourceId!), '/'))}.managedhsm.azure.net/'
+                : 'https://${last(split((customerManagedKey!.keyVaultResourceId), '/'))}.managedhsm.azure.net/'
             keyName: customerManagedKey!.keyName
             keyversion: !empty(customerManagedKey.?keyVersion)
                 ? customerManagedKey!.keyVersion!

--- a/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
+++ b/docs/static/includes/interfaces/bicep/int.cmk.udt.schema2.bicep
@@ -15,14 +15,14 @@ var isHSMManagedCMK = split(customerManagedKey.?keyVaultResourceId ?? '', '/')[?
 //   Resources   //
 // ============= //
 
-resource cMKKeyVault 'Microsoft.KeyVault/vaults@2025-05-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId)) {
+resource cMKKeyVault 'Microsoft.KeyVault/vaults@2025-05-01' existing = if (!empty(customerManagedKey) && !isHSMManagedCMK) {
   name: last(split((customerManagedKey.?keyVaultResourceId!), '/'))
   scope: resourceGroup(
     split(customerManagedKey.?keyVaultResourceId!, '/')[2],
     split(customerManagedKey.?keyVaultResourceId!, '/')[4]
   )
 
-  resource cMKKey 'keys@2025-05-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId) && !empty(customerManagedKey.?keyName)) {
+  resource cMKKey 'keys@2025-05-01' existing = if (!empty(customerManagedKey) && !isHSMManagedCMK) {
     name: customerManagedKey.?keyName!
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Closes https://github.com/Azure/Azure-Verified-Modules/issues/2407

Extend bicep CMK schema to support managedHSM keys.
Unlike Option 1, this implementation uses string interpolation to dynamically retrieve the keyVaultUri property. 
Unlike Option 2, this implementation additionally leverages the `fail` function to enforce validation: if `keyVersion` is not provided or if auto-rotation is not explicitly enabled (when supported), the deployment will fail with a clear error message.

These changes avoids requiring Reader access to the parent HSM Key Vault for the deployment identity.

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
