### PR TITLE
Clarify module deprecation notice

### DIFF
--- a/docs/static/includes/deprecated-module-notice.md
+++ b/docs/static/includes/deprecated-module-notice.md
@@ -1,5 +1,5 @@
 ⚠️THIS MODULE IS DEPRECATED.⚠️
 
 - It will no longer receive any updates.
-- The module can still be used as is (references to any existing versions will keep working), but it is not recommended for new deployments.
+- If the underlying Azure service is not deprecated/retired, this module may still be used as is (references to any existing versions will keep working), but it is not recommended for new deployments.
 - It is recommended to migrate to a replacement/alternative version of the module, if available.


### PR DESCRIPTION
Update the deprecation notice to specify that the module may still be used **if the underlying Azure service is not deprecated or retired**, while recommending against new deployments. This change aims to provide clearer guidance for users regarding the module's status and usage conditions.

