### PR TITLE
show available Terraform submodules in the module index

### DIFF
--- a/docs/layouts/partials/render-terraform-submodules.html
+++ b/docs/layouts/partials/render-terraform-submodules.html
@@ -1,0 +1,49 @@
+{{- $moduleName := .moduleName -}}
+{{- $repoURL := .repoURL -}}
+{{- $moduleStatus := .moduleStatus -}}
+{{- $useLinks := .useLinks -}}
+{{/* Only query the registry API for published modules */}}
+{{- if and (or (eq $moduleStatus "Available") (eq $moduleStatus "Orphaned") (eq $moduleStatus "Deprecated")) (ne $repoURL "") -}}
+  {{/* Extract the provider from the repo URL (e.g., "azurerm" from "terraform-azurerm-...") */}}
+  {{- $repoURLSplit := strings.Split $repoURL "/" -}}
+  {{- $repoName := index $repoURLSplit (sub (len $repoURLSplit) 1) -}}
+  {{- $repoNameSplit := strings.Split $repoName "-" -}}
+  {{- $moduleProvider := index $repoNameSplit 1 -}}
+  {{/* Fetch module details from the Terraform registry API */}}
+  {{- $moduleTfRegApiUrl := printf "https://registry.terraform.io/v1/modules/Azure/%s/%s" $moduleName $moduleProvider -}}
+  {{- $moduleTfRegApiData := dict -}}
+  {{- with resources.GetRemote $moduleTfRegApiUrl -}}
+    {{- with .Err -}}
+    {{- else -}}
+      {{- $moduleTfRegApiData = . | transform.Unmarshal -}}
+    {{- end -}}
+  {{- end -}}
+  {{/* Extract submodules, filtering to only include paths under "modules/" (not examples) */}}
+  {{- $submodules := slice -}}
+  {{- with $moduleTfRegApiData.submodules -}}
+    {{- range . -}}
+      {{- if hasPrefix .path "modules/" -}}
+        {{- $submodules = $submodules | append . -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{/* Render submodules as a flat bullet point list if any exist */}}
+  {{- if $submodules -}}
+<details style="display: inline; cursor: pointer;">
+<summary style="display: inline-block; list-style: none; font-size: 0.7em; vertical-align: middle; opacity: 0.6; padding: 0; margin-left: 4px;">&#9654;</summary>
+<ul style="list-style-type: disc; padding-left: 20px; margin: 0;">
+    {{- range $submodule := $submodules -}}
+      {{- $submoduleDisplayName := strings.TrimPrefix "modules/" $submodule.path -}}
+      {{- $submoduleLink := printf "https://registry.terraform.io/modules/Azure/%s/%s/latest/submodules/%s" $moduleName $moduleProvider $submoduleDisplayName -}}
+  <li>
+        {{- if $useLinks -}}
+    <a href="{{ $submoduleLink }}" title="{{ $submodule.path }}">{{ $submoduleDisplayName }}</a>
+        {{- else -}}
+    {{ $submoduleDisplayName }}
+        {{- end -}}
+  </li>
+    {{- end -}}
+</ul>
+</details>
+  {{- end -}}
+{{- end -}}

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -345,7 +345,7 @@
           {{ $item.ModuleName }}
         {{- end -}}
 
-        {{- partial "render-child-modules.html" (dict "maps" $maps "parentName" $item.ModuleName "useLinks" $useLinks "language" $language) -}}
+        {{- partial "render-terraform-submodules.html" (dict "moduleName" $item.ModuleName "repoURL" $item.RepoURL "moduleStatus" $item.ModuleStatus "useLinks" $useLinks) -}}
       </td>
       <td style="text-align: center;"> {{/* link to the source code repo */}}
         {{- if $useLinks -}}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Show available Terraform submodules in the module index.

## This PR fixes/adds/changes/removes

1. similar to how Bicep child modules are shown in the index, this PR adds support for showing available Terraform submodules in the module index. This includes TF resource, pattern and utility modules.
<img width="1498" height="705" alt="image" src="https://github.com/user-attachments/assets/549dfaa7-22d1-4b52-9c86-d8860b283200" />

### Breaking Changes

1. n/a

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
