### PR TITLE
feat: add BCPNFR24 - Deterministic Deployment Names spec

### DIFF
--- a/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR6.md
+++ b/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR6.md
@@ -30,7 +30,7 @@ param databases databaseType[]?
 resource server 'Microsoft.Sql/servers@(...)' = { (...) }
 
 module server_databases 'database/main.bicep' = [for (database, index) in (databases ?? []): {
-  name: '${uniqueString(deployment().name, location)}-Sql-DB-${index}'
+  name: '${uniqueString(server.id)}-Sql-DB-${index}'
   params: {
     serverName: server.name
     (...)

--- a/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR6.md
+++ b/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR6.md
@@ -30,7 +30,7 @@ param databases databaseType[]?
 resource server 'Microsoft.Sql/servers@(...)' = { (...) }
 
 module server_databases 'database/main.bicep' = [for (database, index) in (databases ?? []): {
-  name: '${uniqueString(server.id)}-Sql-DB-${index}'
+  name: '${uniqueString(server.id, location)}-Sql-DB-${index}'
   params: {
     serverName: server.name
     (...)

--- a/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR7.md
+++ b/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR7.md
@@ -40,7 +40,7 @@ var enableReferencedModulesTelemetry = false
 // local referencing
 module virtualNetwork_subnets 'subnet/main.bicep' = [
   for (subnet, index) in (subnets ?? []): {
-    name: '${uniqueString(virtualNetwork.id)}-subnet-${index}'
+    name: '${uniqueString(virtualNetwork.id, location)}-subnet-${index}'
     params: {
       (...)
       enableTelemetry: enableReferencedModulesTelemetry
@@ -50,7 +50,7 @@ module virtualNetwork_subnets 'subnet/main.bicep' = [
 
 // published module reference
 module virtualNetwork_subnet 'br/public:avm/res/network/virtual-network/subnet:0.1.0' = {
-  name: '${uniqueString(virtualNetwork.id)}-subnet-${index}'
+  name: '${uniqueString(virtualNetwork.id, location)}-subnet-${index}'
     params: {
       (...)
       enableTelemetry: enableReferencedModulesTelemetry

--- a/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR7.md
+++ b/docs/content/specs-defs/includes/bicep/shared/functional/BCPFR7.md
@@ -40,7 +40,7 @@ var enableReferencedModulesTelemetry = false
 // local referencing
 module virtualNetwork_subnets 'subnet/main.bicep' = [
   for (subnet, index) in (subnets ?? []): {
-    name: '${uniqueString(deployment().name, location)}-subnet-${index}'
+    name: '${uniqueString(virtualNetwork.id)}-subnet-${index}'
     params: {
       (...)
       enableTelemetry: enableReferencedModulesTelemetry
@@ -50,7 +50,7 @@ module virtualNetwork_subnets 'subnet/main.bicep' = [
 
 // published module reference
 module virtualNetwork_subnet 'br/public:avm/res/network/virtual-network/subnet:0.1.0' = {
-  name: '${uniqueString(deployment().name, location)}-subnet-${index}'
+  name: '${uniqueString(virtualNetwork.id)}-subnet-${index}'
     params: {
       (...)
       enableTelemetry: enableReferencedModulesTelemetry

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR12.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR12.md
@@ -27,8 +27,6 @@ Module owners **MUST** invoke the module in their test using the syntax:
 module testDeployment '../../../main.bicep' =
 ```
 
-Test deployment names **MUST** include the parent resource ID as an additional input to the `uniqueString` function to ensure deterministic and collision-free naming. See [BCPNFR24]({{% siteparam base %}}/spec/BCPNFR24/) for the broader rationale on deterministic deployment naming.
-
 Example 1: Working example with a single deployment
 
 ```bicep

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR12.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR12.md
@@ -27,14 +27,14 @@ Module owners **MUST** invoke the module in their test using the syntax:
 module testDeployment '../../../main.bicep' =
 ```
 
-Test deployment names **MUST** be deterministic. Use `resourceGroup().id` and `location` as the `uniqueString` seed to ensure names are stable across repeated test runs while remaining unique per resource group. See [BCPNFR24]({{% siteparam base %}}/spec/BCPNFR24/) for the broader rationale on deterministic deployment naming.
+Test deployment names **MUST** include the parent resource ID as an additional input to the `uniqueString` function to ensure deterministic and collision-free naming. See [BCPNFR24]({{% siteparam base %}}/spec/BCPNFR24/) for the broader rationale on deterministic deployment naming.
 
 Example 1: Working example with a single deployment
 
 ```bicep
 module testDeployment '../../../main.bicep' = {
   scope: resourceGroup
-  name: '${uniqueString(resourceGroup().id, location)}-test-${serviceShort}'
+  name: '${uniqueString(deployment().name, resourceGroup().id, location)}-test-${serviceShort}'
   params: {
     (...)
   }
@@ -47,7 +47,7 @@ Example 2: Working example using a deployment loop
 @batchSize(1)
 module testDeployment '../../main.bicep' = [for iteration in [ 'init', 'idem' ]: {
   scope: resourceGroup
-  name: '${uniqueString(resourceGroup().id, location)}-test-${serviceShort}-${iteration}'
+  name: '${uniqueString(deployment().name, resourceGroup().id, location)}-test-${serviceShort}-${iteration}'
   params: {
     (...)
   }

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR12.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR12.md
@@ -32,7 +32,7 @@ Example 1: Working example with a single deployment
 ```bicep
 module testDeployment '../../../main.bicep' = {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, resourceGroup().id, location)}-test-${serviceShort}'
+  name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     (...)
   }
@@ -45,7 +45,7 @@ Example 2: Working example using a deployment loop
 @batchSize(1)
 module testDeployment '../../main.bicep' = [for iteration in [ 'init', 'idem' ]: {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, resourceGroup().id, location)}-test-${serviceShort}-${iteration}'
+  name: '${uniqueString(deployment().name, location)}-test-${serviceShort}-${iteration}'
   params: {
     (...)
   }

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR12.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR12.md
@@ -27,12 +27,14 @@ Module owners **MUST** invoke the module in their test using the syntax:
 module testDeployment '../../../main.bicep' =
 ```
 
+Test deployment names **MUST** be deterministic. Use `resourceGroup().id` and `location` as the `uniqueString` seed to ensure names are stable across repeated test runs while remaining unique per resource group. See [BCPNFR24]({{% siteparam base %}}/spec/BCPNFR24/) for the broader rationale on deterministic deployment naming.
+
 Example 1: Working example with a single deployment
 
 ```bicep
 module testDeployment '../../../main.bicep' = {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
+  name: '${uniqueString(resourceGroup().id, location)}-test-${serviceShort}'
   params: {
     (...)
   }
@@ -45,7 +47,7 @@ Example 2: Working example using a deployment loop
 @batchSize(1)
 module testDeployment '../../main.bicep' = [for iteration in [ 'init', 'idem' ]: {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, location)}-test-${serviceShort}-${iteration}'
+  name: '${uniqueString(resourceGroup().id, location)}-test-${serviceShort}-${iteration}'
   params: {
     (...)
   }

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
@@ -68,6 +68,12 @@ A common scenario is deploying the same module type more than once within the sa
 
 {{% /notice %}}
 
+{{% notice style="important" title="location parameter" %}}
+
+If `location` is not available, for example when deploying a global resource that does not have a location property, it is acceptable to omit it. However, the `<parentResource>.id` **MUST** always be included as the primary seed for `uniqueString`.
+
+{{% /notice %}}
+
 Other approaches fail on one or both of these properties:
 
 | Approach | Deterministic? | Collision-free? | Issue |
@@ -106,34 +112,3 @@ module server_databases 'database/main.bicep' = [for (database, index) in (datab
   }
 }]
 ```
-
-Example 3: Federated identity credentials on a user-assigned managed identity
-
-```bicep
-resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = { ... }
-
-module identity_federatedIdentityCredentials 'federated-identity-credential/main.bicep' = [for (credential, index) in (federatedIdentityCredentials ?? []): {
-  name: '${uniqueString(userAssignedIdentity.id, location)}-UserMSI-FederatedIdentityCred-${index}'
-  params: {
-    userAssignedIdentityName: userAssignedIdentity.name
-    (...)
-  }
-}]
-```
-
-{{% notice style="important" %}}
-
-Do **NOT** use any of the following patterns for deployment names in module references:
-
-```bicep
-// ❌ Non-deterministic — uses deployment().name which changes each run
-name: '${uniqueString(deployment().name, location)}-Sql-DB-${index}'
-
-// ❌ Non-deterministic — uses utcNow()
-name: '${utcNow()}-Sql-DB-${index}'
-
-// ❌ Deterministic but NOT collision-free — same hash for all resources in a scope
-name: '${uniqueString(subscription().id, resourceGroup().id, location)}-Sql-DB-${index}'
-```
-
-{{% /notice %}}

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
@@ -33,19 +33,19 @@ Deterministic deployment names cause Azure to **overwrite** the previous deploym
 
 ### Requirement
 
-Module owners **MUST** construct deployment names for referenced modules using `uniqueString()` seeded with the **parent resource's ID** (`<parentResource>.id`), rather than `deployment().name`, `subscription().id`, `resourceGroup().id`, `utcNow()`, or other non-deterministic or scope-level values.
+Module owners **MUST** construct deployment names for referenced modules using `uniqueString()` seeded with the **parent resource's ID** (`<parentResource>.id`) and **`location`**, rather than `deployment().name`, `subscription().id`, `resourceGroup().id`, `utcNow()`, or other non-deterministic or scope-level values.
 
 The deployment name **MUST** follow the pattern:
 
 ```text
-'${uniqueString(<parentResource>.id)}-<ChildModuleDescriptor>-${index}'
+'${uniqueString(<parentResource>.id, location)}-<ChildModuleDescriptor>-${index}'
 ```
 
 Where:
 
 | Segment | Description |
 |---|---|
-| `uniqueString(<parentResource>.id)` | A deterministic hash derived from the parent resource's resource ID. This is both unique per resource instance and stable across deployments. |
+| `uniqueString(<parentResource>.id, location)` | A deterministic hash derived from the parent resource's resource ID and deployment location. This is both unique per resource instance and stable across deployments. |
 | `<ChildModuleDescriptor>` | A short, human-readable label identifying the child module being deployed (e.g., `DB`, `Subnet`, `FederatedIdentityCred`). |
 | `${index}` | The loop index variable, included when deploying in a loop. Omit for single (non-looped) deployments. |
 
@@ -63,7 +63,7 @@ Other approaches fail on one or both of these properties:
 | `deployment().name` | ❌ | ✅ | Changes every deployment; hits 800-limit |
 | `utcNow()` / timestamps | ❌ | ✅ | Changes every deployment; hits 800-limit |
 | `subscription().id` + `resourceGroup().id` | ✅ | ❌ | Same hash for all resources in the same RG; collisions when deploying multiple instances |
-| **`<parentResource>.id`** | **✅** | **✅** | **Recommended — stable and unique per instance** |
+| **`<parentResource>.id, location`** | **✅** | **✅** | **Recommended — stable and unique per instance** |
 
 ### Examples
 
@@ -73,7 +73,7 @@ Example 1: Single child module deployment
 resource server 'Microsoft.Sql/servers@2023-05-01-preview' = { ... }
 
 module server_database 'database/main.bicep' = {
-  name: '${uniqueString(server.id)}-Sql-DB'
+  name: '${uniqueString(server.id, location)}-Sql-DB'
   params: {
     serverName: server.name
     (...)
@@ -87,7 +87,7 @@ Example 2: Child module deployment in a loop
 resource server 'Microsoft.Sql/servers@2023-05-01-preview' = { ... }
 
 module server_databases 'database/main.bicep' = [for (database, index) in (databases ?? []): {
-  name: '${uniqueString(server.id)}-Sql-DB-${index}'
+  name: '${uniqueString(server.id, location)}-Sql-DB-${index}'
   params: {
     serverName: server.name
     (...)
@@ -101,7 +101,7 @@ Example 3: Federated identity credentials on a user-assigned managed identity
 resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = { ... }
 
 module identity_federatedIdentityCredentials 'federated-identity-credential/main.bicep' = [for (credential, index) in (federatedIdentityCredentials ?? []): {
-  name: '${uniqueString(userAssignedIdentity.id)}-UserMSI-FederatedIdentityCred-${index}'
+  name: '${uniqueString(userAssignedIdentity.id, location)}-UserMSI-FederatedIdentityCred-${index}'
   params: {
     userAssignedIdentityName: userAssignedIdentity.name
     (...)

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
@@ -25,7 +25,7 @@ When a module references child, utility, or other modules, the deployment name *
 
 {{% notice style="note" title="Why deterministic?" %}}
 
-Azure Resource Manager enforces an [800-deployment limit](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#resource-group-limits) per scope (resource group, subscription, management group). Non-deterministic names (e.g., those incorporating timestamps or `utcNow()`) create a new deployment object on every run, quickly exhausting this limit — especially at subscription and management group scopes where cleanup is difficult and unreliable.
+Azure Resource Manager enforces an [800-deployment limit](https://learn.microsoft.com/azure/azure-resource-manager/management/azure-subscription-service-limits#resource-group-limits) per scope (resource group, subscription, management group). Non-deterministic names (e.g., those incorporating timestamps or `utcNow()`) create a new deployment object on every run, quickly exhausting this limit — especially at subscription and management group scopes where cleanup is difficult and unreliable.
 
 Deterministic deployment names cause Azure to **overwrite** the previous deployment object, keeping the deployment count stable regardless of how many times the module is deployed.
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
@@ -25,7 +25,11 @@ When a module references child, utility, or other modules, the deployment name *
 
 {{% notice style="note" title="Why deterministic?" %}}
 
-Azure Resource Manager has an [800-deployment limit](https://learn.microsoft.com/azure/azure-resource-manager/management/azure-subscription-service-limits#resource-group-limits) per scope (resource group, subscription, management group). Non-deterministic names (e.g., those incorporating timestamps or `utcNow()`) create a new deployment object on every run, which can lead to this limit being reached over time. While a cleanup process exists today, it does not yet meet the needs of all scenarios, particularly at subscription and management group scopes. We are actively working with the product team to enhance this process. In the meantime, deterministic deployment names provide a reliable way to keep deployment counts stable.
+Azure Resource Manager has an [800-deployment limit](https://learn.microsoft.com/azure/azure-resource-manager/management/azure-subscription-service-limits#resource-group-limits) per scope (resource group, subscription, management group, tenant). Non-deterministic names (e.g., those incorporating timestamps or `utcNow()`) create a new deployment object on every run, which can lead to this limit being reached over time.
+
+While an automatic cleanup process exists for resource group and subscription scopes, it can take some time to take effect. Due to eventual consistency in the backend, the deployment count may not reflect the cleanup immediately, which can lead to failed deployments even when the actual number of deployments is below the 800 limit. Additionally, automatic cleanup does not apply to management group or tenant scopes.
+
+We are actively working with the product team to enhance the cleanup process. In the meantime, deterministic deployment names provide a reliable way to keep deployment counts stable by overwriting previous deployment objects rather than creating new ones.
 
 Deterministic deployment names cause Azure to **overwrite** the previous deployment object, keeping the deployment count stable regardless of how many times the module is deployed.
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
@@ -25,7 +25,7 @@ When a module references child, utility, or other modules, the deployment name *
 
 {{% notice style="note" title="Why deterministic?" %}}
 
-Azure Resource Manager enforces an [800-deployment limit](https://learn.microsoft.com/azure/azure-resource-manager/management/azure-subscription-service-limits#resource-group-limits) per scope (resource group, subscription, management group). Non-deterministic names (e.g., those incorporating timestamps or `utcNow()`) create a new deployment object on every run, quickly exhausting this limit — especially at subscription and management group scopes where cleanup is difficult and unreliable.
+Azure Resource Manager has an [800-deployment limit](https://learn.microsoft.com/azure/azure-resource-manager/management/azure-subscription-service-limits#resource-group-limits) per scope (resource group, subscription, management group). Non-deterministic names (e.g., those incorporating timestamps or `utcNow()`) create a new deployment object on every run, which can lead to this limit being reached over time. While a cleanup process exists today, it does not yet meet the needs of all scenarios, particularly at subscription and management group scopes. We are actively working with the product team to enhance this process. In the meantime, deterministic deployment names provide a reliable way to keep deployment counts stable.
 
 Deterministic deployment names cause Azure to **overwrite** the previous deployment object, keeping the deployment count stable regardless of how many times the module is deployed.
 

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
@@ -14,7 +14,7 @@ tags: [
   Persona-Owner, # MULTIPLE VALUES: this can be "Persona-Owner" AND/OR "Persona-Contributor"
   Persona-Contributor, # MULTIPLE VALUES: this can be "Persona-Owner" AND/OR "Persona-Contributor"
   Lifecycle-BAU, # SINGLE VALUE: this can be "Lifecycle-Initial" OR "Lifecycle-BAU" OR "Lifecycle-EOL"
-  Validation-TBD # SINGLE VALUE (PER LANGUAGE): for Bicep, this can be "Validation-BCP/Manual" OR "Validation-BCP/CI/Informational" OR "Validation-BCP/CI/Enforced"
+  Validation-BCP/Manual # SINGLE VALUE (PER LANGUAGE): for Bicep, this can be "Validation-BCP/Manual" OR "Validation-BCP/CI/Informational" OR "Validation-BCP/CI/Enforced"
 ]
 priority: 11024
 ---

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
@@ -56,6 +56,18 @@ Using the parent resource's ID as the `uniqueString` seed provides two critical 
 1. **Deterministic** — the same parent resource always produces the same hash, so repeated deployments overwrite rather than accumulate.
 2. **Collision-free** — different parent resource instances produce different hashes, so deploying multiple instances of the same module type within the same scope does not cause naming collisions.
 
+{{% notice style="tip" title="Why not subscription().id and resourceGroup().id separately?" %}}
+
+The parent resource's ID (e.g., `/subscriptions/.../resourceGroups/.../providers/.../resourceName`) already contains the subscription ID and resource group ID as segments. Using `<parentResource>.id` as a single input to `uniqueString` captures all of this context in one value, keeping the code concise and readable rather than passing multiple scope-level values separately.
+
+{{% /notice %}}
+
+{{% notice style="note" title="Supporting multiple deployments of the same module at the same scope" %}}
+
+A common scenario is deploying the same module type more than once within the same scope — for example, two different SQL servers each with their own set of databases, or two user-assigned identities each with their own federated credentials. Because the parent resource ID is unique per resource instance, the resulting deployment names will differ even when the child module type and index are identical. This ensures that parallel deployments of the same module at the same scope do not collide.
+
+{{% /notice %}}
+
 Other approaches fail on one or both of these properties:
 
 | Approach | Deterministic? | Collision-free? | Issue |

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
@@ -1,0 +1,127 @@
+---
+title: BCPNFR24 - Deterministic Deployment Names
+description: Module Specification for the Azure Verified Modules (AVM) program
+url: /spec/BCPNFR24
+type: default
+tags: [
+  Class-Resource, # MULTIPLE VALUES: this can be "Class-Resource" AND/OR "Class-Pattern" AND/OR "Class-Utility"
+  Class-Pattern, # MULTIPLE VALUES: this can be "Class-Resource" AND/OR "Class-Pattern" AND/OR "Class-Utility"
+  Class-Utility, # MULTIPLE VALUES: this can be "Class-Resource" AND/OR "Class-Pattern" AND/OR "Class-Utility"
+  Type-NonFunctional, # SINGLE VALUE: this can be "Type-Functional" OR "Type-NonFunctional"
+  Category-Naming/Composition, # SINGLE VALUE: this can be "Category-Testing" OR "Category-Telemetry" OR "Category-Contribution/Support" OR "Category-Documentation" OR "Category-CodeStyle" OR "Category-Naming/Composition" OR "Category-Inputs/Outputs" OR "Category-Release/Publishing"
+  Language-Bicep, # MULTIPLE VALUES: this can be "Language-Bicep" AND/OR "Language-Terraform"
+  Severity-MUST, # SINGLE VALUE: this can be "Severity-MUST" OR "Severity-SHOULD" OR "Severity-MAY"
+  Persona-Owner, # MULTIPLE VALUES: this can be "Persona-Owner" AND/OR "Persona-Contributor"
+  Persona-Contributor, # MULTIPLE VALUES: this can be "Persona-Owner" AND/OR "Persona-Contributor"
+  Lifecycle-BAU, # SINGLE VALUE: this can be "Lifecycle-Initial" OR "Lifecycle-BAU" OR "Lifecycle-EOL"
+  Validation-TBD # SINGLE VALUE (PER LANGUAGE): for Bicep, this can be "Validation-BCP/Manual" OR "Validation-BCP/CI/Informational" OR "Validation-BCP/CI/Enforced"
+]
+priority: 11024
+---
+
+## ID: BCPNFR24 - Category: Naming/Composition - Deterministic Deployment Names
+
+When a module references child, utility, or other modules, the deployment name **MUST** be **deterministic**. This means the deployment name must produce the same value for the same set of inputs across repeated deployments.
+
+{{% notice style="note" title="Why deterministic?" %}}
+
+Azure Resource Manager enforces an [800-deployment limit](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#resource-group-limits) per scope (resource group, subscription, management group). Non-deterministic names (e.g., those incorporating timestamps or `utcNow()`) create a new deployment object on every run, quickly exhausting this limit — especially at subscription and management group scopes where cleanup is difficult and unreliable.
+
+Deterministic deployment names cause Azure to **overwrite** the previous deployment object, keeping the deployment count stable regardless of how many times the module is deployed.
+
+{{% /notice %}}
+
+### Requirement
+
+Module owners **MUST** construct deployment names for referenced modules using `uniqueString()` seeded with the **parent resource's ID** (`<parentResource>.id`), rather than `deployment().name`, `subscription().id`, `resourceGroup().id`, `utcNow()`, or other non-deterministic or scope-level values.
+
+The deployment name **MUST** follow the pattern:
+
+```text
+'${uniqueString(<parentResource>.id)}-<ChildModuleDescriptor>-${index}'
+```
+
+Where:
+
+| Segment | Description |
+|---|---|
+| `uniqueString(<parentResource>.id)` | A deterministic hash derived from the parent resource's resource ID. This is both unique per resource instance and stable across deployments. |
+| `<ChildModuleDescriptor>` | A short, human-readable label identifying the child module being deployed (e.g., `DB`, `Subnet`, `FederatedIdentityCred`). |
+| `${index}` | The loop index variable, included when deploying in a loop. Omit for single (non-looped) deployments. |
+
+### Why parent resource ID?
+
+Using the parent resource's ID as the `uniqueString` seed provides two critical properties:
+
+1. **Deterministic** — the same parent resource always produces the same hash, so repeated deployments overwrite rather than accumulate.
+2. **Collision-free** — different parent resource instances produce different hashes, so deploying multiple instances of the same module type within the same scope does not cause naming collisions.
+
+Other approaches fail on one or both of these properties:
+
+| Approach | Deterministic? | Collision-free? | Issue |
+|---|---|---|---|
+| `deployment().name` | ❌ | ✅ | Changes every deployment; hits 800-limit |
+| `utcNow()` / timestamps | ❌ | ✅ | Changes every deployment; hits 800-limit |
+| `subscription().id` + `resourceGroup().id` | ✅ | ❌ | Same hash for all resources in the same RG; collisions when deploying multiple instances |
+| **`<parentResource>.id`** | **✅** | **✅** | **Recommended — stable and unique per instance** |
+
+### Examples
+
+Example 1: Single child module deployment
+
+```bicep
+resource server 'Microsoft.Sql/servers@2023-05-01-preview' = { ... }
+
+module server_database 'database/main.bicep' = {
+  name: '${uniqueString(server.id)}-Sql-DB'
+  params: {
+    serverName: server.name
+    (...)
+  }
+}
+```
+
+Example 2: Child module deployment in a loop
+
+```bicep
+resource server 'Microsoft.Sql/servers@2023-05-01-preview' = { ... }
+
+module server_databases 'database/main.bicep' = [for (database, index) in (databases ?? []): {
+  name: '${uniqueString(server.id)}-Sql-DB-${index}'
+  params: {
+    serverName: server.name
+    (...)
+  }
+}]
+```
+
+Example 3: Federated identity credentials on a user-assigned managed identity
+
+```bicep
+resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = { ... }
+
+module identity_federatedIdentityCredentials 'federated-identity-credential/main.bicep' = [for (credential, index) in (federatedIdentityCredentials ?? []): {
+  name: '${uniqueString(userAssignedIdentity.id)}-UserMSI-FederatedIdentityCred-${index}'
+  params: {
+    userAssignedIdentityName: userAssignedIdentity.name
+    (...)
+  }
+}]
+```
+
+{{% notice style="important" %}}
+
+Do **NOT** use any of the following patterns for deployment names in module references:
+
+```bicep
+// ❌ Non-deterministic — uses deployment().name which changes each run
+name: '${uniqueString(deployment().name, location)}-Sql-DB-${index}'
+
+// ❌ Non-deterministic — uses utcNow()
+name: '${utcNow()}-Sql-DB-${index}'
+
+// ❌ Deterministic but NOT collision-free — same hash for all resources in a scope
+name: '${uniqueString(subscription().id, resourceGroup().id, location)}-Sql-DB-${index}'
+```
+
+{{% /notice %}}

--- a/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
+++ b/docs/content/specs-defs/includes/bicep/shared/non-functional/BCPNFR24.md
@@ -53,6 +53,12 @@ Where:
 | `<ChildModuleDescriptor>` | A short, human-readable label identifying the child module being deployed (e.g., `DB`, `Subnet`, `FederatedIdentityCred`). |
 | `${index}` | The loop index variable, included when deploying in a loop. Omit for single (non-looped) deployments. |
 
+{{% notice style="important" title="location parameter" %}}
+
+If `location` is not available, for example when deploying a global resource that does not have a location property, it is acceptable to omit it. However, the `<parentResource>.id` **MUST** always be included as the primary seed for `uniqueString`.
+
+{{% /notice %}}
+
 ### Why parent resource ID?
 
 Using the parent resource's ID as the `uniqueString` seed provides two critical properties:
@@ -69,12 +75,6 @@ The parent resource's ID (e.g., `/subscriptions/.../resourceGroups/.../providers
 {{% notice style="note" title="Supporting multiple deployments of the same module at the same scope" %}}
 
 A common scenario is deploying the same module type more than once within the same scope — for example, two different SQL servers each with their own set of databases, or two user-assigned identities each with their own federated credentials. Because the parent resource ID is unique per resource instance, the resulting deployment names will differ even when the child module type and index are identical. This ensures that parallel deployments of the same module at the same scope do not collide.
-
-{{% /notice %}}
-
-{{% notice style="important" title="location parameter" %}}
-
-If `location` is not available, for example when deploying a global resource that does not have a location property, it is acceptable to omit it. However, the `<parentResource>.id` **MUST** always be included as the primary seed for `uniqueString`.
 
 {{% /notice %}}
 


### PR DESCRIPTION
This pull request introduces a new non-functional requirement specification for deterministic deployment names in Bicep modules and updates several example and reference files to follow this approach. The changes ensure that deployment names for child modules are stable and unique by using the parent resource's ID and location as the seed for `uniqueString()`, preventing issues with Azure deployment limits and name collisions.

**Key changes:**

**1. New specification for deterministic deployment names:**
- Added a new documentation file, `BCPNFR24.md`, which defines and explains the requirement for deterministic deployment names in module references. It provides rationale, examples, and guidance for using the parent resource's ID and location as the `uniqueString` seed.

**2. Updates to Bicep module deployment naming patterns:**
- Updated module deployment names in `BCPFR6.md`, `BCPFR7.md`, and related files to use `uniqueString(<parentResource>.id, location)` instead of `uniqueString(deployment().name, location)`, ensuring deterministic and collision-free naming for both local and published modules. [[1]](diffhunk://#diff-b28f293b487ed18cafbb61b54994947323d275e38da5602ac1324454a4271ed3L33-R33) [[2]](diffhunk://#diff-a33451b3447ea0899d40cd1a6e65bac2eb22828aabc2d0f69dafbe5f181c7bc9L43-R43) [[3]](diffhunk://#diff-a33451b3447ea0899d40cd1a6e65bac2eb22828aabc2d0f69dafbe5f181c7bc9L53-R53)

**3. Example improvements for deterministic naming:**
- Modified examples in `BCPNFR12.md` to include the parent resource group ID in the `uniqueString` seed, further demonstrating the correct approach for deterministic deployment names in both single and looped deployments. [[1]](diffhunk://#diff-2f59be80dbb7807dcde6736e94aad51f2ccb181596e2607117ae56761f78bfa6L35-R35) [[2]](diffhunk://#diff-2f59be80dbb7807dcde6736e94aad51f2ccb181596e2607117ae56761f78bfa6L48-R48)