### PR TITLE
Fix: minor bugs on index pages

### DIFF
--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -323,7 +323,6 @@
     {{ end }}
     {{ $trimmedModuleStatus := replace $item.ModuleStatus "Module " "" }}
     {{ $trimmedModuleStatus = replace $trimmedModuleStatus "Deprecated" "Deprecated :red_circle:" }}
-    {{ $trimmedModuleStatus = replace $trimmedModuleStatus "Deprecated" "Deprecated :red_circle:" }}
     {{ $trimmedModuleStatus = replace $trimmedModuleStatus "Available" "Available :green_circle:" }}
     {{ $trimmedModuleStatus = replace $trimmedModuleStatus "Orphaned" "Orphaned :yellow_circle:" }}
     {{ $trimmedModuleStatus = replace $trimmedModuleStatus "Proposed" "Proposed :white_circle:" }}

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -392,8 +392,10 @@
       </td>
       <td> {{/* availability badge and versions  */}}
         {{- if or (eq $item.ModuleStatus "Available") (eq $item.ModuleStatus "Orphaned") (eq $item.ModuleStatus "Deprecated") -}}
+          {{/* Replace single hyphens with double hyphens for correct badge rendering for pre-releases - e.g., 0.2.0-pre1 */}}
+          {{- $badgeVersion := replace $moduleLatestVersion "-" "--" -}}
           <a href="{{ $item.PublicRegistryReference }}">
-            <image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $moduleLatestVersion }}-purple"/>
+            <image src="https://img.shields.io/badge/{{ emojify $trimmedModuleStatus }}-{{ $badgeVersion }}-purple"/>
           </a>
         {{- else -}}
           <a href="">

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -204,13 +204,9 @@
           {{- if (eq $element.ParentModule $item.ModuleName) -}}
             {{ $child := trim (replace $element.ModuleName (print $item.ModuleName "/") "") "/" }}
             {{ if $useLinks }}
-              {{- if eq $element.ModuleStatus "Available" -}}
+              {{- if or (eq $element.ModuleStatus "Available") (eq $element.ModuleStatus "Orphaned") -}}
                 <li style="margin-left: 20px;">
-                  <a href="{{ $element.RepoURL }}" title="[Available 🟢] {{ $element.ModuleDisplayName }} | {{ $element.ModuleName }}">{{ $child }}</a>
-                </li>
-              {{- else if eq $element.ModuleStatus "Orphaned" -}}
-                <li style="margin-left: 20px;">
-                  <span title="[Orphaned 🟡] {{ $element.ModuleDisplayName }} ({{ $element.ModuleName }})">{{ $child }}</span>
+                  <a href="{{ $element.RepoURL }}" title="[{{ $element.ModuleStatus }} {{ if eq $element.ModuleStatus "Available" }}🟢{{ else }}🟡{{ end }}] {{ $element.ModuleDisplayName }} | {{ $element.ModuleName }}">{{ $child }}</a>
                 </li>
               {{- else -}}
                 <li style="margin-left: 20px;">
@@ -352,13 +348,9 @@
           {{- if (eq $element.ParentModule $item.ModuleName) -}}
             {{ $child := trim (replace $element.ModuleName (print $item.ModuleName "/") "") "/" }}
             {{ if $useLinks }}
-              {{- if eq $element.ModuleStatus "Available" -}}
+              {{- if or (eq $element.ModuleStatus "Available") (eq $element.ModuleStatus "Orphaned") -}}
                 <li style="margin-left: 20px;">
-                  <a href="[Available 🟢] {{ $element.PublicRegistryReference }}" title="{{ $element.ModuleDisplayName }} | {{ $element.ModuleName }}">{{ $child }}</a>
-                </li>
-              {{- else if eq $element.ModuleStatus "Orphaned" -}}
-                <li style="margin-left: 20px;">
-                  <span title="[Orphaned 🟡] {{ $element.ModuleDisplayName }} ({{ $element.ModuleName }})">{{ $child }}</span>
+                  <a href="{{ $element.PublicRegistryReference }}" title="[{{ $element.ModuleStatus }} {{ if eq $element.ModuleStatus "Available" }}🟢{{ else }}🟡{{ end }}] {{ $element.ModuleDisplayName }} | {{ $element.ModuleName }}">{{ $child }}</a>
                 </li>
               {{- else -}}
                 <li style="margin-left: 20px;">


### PR DESCRIPTION
- Correct badge rendering by replacing single hyphens with double hyphens for pre-release version formatting.
  - before: <img width="1148" height="58" alt="image" src="https://github.com/user-attachments/assets/c8e7e95c-36b5-47e3-a32a-58195329cb61" />
  - after: <img width="1167" height="68" alt="image" src="https://github.com/user-attachments/assets/7e1fe520-46bf-4899-9907-d6d55ea76008" />

- remove double traffic lights for deprecated TF modules
  - before: <img width="1147" height="62" alt="image" src="https://github.com/user-attachments/assets/a1dffa16-054a-4cdb-a5be-6b452b8c5d5e" />
  - after: <img width="1160" height="59" alt="image" src="https://github.com/user-attachments/assets/6e36fee7-202b-4f5a-9896-a632c997fed7" />

- show links to published child modules, even when the parent is orphaned
  - before: <img width="1158" height="522" alt="image" src="https://github.com/user-attachments/assets/b024361f-a655-4e4c-a860-f27896d778cc" />

  - after: <img width="1151" height="518" alt="image" src="https://github.com/user-attachments/assets/c438217a-b334-4cc2-94a6-ccaa615da97c" />

Closes #2417
