### PR TITLE
fix: avm child module publishing skill naming

### DIFF
--- a/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
@@ -158,7 +158,7 @@ Please follow the steps below:
   {{% notice style="tip" title="Retrieve affected module paths programmatically" icon="lightbulb" %}}
   To retrieve affected module paths programmatically you can leverage the [Get-ParentFolderPathList](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/pipelines/sharedScripts/Get-ParentFolderPathList.ps1) utility using the `'OnlyModules'` option
   ```powershell
-    $affectedModulePathList = Get-ParentFolderPathList -Path '<path/to/avm/child-module>' -Filter 'OnlyModules'
+$affectedModulePathList = Get-ParentFolderPathList -Path '<path/to/avm/child-module>' -Filter 'OnlyModules'
   ```
 
   {{% /notice %}}

--- a/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
@@ -39,7 +39,7 @@ For a step-by-step explanation with detailed instructions, refer to the followin
   * **Parent module template**: In the `main.bicep` template of the child module direct parent, add a `enableReferencedModulesTelemetry` variable with a value of `false`, and pass it as the `enableTelemetry` value down to the child module deployment.
   * **Version**: Add the `version.json` file to the child module folder and set version to `0.1`.
   * **Changelog**: Add a new `CHANGELOG.md` file to the child module folder and update the changelog of all its versioned parents with a new patch version, up to the top-level parent.
-  * **Set-AVMModule**: Run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility explicitly on the affected bicep modules, test your changes and raise a PR.
+  * **Set-AVMModule**: Run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility explicitly on the affected bicep modules, i.e., the child module(s) and all their parent modules up to the top-level module, test your changes and raise a PR.
 
 ## Prerequisites
 
@@ -139,7 +139,7 @@ Please follow the steps below:
     "version": "0.1"
   }
   ```
-- Determine all affected module paths. These are both the child module(s) and all their ancestor modules in the tree.
+- Determine all affected module paths. This includes the child module(s) and all parent modules up to the top-level module.
 
   Examples:
 
@@ -158,7 +158,7 @@ Please follow the steps below:
   {{% notice style="tip" title="Retrieve affected module paths programmatically" icon="lightbulb" %}}
   To retrieve affected module paths programmatically you can leverage the [Get-ParentFolderPathList](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/pipelines/sharedScripts/Get-ParentFolderPathList.ps1) utility using the `'OnlyModules'` option
   ```powershell
-$affectedModulePathList = Get-ParentFolderPathList -Path '<path/to/avm/child-module>' -Filter 'OnlyModules'
+  $affectedModulePathList = Get-ParentFolderPathList -Path '<path/to/avm/child-module>' -Filter 'OnlyModules'
   ```
 
   {{% /notice %}}
@@ -194,7 +194,7 @@ $affectedModulePathList = Get-ParentFolderPathList -Path '<path/to/avm/child-mod
 
     ```
 
-- Run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility, loading the script with dot sourcing and calling it explicitly on all affected modules.
+- Run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility, calling it explicitly on all affected modules.
   ```powershell
   foreach ($modulePath in $affectedModulePaths) {
     Set-AVMModule -ModuleFolderPath $modulePath

--- a/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
@@ -158,11 +158,6 @@ Please follow the steps below:
   {{% notice style="tip" title="Retrieve affected module paths programmatically" icon="lightbulb" %}}
   To retrieve affected module paths programmatically you can leverage the [Get-ParentFolderPathList](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/pipelines/sharedScripts/Get-ParentFolderPathList.ps1) utility using the `'OnlyModules'` option
   ```powershell
-    # Dot-source the script
-    . ./utilities/pipelines/sharedScripts/
-
-    # Call the function
-    Get-ParentFolderPathList.ps1
     $affectedModulePathList = Get-ParentFolderPathList -Path '<path/to/avm/child-module>' -Filter 'OnlyModules'
   ```
 
@@ -201,10 +196,6 @@ Please follow the steps below:
 
 - Run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility, loading the script with dot sourcing and calling it explicitly on all affected modules.
   ```powershell
-  # Dot-source the script
-  . ./utilities/tools/Set-AVMModule.ps1
-
-  # Iterate over each path
   foreach ($modulePath in $affectedModulePaths) {
     Set-AVMModule -ModuleFolderPath $modulePath
   }

--- a/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
@@ -97,7 +97,7 @@ Please follow the steps below:
 
 - Make sure the child module name is listed in the publishing allowed list [child-module-publish-allowed-list.json](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/pipelines/staticValidation/compliance/helper/child-module-publish-allowed-list.json). If not, add it to the file, keeping an alphabetical order. This step is relevant until the process is in a pilot phase.
 - Update the child module `main.bicep` template to support telemetry, as per [SFR4]({{% siteparam base %}}/spec/SFR4), [SFR3]({{% siteparam base %}}/spec/SFR3) and [BCPFR4]({{% siteparam base %}}/spec/BCPFR4)
-  - Add the `enableTelemetry` parameter with a default value of `true`.
+  - Add the `enableTelemetry` parameter with a default value of `true`. Place it as the **last `param` declaration**, immediately before the first `var` statement
     ```bicep
     @description('Optional. Enable/Disable usage telemetry for module.')
     param enableTelemetry bool = true

--- a/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
@@ -97,7 +97,7 @@ Please follow the steps below:
 
 - Make sure the child module name is listed in the publishing allowed list [child-module-publish-allowed-list.json](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/pipelines/staticValidation/compliance/helper/child-module-publish-allowed-list.json). If not, add it to the file, keeping an alphabetical order. This step is relevant until the process is in a pilot phase.
 - Update the child module `main.bicep` template to support telemetry, as per [SFR4]({{% siteparam base %}}/spec/SFR4), [SFR3]({{% siteparam base %}}/spec/SFR3) and [BCPFR4]({{% siteparam base %}}/spec/BCPFR4)
-  - Add the `enableTelemetry` parameter with a default value of `true`. Place it as the **last `param` declaration**, immediately before the first `var` statement
+  - Add the `enableTelemetry` parameter with a default value of `true`. Place it as the **last `param` declaration**, immediately before the first `var` declaration.
     ```bicep
     @description('Optional. Enable/Disable usage telemetry for module.')
     param enableTelemetry bool = true
@@ -124,7 +124,7 @@ Please follow the steps below:
       }
     ```
 - Update the `main.bicep` template of the child module direct parent, as per [BCPFR7]({{% siteparam base %}}/spec/BCPFR7).
-  - Add the `enableReferencedModulesTelemetry` variable with a default value of `false`.
+  - Add the `enableReferencedModulesTelemetry` variable with a default value of `false`. Place it as the **last `var` declaration**, immediately before the first `resource` declaration.
     ```bicep
     var enableReferencedModulesTelemetry = false
     ```

--- a/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
@@ -39,7 +39,7 @@ For a step-by-step explanation with detailed instructions, refer to the followin
   * **Parent module template**: In the `main.bicep` template of the child module direct parent, add a `enableReferencedModulesTelemetry` variable with a value of `false`, and pass it as the `enableTelemetry` value down to the child module deployment.
   * **Version**: Add the `version.json` file to the child module folder and set version to `0.1`.
   * **Changelog**: Add a new `CHANGELOG.md` file to the child module folder and update the changelog of all its versioned parents with a new patch version, up to the top-level parent.
-  * **Set-AVMModule**: Run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility using the `-Recurse` flag and the path to the top-level module, test your changes and raise a PR.
+  * **Set-AVMModule**: Run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility explicitly on the affected bicep modules, test your changes and raise a PR.
 
 ## Prerequisites
 
@@ -139,6 +139,35 @@ Please follow the steps below:
     "version": "0.1"
   }
   ```
+- Determine all affected module paths. These are both the child module(s) and all their ancestor modules in the tree.
+
+  Examples:
+
+  - Child module to publish: `avm/res/virtual-network/subnet`
+  - Affected modules:
+    - `avm/res/virtual-network/subnet`
+    - `avm/res/virtual-network`
+
+  - Child module to publish: `avm/res/storage/storage-account/blob-service/container/immutability-policy`
+  - Affected modules:
+    - `avm/res/storage/storage-account/blob-service/container/immutability-policy`
+    - `avm/res/storage/storage-account/blob-service/container`
+    - `avm/res/storage/storage-account/blob-service`
+    - `avm/res/storage/storage-account`
+
+  {{% notice style="tip" title="Retrieve affected module paths programmatically" icon="lightbulb" %}}
+  To retrieve affected module paths programmatically you can leverage the [Get-ParentFolderPathList](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/pipelines/sharedScripts/Get-ParentFolderPathList.ps1) utility using the `'OnlyModules'` option
+  ```powershell
+    # Dot-source the script
+    . ./utilities/pipelines/sharedScripts/
+
+    # Call the function
+    Get-ParentFolderPathList.ps1
+    $affectedModulePathList = Get-ParentFolderPathList -Path '<path/to/avm/child-module>' -Filter 'OnlyModules'
+  ```
+
+  {{% /notice %}}
+
 - Update Changelogs
   - Add a new `CHANGELOG.md` file to the child module folder, with the following sample content. Make sure to replace the `<avm/res/path/to/child-module>` placeholder with the name of the child module.
     ```markdown
@@ -156,20 +185,32 @@ Please follow the steps below:
 
     - None
     ```
-  - Update the changelog of all the child module's versioned parents with a new patch version, up to the top-level parent. Refer below for an example content section:
+  - Check the list of affected modules. Update the changelog of all the affected modules with a version.json. Add a new patch version for each. Refer below for an example content section:
     ```markdown
       ## <CurrentMajor>.<CurrentMinor>.<CurrentPatch+1>
 
       ### Changes
 
-      - Publishing child module `<child-module-path>`
+      - Publishing child module `<avm/res/path/to/child-module>`
 
       ### Breaking Changes
 
       - None
 
     ```
-- As per the default pull request process, run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility using the `-Recurse` flag and top-level parent's folder path. Then test your changes locally and/or via the top-level module pipeline, raise a PR and attach a status badge proving successful validation.
+
+- Run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility, loading the script with dot sourcing and calling it explicitly on all affected modules.
+  ```powershell
+  # Dot-source the script
+  . ./utilities/tools/Set-AVMModule.ps1
+
+  # Iterate over each path
+  foreach ($modulePath in $affectedModulePaths) {
+    Set-AVMModule -ModuleFolderPath $modulePath
+  }
+  ```
+
+- Test your changes via the top-level module pipeline, raise a PR and attach a status badge proving successful validation.
 
 {{% notice style="note" %}}
 

--- a/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
@@ -39,7 +39,7 @@ For a step-by-step explanation with detailed instructions, refer to the followin
   * **Parent module template**: In the `main.bicep` template of the child module direct parent, add a `enableReferencedModulesTelemetry` variable with a value of `false`, and pass it as the `enableTelemetry` value down to the child module deployment.
   * **Version**: Add the `version.json` file to the child module folder and set version to `0.1`.
   * **Changelog**: Add a new `CHANGELOG.md` file to the child module folder and update the changelog of all its versioned parents with a new patch version, up to the top-level parent.
-  * **Set-AVMModule**: Run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility explicitly on the affected bicep modules, i.e., the child module(s) and all their parent modules up to the top-level module, test your changes and raise a PR.
+  * **Set-AVMModule**: Run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility using the `-Recurse` flag and the path to the top-level module, test your changes and raise a PR.
 
 ## Prerequisites
 
@@ -97,7 +97,7 @@ Please follow the steps below:
 
 - Make sure the child module name is listed in the publishing allowed list [child-module-publish-allowed-list.json](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/pipelines/staticValidation/compliance/helper/child-module-publish-allowed-list.json). If not, add it to the file, keeping an alphabetical order. This step is relevant until the process is in a pilot phase.
 - Update the child module `main.bicep` template to support telemetry, as per [SFR4]({{% siteparam base %}}/spec/SFR4), [SFR3]({{% siteparam base %}}/spec/SFR3) and [BCPFR4]({{% siteparam base %}}/spec/BCPFR4)
-  - Add the `enableTelemetry` parameter with a default value of `true`. Place it as the **last `param` declaration**, immediately before the first `var` declaration.
+  - Add the `enableTelemetry` parameter with a default value of `true`.
     ```bicep
     @description('Optional. Enable/Disable usage telemetry for module.')
     param enableTelemetry bool = true
@@ -124,7 +124,7 @@ Please follow the steps below:
       }
     ```
 - Update the `main.bicep` template of the child module direct parent, as per [BCPFR7]({{% siteparam base %}}/spec/BCPFR7).
-  - Add the `enableReferencedModulesTelemetry` variable with a default value of `false`. Place it as the **last `var` declaration**, immediately before the first `resource` declaration.
+  - Add the `enableReferencedModulesTelemetry` variable with a default value of `false`.
     ```bicep
     var enableReferencedModulesTelemetry = false
     ```
@@ -139,30 +139,6 @@ Please follow the steps below:
     "version": "0.1"
   }
   ```
-- Determine all affected module paths. This includes the child module(s) and all parent modules up to the top-level module.
-
-  Examples:
-
-  - Child module to publish: `avm/res/virtual-network/subnet`
-  - Affected modules:
-    - `avm/res/virtual-network/subnet`
-    - `avm/res/virtual-network`
-
-  - Child module to publish: `avm/res/storage/storage-account/blob-service/container/immutability-policy`
-  - Affected modules:
-    - `avm/res/storage/storage-account/blob-service/container/immutability-policy`
-    - `avm/res/storage/storage-account/blob-service/container`
-    - `avm/res/storage/storage-account/blob-service`
-    - `avm/res/storage/storage-account`
-
-  {{% notice style="tip" title="Retrieve affected module paths programmatically" icon="lightbulb" %}}
-  To retrieve affected module paths programmatically you can leverage the [Get-ParentFolderPathList](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/pipelines/sharedScripts/Get-ParentFolderPathList.ps1) utility using the `'OnlyModules'` option
-  ```powershell
-  $affectedModulePathList = Get-ParentFolderPathList -Path '<path/to/avm/child-module>' -Filter 'OnlyModules'
-  ```
-
-  {{% /notice %}}
-
 - Update Changelogs
   - Add a new `CHANGELOG.md` file to the child module folder, with the following sample content. Make sure to replace the `<avm/res/path/to/child-module>` placeholder with the name of the child module.
     ```markdown
@@ -180,28 +156,20 @@ Please follow the steps below:
 
     - None
     ```
-  - Check the list of affected modules. Update the changelog of all the affected modules with a version.json. Add a new patch version for each. Refer below for an example content section:
+  - Update the changelog of all the child module's versioned parents with a new patch version, up to the top-level parent. Refer below for an example content section:
     ```markdown
       ## <CurrentMajor>.<CurrentMinor>.<CurrentPatch+1>
 
       ### Changes
 
-      - Publishing child module `<avm/res/path/to/child-module>`
+      - Publishing child module `<child-module-path>`
 
       ### Breaking Changes
 
       - None
 
     ```
-
-- Run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility, calling it explicitly on all affected modules.
-  ```powershell
-  foreach ($modulePath in $affectedModulePaths) {
-    Set-AVMModule -ModuleFolderPath $modulePath
-  }
-  ```
-
-- Test your changes via the top-level module pipeline, raise a PR and attach a status badge proving successful validation.
+- As per the default pull request process, run the [Set-AVMModule](https://github.com/Azure/bicep-registry-modules/blob/main/utilities/tools/Set-AVMModule.ps1) utility using the `-Recurse` flag and top-level parent's folder path. Then test your changes locally and/or via the top-level module pipeline, raise a PR and attach a status badge proving successful validation.
 
 {{% notice style="note" %}}
 

--- a/docs/content/experimental/ai-assisted-module-dev/avm-bicep-ai-assets/_index.md
+++ b/docs/content/experimental/ai-assisted-module-dev/avm-bicep-ai-assets/_index.md
@@ -36,13 +36,13 @@ Skills encode complex, multi-step domain workflows into structured instructions 
 **Example prompt:**
 
 ```text
-Publish a child module avm/res/network/virtual-network/virtual-network-peering.
+Publish AVM child module avm/res/network/virtual-network/virtual-network-peering
 ```
 
 Note: in some cases, VS Code is not identifying the correct skill based on the above prompt. If this happens, you can try to use the follow prompt that explicitly triggers the correct skill:
 
 ```text
-/AVM-Child-Module-Publishing Publish the child module avm/res/network/virtual-network/subnet!
+/avm-child-module-publishing Publish AVM child module avm/res/network/virtual-network/virtual-network-peering
 ```
 
 ## Prompt Files


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Ref https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-skills

The above documentation mentions that the skill name must be lowercase, using hyphens for spaces. Also for me the current name shows a warning in vs code which suggests the name to be exactly like the name of the skill folder (which also must be lowercase).

<img width="1176" height="194" alt="image" src="https://github.com/user-attachments/assets/9e5e335b-32a8-42c0-80ca-a22ee32331b6" />


## This PR fixes/adds/changes/removes

1. *Replace me*
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
