### PR TITLE
Remove moduleProvider input from repository setup

### DIFF
--- a/docs/content/contributing/terraform/repository-setup.md
+++ b/docs/content/contributing/terraform/repository-setup.md
@@ -76,7 +76,6 @@ if(!(Test-Path -Path "./scripts/New-Repository.ps1")) {
 }
 
 # Required Inputs
-$moduleProvider = "azurerm" # Allowed: azurerm, azapi, azure
 $moduleName = "<module name>" # e.g. avm-res-network-virtualnetwork
 $moduleDisplayName = "<module description>"
 $resourceProviderNamespace = "" # Leave empty for Pattern/Utility modules
@@ -90,7 +89,6 @@ $ownerSecondaryGitHubHandle = ""
 $ownerSecondaryDisplayName = ""
 
 ./scripts/New-Repository.ps1 `
-    -moduleProvider $moduleProvider `
     -moduleName $moduleName `
     -moduleDisplayName $moduleDisplayName `
     -resourceProviderNamespace $resourceProviderNamespace `


### PR DESCRIPTION
This pull request makes a minor update to the Terraform repository setup documentation. The change removes the unused `$moduleProvider` input parameter from both the input section and the example script invocation, simplifying the setup instructions.