### PR TITLE
Add YouTube privacy settings to configuration (aka nocookies)

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -7,6 +7,11 @@ images = ['images/avm_logo.png']
 
 enableGitInfo = true
 
+[privacy]
+  [privacy.youTube]
+    disable = false # Whether to disable the shortcode. Default is false.
+    privacyEnhanced = true # Whether to block YouTube from storing information about visitors on your website unless the user plays the embedded video. Default is false.
+
 [params]
 base = '/Azure-Verified-Modules'
 images = ['images/avm_logo.png']


### PR DESCRIPTION
Introduce YouTube privacy settings to the configuration, allowing users to control the shortcode and enhance privacy by blocking data storage from embedded videos. This change enhances user privacy options when using YouTube videos on the site.

