### PR TITLE
Update team linter scripts for Bicep and Terraform utilities; remove contributor teams

### DIFF
--- a/.github/workflows/github-teams-check-existance.yml
+++ b/.github/workflows/github-teams-check-existance.yml
@@ -72,9 +72,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
-      - name: "Compare Bicep Contributor Resource Teams"
+      - name: "Compare Bicep Pattern Teams"
         if: always()
-        id: comparebcpcontrib
+        id: comparebcpptn
         shell: pwsh
         run: |
           # Load used functions
@@ -83,8 +83,8 @@ jobs:
           # Branch check so issues are only opened on main
 
           $functionInput = @{
-            ModuleIndex                       = 'Bicep-Resource'
-            TeamFilter                        = 'BicepResourceContributors'
+            ModuleIndex                       = 'Bicep-Pattern'
+            TeamFilter                        = 'AllBicepPattern'
             ValidateBicepParentConfiguration  = $true
           }
 
@@ -101,9 +101,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
-      - name: "Compare Bicep Pattern Teams"
+      - name: "Compare Bicep Utility Teams"
         if: always()
-        id: comparebcpptn
+        id: comparebcputl
         shell: pwsh
         run: |
           # Load used functions
@@ -112,8 +112,8 @@ jobs:
           # Branch check so issues are only opened on main
 
           $functionInput = @{
-            ModuleIndex                       = 'Bicep-Pattern'
-            TeamFilter                        = 'AllBicepPattern'
+            ModuleIndex                       = 'Bicep-Utility'
+            TeamFilter                        = 'AllBicepUtility'
             ValidateBicepParentConfiguration  = $true
           }
 
@@ -168,6 +168,33 @@ jobs:
           $functionInput = @{
             ModuleIndex                       = 'Terraform-Pattern'
             TeamFilter                        = 'AllTerraformPattern'
+            ValidateTerraformTeamsPermissons  = $true
+          }
+
+          $branch = git branch --show-current
+          $branchName = $branch.split('/')[-1]
+          if ($branchName -eq "main"){
+              $functionInput['CreateIssues'] = $true
+          }
+
+          Write-Verbose 'Invoke task with' -Verbose
+          Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+
+          Invoke-AvmGitHubTeamLinter @functionInput -Verbose
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: "Compare Terraform Utility Teams"
+        if: always()
+        id: comparetfutl
+        shell: pwsh
+        run: |
+          # Load used functions
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'teamLinter' 'Invoke-AvmGitHubTeamLinter.ps1')
+
+          $functionInput = @{
+            ModuleIndex                       = 'Terraform-Utility'
+            TeamFilter                        = 'AllTerraformUtility'
             ValidateTerraformTeamsPermissons  = $true
           }
 

--- a/utilities/pipelines/sharedScripts/teamLinter/Get-AvmCsvData.ps1
+++ b/utilities/pipelines/sharedScripts/teamLinter/Get-AvmCsvData.ps1
@@ -2,7 +2,7 @@ Function Get-AvmCsvData {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
-        [ValidateSet('Bicep-Resource','Bicep-Pattern', 'Terraform-Resource','Terraform-Pattern')]
+        [ValidateSet('Bicep-Resource','Bicep-Pattern','Bicep-Utility', 'Terraform-Resource','Terraform-Pattern','Terraform-Utility')]
         [string]$ModuleIndex
     )
 
@@ -23,6 +23,14 @@ Function Get-AvmCsvData {
             Write-Error "Unable to retrieve CSV file - Check network connection."
         }
     }
+    elseif ($ModuleIndex -eq 'Bicep-Utility') {
+        try {
+            $unfilteredCSV = Invoke-WebRequest -Uri "https://aka.ms/avm/index/bicep/utl/csv"
+        }
+        catch {
+            Write-Error "Unable to retrieve CSV file - Check network connection."
+        }
+    }
     elseif ($ModuleIndex -eq 'Terraform-Resource') {
         try {
             $unfilteredCSV = Invoke-WebRequest -Uri "https://aka.ms/avm/index/tf/res/csv"
@@ -34,6 +42,14 @@ Function Get-AvmCsvData {
     elseif ($ModuleIndex -eq 'Terraform-Pattern') {
         try {
             $unfilteredCSV = Invoke-WebRequest -Uri "https://aka.ms/avm/index/tf/ptn/csv"
+        }
+        catch {
+            Write-Error "Unable to retrieve CSV file - Check network connection."
+        }
+    }
+    elseif ($ModuleIndex -eq 'Terraform-Utility') {
+        try {
+            $unfilteredCSV = Invoke-WebRequest -Uri "https://aka.ms/avm/index/tf/utl/csv"
         }
         catch {
             Write-Error "Unable to retrieve CSV file - Check network connection."

--- a/utilities/pipelines/sharedScripts/teamLinter/Get-AvmGitHubTeamsData.ps1
+++ b/utilities/pipelines/sharedScripts/teamLinter/Get-AvmGitHubTeamsData.ps1
@@ -2,7 +2,7 @@ Function Get-AvmGitHubTeamsData {
   [CmdletBinding()]
   param (
       [Parameter(Mandatory)]
-      [ValidateSet('AllTeams', 'AllResource', 'AllPattern', 'AllBicep', 'AllBicepResource', 'BicepResourceOwners', 'BicepResourceContributors', 'AllBicepPattern', 'BicepPatternOwners', 'BicepPatternContributors', 'AllTerraform', 'AllTerraformResource', 'TerraformResourceOwners', 'TerraformResourceContributors', 'AllTerraformPattern', 'TerraformPatternOwners', 'TerraformPatternContributors' )]
+      [ValidateSet('AllTeams', 'AllResource', 'AllPattern', 'AllUtility', 'AllBicep', 'AllBicepResource', 'BicepResourceOwners', 'AllBicepPattern', 'BicepPatternOwners', 'AllBicepUtility', 'BicepUtilityOwners', 'AllTerraform', 'AllTerraformResource', 'TerraformResourceOwners', 'AllTerraformPattern', 'TerraformPatternOwners', 'AllTerraformUtility', 'TerraformUtilityOwners' )]
       [string]$TeamFilter
   )
 
@@ -23,6 +23,8 @@ Function Get-AvmGitHubTeamsData {
   $filterAvmResGhTeams = $filterAvmGhTeams | Where-Object { $_.name -like '*res-*' }
   # Filter Teams for AVM Pattern Modules
   $filterAvmPtnGhTeams = $filterAvmGhTeams | Where-Object { $_.name -like '*ptn-*' }
+  # Filter Teams for AVM Utility Modules
+  $filterAvmUtlGhTeams = $filterAvmGhTeams | Where-Object { $_.name -like '*utl-*' }
   # Filter AVM Module Teams for Bicep
   $filterAvmBicepGhTeams = $filterAvmGhTeams | Where-Object { $_.name -like '*bicep' }
   # Filter AVM Module Teams for Bicep Resource Modules
@@ -33,6 +35,10 @@ Function Get-AvmGitHubTeamsData {
   $filterAvmBicepPtnGhTeams = $filterAvmBicepGhTeams | Where-Object { $_.name -like '*ptn-*' }
   # Filter AVM Module Teams for Bicep Pattern Modules Owners
   $filterAvmBicepPtnGhTeamsOwners = $filterAvmBicepPtnGhTeams | Where-Object { $_.name -like '*owners-*' }
+  # Filter AVM Module Teams for Bicep Utility Modules
+  $filterAvmBicepUtlGhTeams = $filterAvmBicepGhTeams | Where-Object { $_.name -like '*utl-*' }
+  # Filter AVM Module Teams for Bicep Utility Modules Owners
+  $filterAvmBicepUtlGhTeamsOwners = $filterAvmBicepUtlGhTeams | Where-Object { $_.name -like '*owners-*' }
   # Filter AVM Module Teams for Terraform
   $filterAvmTfGhTeams = $filterAvmGhTeams | Where-Object { $_.name -like '*tf' }
   # Filter AVM Module Teams for Terraform Resource Modules
@@ -43,20 +49,29 @@ Function Get-AvmGitHubTeamsData {
   $filterAvmTfPtnGhTeams = $filterAvmTfGhTeams | Where-Object { $_.name -like '*ptn-*' }
   # Filter AVM Module Teams for Terraform Pattern Modules Owners
   $filterAvmTfPtnGhTeamsOwners = $filterAvmTfPtnGhTeams | Where-Object { $_.name -like '*owners-*' }
+  # Filter AVM Module Teams for Terraform Utility Modules
+  $filterAvmTfUtlGhTeams = $filterAvmTfGhTeams | Where-Object { $_.name -like '*utl-*' }
+  # Filter AVM Module Teams for Terraform Utility Modules Owners
+  $filterAvmTfUtlGhTeamsOwners = $filterAvmTfUtlGhTeams | Where-Object { $_.name -like '*owners-*' }
 
   switch ($TeamFilter) {
       'AllTeams' { return $filterAvmGhTeams }
       'AllResource' { return $filterAvmResGhTeams }
       'AllPattern' { return $filterAvmPtnGhTeams }
+      'AllUtility' { return $filterAvmUtlGhTeams }
       'AllBicep' { return $filterAvmBicepGhTeams }
       'BicepResourceOwners' { return $filterAvmBicepResGhTeamsOwners }
       'AllBicepResource' { return $filterAvmBicepResGhTeams }
       'AllBicepPattern' { return $filterAvmBicepPtnGhTeams }
       'BicepPatternOwners' { return $filterAvmBicepPtnGhTeamsOwners }
+      'AllBicepUtility' { return $filterAvmBicepUtlGhTeams }
+      'BicepUtilityOwners' { return $filterAvmBicepUtlGhTeamsOwners }
       'AllTerraform' { return $filterAvmTfGhTeams }
       'AllTerraformResource' { return $filterAvmTfResGhTeams }
       'TerraformResourceOwners' { return $filterAvmTfResGhTeamsOwners }
       'AllTerraformPattern' { return $filterAvmTfPtnGhTeams }
       'TerraformPatternOwners' { return $filterAvmTfPtnGhTeamsOwners }
+      'AllTerraformUtility' { return $filterAvmTfUtlGhTeams }
+      'TerraformUtilityOwners' { return $filterAvmTfUtlGhTeamsOwners }
   }
 }

--- a/utilities/pipelines/sharedScripts/teamLinter/Invoke-AvmGitHubTeamLinter.ps1
+++ b/utilities/pipelines/sharedScripts/teamLinter/Invoke-AvmGitHubTeamLinter.ps1
@@ -7,11 +7,11 @@ Compares Azure Verified Modules Module Indexes with existing GitHub Teams config
 
 .PARAMETER ModuleIndex
 Required. Modules Index to use as source, allowed strings are:
-'Bicep-Resource', 'Bicep-Pattern', 'Terraform-Resource', 'Terraform-Pattern'
+'Bicep-Resource', 'Bicep-Pattern', 'Bicep-Utility', 'Terraform-Resource', 'Terraform-Pattern', 'Terraform-Utility'
 
 .PARAMETER TeamFilter
 Required. Teams to filter on, allowed strings are:
-'AllTeams', 'AllResource', 'AllPattern', 'AllBicep', 'AllBicepResource', 'BicepResourceOwners', 'BicepResourceContributors', 'AllBicepPattern', 'BicepPatternOwners', 'BicepPatternContributors', 'AllTerraform', 'AllTerraformResource', 'TerraformResourceOwners', 'TerraformResourceContributors', 'AllTerraformPattern', 'TerraformPatternOwners', 'TerraformPatternContributors'
+'AllTeams', 'AllResource', 'AllPattern', 'AllUtility', 'AllBicep', 'AllBicepResource', 'BicepResourceOwners', 'AllBicepPattern', 'BicepPatternOwners', 'AllBicepUtility', 'BicepUtilityOwners', 'AllTerraform', 'AllTerraformResource', 'TerraformResourceOwners', 'AllTerraformPattern', 'TerraformPatternOwners', 'AllTerraformUtility', 'TerraformUtilityOwners'
 
 .PARAMETER ValidateBicepParentConfiguration
 Optional. Validate if Parent Team is configured for Owners Team
@@ -36,6 +36,11 @@ Compares all terraform resource modules with GitHub Teams and validates if Teams
 Invoke-AvmGitHubTeamLinter -ModuleIndex Bicep-Pattern -TeamFilter AllBicepPattern -ValidateBicepParentConfiguration -Verbose
 
 Compares all bicep pattern modules with GitHub Teams and validates if Parent Team is configured for Owners Team. Verbose output is displayed, GitHub Issues are not created for unmatched teams.
+
+.EXAMPLE
+Invoke-AvmGitHubTeamLinter -ModuleIndex Bicep-Utility -TeamFilter AllBicepUtility -ValidateBicepParentConfiguration -Verbose -CreateIssues
+
+Compares all bicep utility modules with GitHub Teams and validates if Parent Team is configured for Owners Team. Verbose output is displayed and GitHub Issues are created for unmatched teams.
 #>
 
 Function Invoke-AvmGitHubTeamLinter {
@@ -43,11 +48,11 @@ Function Invoke-AvmGitHubTeamLinter {
   [CmdletBinding()]
   param (
       [Parameter(Mandatory)]
-      [ValidateSet('Bicep-Resource', 'Bicep-Pattern', 'Terraform-Resource', 'Terraform-Pattern')]
+      [ValidateSet('Bicep-Resource', 'Bicep-Pattern', 'Bicep-Utility', 'Terraform-Resource', 'Terraform-Pattern', 'Terraform-Utility')]
       [string]$ModuleIndex,
 
       [Parameter(Mandatory)]
-      [ValidateSet('AllTeams', 'AllResource', 'AllPattern', 'AllBicep', 'AllBicepResource', 'BicepResourceOwners', 'BicepResourceContributors', 'AllBicepPattern', 'BicepPatternOwners', 'BicepPatternContributors', 'AllTerraform', 'AllTerraformResource', 'TerraformResourceOwners', 'TerraformResourceContributors', 'AllTerraformPattern', 'TerraformPatternOwners', 'TerraformPatternContributors' )]
+      [ValidateSet('AllTeams', 'AllResource', 'AllPattern', 'AllUtility', 'AllBicep', 'AllBicepResource', 'BicepResourceOwners', 'AllBicepPattern', 'BicepPatternOwners', 'AllBicepUtility', 'BicepUtilityOwners', 'AllTerraform', 'AllTerraformResource', 'TerraformResourceOwners', 'AllTerraformPattern', 'TerraformPatternOwners', 'AllTerraformUtility', 'TerraformUtilityOwners' )]
       [string]$TeamFilter,
 
       [Parameter(Mandatory = $false)]


### PR DESCRIPTION
Enhance the team linter scripts to support additional Bicep and Terraform utility modules, improving the validation process for GitHub teams associated with these modules. Remove support for contributor teams.

Closes #1032