### PR TITLE
Fix Federated Credential creation failure due to eventual consistency

### DIFF
--- a/docs/static/scripts/New-AVMBicepBRMForkSetup.ps1
+++ b/docs/static/scripts/New-AVMBicepBRMForkSetup.ps1
@@ -273,15 +273,15 @@ if ($UseOIDC) {
   Write-Host "New UAMI created with a Name of '$($newUAMI.Name)' and an Object ID of '$($newUAMI.PrincipalId)'." -ForegroundColor Green
   Write-Host ''
 
+  Write-Host 'Starting 120 second sleep to allow the UAMI to be created and available for Federated Credential creation and RBAC Role Assignments (eventual consistency) ...' -ForegroundColor Yellow
+  Start-Sleep -Seconds 120
+
   # Create Federated Credentials for UAMI for OIDC
   Write-Host "Creating Federated Credentials for the User-Assigned Managed Identity Name (UAMI) for OIDC ... '$($newUAMI.Name)' for OIDC ..." -ForegroundColor Magenta
   New-AzFederatedIdentityCredentials -ResourceGroupName $newUAMIRsg.ResourceGroupName -IdentityName $newUAMI.Name -Name 'avm-gh-env-validation' -Issuer "https://token.actions.githubusercontent.com" -Subject "repo:$($GitHubOrgAndRepoNameCombined):environment:avm-validation" -ErrorAction Stop
   Write-Host ''
 
   # Create RBAC Role Assignments for UAMI
-  Write-Host 'Starting 120 second sleep to allow the UAMI to be created and available for RBAC Role Assignments (eventual consistency) ...' -ForegroundColor Yellow
-  Start-Sleep -Seconds 120
-
   Write-Host "Creating RBAC Role Assignments of 'Owner' for the User-Assigned Managed Identity Name (UAMI) '$($newUAMI.Name)' on the Subscription with the ID of '$($GitHubSecret_ARM_SUBSCRIPTION_ID)' ..." -ForegroundColor Magenta
   New-AzRoleAssignment -ObjectId $newUAMI.PrincipalId -RoleDefinitionName 'Owner' -Scope "/subscriptions/$($GitHubSecret_ARM_SUBSCRIPTION_ID)" -ErrorAction Stop
   Write-Host "RBAC Role Assignments of 'Owner' for the User-Assigned Managed Identity Name (UAMI) '$($newUAMI.Name)' created successfully on the Subscription with the ID of '$($GitHubSecret_ARM_SUBSCRIPTION_ID)'." -ForegroundColor Green


### PR DESCRIPTION
# Overview/Summary

Move the 120 sec sleep to execute before attempting to create a federated cred under the created UAMI to prevent it failing due to eventual consistency in Entra.

Currently, that step frequently fails with:

New-AzFederatedIdentityCredential_CreateExpanded: C:\dev\temp\New-AVMBicepBRMForkSetup.ps1:278
Line |
 278 |  … ercontent.com" -Subject "repo:$($GitHubOrgAndRepoNameCombined):enviro …
     |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | MS Graph resource not found during Federated Identity Credential creation.

## This PR fixes/adds/changes/removes

### Breaking Changes
None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
