### PR TITLE
docs(terraform): clarify resource_types, retry and timeouts for submodules

### DIFF
--- a/docs/content/specs-defs/includes/terraform/resource/functional/TFRMFR1.md
+++ b/docs/content/specs-defs/includes/terraform/resource/functional/TFRMFR1.md
@@ -69,7 +69,7 @@ DESCRIPTION
 
 ```terraform
 resource "azapi_resource" "this" {
-  type      = var.resource_types.this
+  type      = var.resource_types.example_widgets
   name      = var.name
   parent_id = var.parent_id
   body      = { /* ... */ }

--- a/docs/content/specs-defs/includes/terraform/resource/non-functional/TFRMNFR1.md
+++ b/docs/content/specs-defs/includes/terraform/resource/non-functional/TFRMNFR1.md
@@ -63,7 +63,7 @@ Cardinality is the parent module's responsibility: the parent module **MUST** us
 
 This rule applies equally when a submodule is consumed through its parent module and when the same submodule is consumed directly by another caller.
 
-For example, a parent module deploying multiple `parts` calls its `part` submodule using `for_each`:
+For example, a parent module deploying multiple `parts` calls its `part` submodule using `for_each`, cascades the matching nested slot from its own `resource_types` (see [TFFR6]({{% siteparam base %}}/spec/TFFR6) for the naming rule and nested-slot pattern), and passes `retry` and `timeouts` through unchanged (see [TFFR7]({{% siteparam base %}}/spec/TFFR7)):
 
 ```terraform
 module "part" {
@@ -72,7 +72,23 @@ module "part" {
 
   name           = each.value.name
   parent_id      = azapi_resource.this.id
-  resource_types = { this = var.resource_types.part }
+  resource_types = var.resource_types.example_widgets_parts
+  retry          = var.retry
+  timeouts       = var.timeouts
+}
+```
+
+When the subresource tree is more than one level deep (for example `Microsoft.Example/widgets/parts/components`), the same pattern recurses: the `part` submodule declares its own `resource_types` with a nested slot for `example_widgets_parts_components`, and cascades that slot through to its sibling `component` submodule unchanged:
+
+```terraform
+# Inside modules/part/main.tf
+module "component" {
+  source   = "../component"
+  for_each = var.components
+
+  name           = each.value.name
+  parent_id      = azapi_resource.this.id
+  resource_types = var.resource_types.example_widgets_parts_components
   retry          = var.retry
   timeouts       = var.timeouts
 }
@@ -133,8 +149,8 @@ Submodules **MUST** meet every requirement that applies to a top-level AVM Terra
   - [TFFR3]({{% siteparam base %}}/spec/TFFR3) — AzAPI provider usage.
   - [TFFR4]({{% siteparam base %}}/spec/TFFR4) — `response_export_values`.
   - [TFFR5]({{% siteparam base %}}/spec/TFFR5) — `replace_triggers_refs`.
-  - [TFFR6]({{% siteparam base %}}/spec/TFFR6) — `resource_types` variable.
-  - [TFFR7]({{% siteparam base %}}/spec/TFFR7) — `retry` and `timeouts` variables (which the parent module **MUST** cascade to each submodule).
+  - [TFFR6]({{% siteparam base %}}/spec/TFFR6) — `resource_types` variable. Each submodule declares its own `resource_types` for the resources it owns; the parent declares a nested `optional(object({...}), {})` slot per submodule that mirrors the submodule's variable exactly, and cascades it through unchanged.
+  - [TFFR7]({{% siteparam base %}}/spec/TFFR7) — `retry` and `timeouts` variables, which the parent module **MUST** cascade to each submodule unchanged.
 - All applicable [interface]({{% siteparam base %}}/specs/tf/interfaces/) specifications (managed identities, role assignments, locks, diagnostic settings, private endpoints, customer-managed keys, tags) — for any interface that is supported by the underlying ARM subresource.
 
 To avoid duplication, this specification deliberately states the requirement once: *every requirement that applies to a top-level resource module applies equally to every one of its submodules*. Where a requirement contradicts the submodule's nature (for example, a submodule that is never published independently still **MUST** include all required documentation files but is not itself listed in the registry), the requirement is interpreted in the context of the submodule.

--- a/docs/content/specs-defs/includes/terraform/resource/non-functional/TFRMNFR2.md
+++ b/docs/content/specs-defs/includes/terraform/resource/non-functional/TFRMNFR2.md
@@ -27,9 +27,11 @@ Standardizing on `this` for the primary resource lets consumers, CI checks, and 
 
 ### Example
 
+The resource label (`this`) and the `var.resource_types.<key>` argument supplied to `type =` are independent concerns: the label is governed by this spec, the key by the naming rule in [TFFR6]({{% siteparam base %}}/spec/TFFR6). `this` is therefore never a valid `resource_types` key — the key names the AzAPI resource type, not the Terraform graph node.
+
 ```terraform
 resource "azapi_resource" "this" {
-  type      = var.resource_types.this
+  type      = var.resource_types.example_widgets
   name      = var.name
   parent_id = var.parent_id
   body      = { /* ... */ }

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR6.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR6.md
@@ -23,53 +23,180 @@ priority: 20060
 
 Authors **MUST NOT** hard-code the `type` argument of an `azapi_resource` (or `azapi_data_plane_resource`, `azapi_resource_action`, `azapi_update_resource`) inline.
 
-Instead, every AzAPI resource type string used by the module **MUST** be sourced from a single object variable named `resource_types`. This variable **MUST**:
+Instead, every AzAPI resource type string used by the module **MUST** be sourced from a single object variable named `resource_types`.
 
-- Have one `optional(string, "<provider>/<resource>@<api-version>")` field per `azapi_resource` declared by the module (and by its submodules — see [TFRMNFR1]({{% siteparam base %}}/spec/TFRMNFR1)).
-- Default each field to the latest API version that the module has been tested against. The default **MUST** be a stable (non-preview) API version unless the module's primary resource only ships a preview API.
+### `resource_types` keys vs Terraform resource labels
+
+These are two unrelated concepts and the spec treats them independently:
+
+- **Keys in `var.resource_types`** name the *AzAPI resource type* and are derived from the ARM type by the naming rule below. They appear on the right of an assignment as the value of the `type` argument.
+- **Terraform resource labels** (e.g. `azapi_resource.this`) name the *graph node* and govern how the resource is referenced elsewhere in HCL. The primary resource label **MUST** be `this`, per [TFRMNFR2]({{% siteparam base %}}/spec/TFRMNFR2).
+
+A typical primary-resource declaration therefore reads:
+
+```terraform
+resource "azapi_resource" "this" {            # label per TFRMNFR2
+  type = var.resource_types.example_widgets   # key per the naming rule below
+  # ...
+}
+```
+
+`this` and `example_widgets` describe different things and are derived by different rules. They **MUST NOT** be made to coincide — `this` is never a valid `resource_types` key.
+
+### Key naming
+
+Each `resource_types` key (at every level of nesting) **MUST** be the snake_case form of the ARM resource type, with the `Microsoft.` prefix dropped:
+
+- Drop the `Microsoft.` prefix.
+- Render the provider namespace as a single lowercase token — do **not** split internal camelCase (`KeyVault` → `keyvault`, `DocumentDB` → `documentdb`, `EventHub` → `eventhub`).
+- Convert each resource path segment after the provider from camelCase to snake_case (`virtualNetworks` → `virtual_networks`, `roleAssignments` → `role_assignments`).
+- Join the provider token and each path segment with `_`.
+
+| ARM type | Key |
+|---|---|
+| `Microsoft.Example/widgets` | `example_widgets` |
+| `Microsoft.Example/widgets/parts` | `example_widgets_parts` |
+| `Microsoft.Example/widgets/parts/components` | `example_widgets_parts_components` |
+| `Microsoft.Authorization/locks` | `authorization_locks` |
+| `Microsoft.Authorization/roleAssignments` | `authorization_role_assignments` |
+| `Microsoft.Insights/diagnosticSettings` | `insights_diagnostic_settings` |
+| `Microsoft.KeyVault/vaults/secrets` | `keyvault_vaults_secrets` |
+| `Microsoft.Network/virtualNetworks/subnets` | `network_virtual_networks_subnets` |
+
+The rule is deterministic so consumers, lint checks and tooling can derive the expected key for any ARM type without consulting the module source. Authors **MUST NOT** invent shorter aliases (e.g. `widgets` instead of `example_widgets`).
+
+### Variable shape
+
+The `resource_types` variable **MUST**:
+
+- Be a single `object({...})` (not a `map(string)`) so typos at call sites error at plan time and per-key defaults are visible in the variable declaration.
 - Default the variable itself to `{}` so consumers only need to supply the keys they wish to override.
 - Be `nullable = false`.
-- Document each field in the variable's `description`, including the resource it controls.
+- Declare one `optional(string, "<provider>/<resource>@<api-version>")` field for every AzAPI resource the module itself declares, defaulting each to the latest API version the module has been tested against. The default **MUST** be a stable (non-preview) API version unless the module's primary resource only ships a preview API.
+- Declare one nested `optional(object({...}), {})` field for every submodule the module instantiates (see [TFRMNFR1]({{% siteparam base %}}/spec/TFRMNFR1)). The shape of the nested object **MUST** match that submodule's own `resource_types` variable exactly. The parent **MUST NOT** repeat the submodule's defaults — the inner string attributes are declared as `optional(string)` (no default) so the submodule remains the single source of truth for its own tested API versions.
+- Document every field in the variable's `description`.
 
-The rationale is to allow consumers to:
+### Cascading to submodules
+
+Because the nested slot in the parent mirrors the submodule's variable, the parent cascades the slot through unchanged:
+
+```terraform
+module "part" {
+  source         = "./modules/part"
+  resource_types = var.resource_types.example_widgets_parts
+}
+```
+
+No renaming, repacking, or null filtering is required. When the consumer omits a key or sets it explicitly to `null`, Terraform substitutes the default declared on the owning module's variable (per [Terraform's optional-attribute semantics](https://developer.hashicorp.com/terraform/language/expressions/type-constraints#optional-object-type-attributes)).
+
+The rationale for the variable is to let consumers:
 
 - Target sovereign clouds (e.g., Azure US Government, Azure China) where older API versions may be the latest available.
 - Opt into a newer preview API version without waiting for a module release.
 - Pin a specific API version for compliance or reproducibility reasons.
 
-Parent modules **MUST** cascade the relevant subset of `resource_types` to each submodule they instantiate, so that submodule API versions remain consistent with the parent's chosen versions and a single override at the parent level propagates everywhere.
+Nesting submodule slots inside the parent's `resource_types` (rather than flattening every AzAPI resource into a single top-level namespace):
+
+- Keeps each module's defaults co-located with the resource it owns.
+- Lets a submodule add or rename its own resources without forcing a breaking change on parent-module consumers who never touched those keys.
+- Makes the override surface mirror the actual module tree — a consumer looking at the parent's variable can see, in shape, every resource managed beneath it.
+
+### Example — root, child and grandchild
+
+A module managing `Microsoft.Example/widgets`, with a `parts` submodule for `Microsoft.Example/widgets/parts`, which in turn instantiates a `component` sibling submodule for `Microsoft.Example/widgets/parts/components` (per [TFRMNFR1]({{% siteparam base %}}/spec/TFRMNFR1)):
 
 ```terraform
+# === root variables.tf ===
 variable "resource_types" {
   type = object({
-    widget = optional(string, "Microsoft.Example/widgets@2024-01-01")
-    part   = optional(string, "Microsoft.Example/widgets/parts@2024-01-01")
-    lock   = optional(string, "Microsoft.Authorization/locks@2020-05-01")
-  })
-  default     = {}
-  nullable    = false
-  description = <<DESCRIPTION
-Override the AzAPI `<provider>/<resource>@<api-version>` strings used by this module. Each key defaults to a tested value; supply only the keys you want to override. Useful when targeting a sovereign cloud with older API versions, or when opting into a newer preview API.
+    example_widgets     = optional(string, "Microsoft.Example/widgets@2024-01-01")
+    authorization_locks = optional(string, "Microsoft.Authorization/locks@2020-05-01")
 
-- `widget` - The primary resource managed by this module.
-- `part`   - Child resources of the primary resource.
-- `lock`   - Management lock applied to the primary resource and its private endpoints.
-DESCRIPTION
+    example_widgets_parts = optional(object({
+      example_widgets_parts            = optional(string)
+      example_widgets_parts_components = optional(object({
+        example_widgets_parts_components = optional(string)
+      }), {})
+    }), {})
+  })
+  default  = {}
+  nullable = false
 }
 
+# === root main.tf ===
 resource "azapi_resource" "this" {
-  type      = var.resource_types.widget
+  type      = var.resource_types.example_widgets
   name      = var.name
   parent_id = var.parent_id
   body      = { /* ... */ }
 }
 
 module "part" {
-  source = "./modules/part"
+  source         = "./modules/part"
+  for_each       = var.parts
+  name           = each.value.name
+  parent_id      = azapi_resource.this.id
+  resource_types = var.resource_types.example_widgets_parts
+}
 
-  # Cascade the relevant subset to the submodule.
+# === modules/part/variables.tf ===
+variable "resource_types" {
+  type = object({
+    example_widgets_parts            = optional(string, "Microsoft.Example/widgets/parts@2024-01-01")
+    example_widgets_parts_components = optional(object({
+      example_widgets_parts_components = optional(string)
+    }), {})
+  })
+  default  = {}
+  nullable = false
+}
+
+# === modules/part/main.tf ===
+resource "azapi_resource" "this" {
+  type      = var.resource_types.example_widgets_parts
+  name      = var.name
+  parent_id = var.parent_id
+  body      = { /* ... */ }
+}
+
+module "component" {
+  source         = "../component"
+  for_each       = var.components
+  name           = each.value.name
+  parent_id      = azapi_resource.this.id
+  resource_types = var.resource_types.example_widgets_parts_components
+}
+
+# === modules/component/variables.tf ===
+variable "resource_types" {
+  type = object({
+    example_widgets_parts_components = optional(string, "Microsoft.Example/widgets/parts/components@2024-01-01")
+  })
+  default  = {}
+  nullable = false
+}
+
+# === modules/component/main.tf ===
+resource "azapi_resource" "this" {
+  type      = var.resource_types.example_widgets_parts_components
+  name      = var.name
+  parent_id = var.parent_id
+  body      = { /* ... */ }
+}
+```
+
+A consumer overriding only the grandchild API version writes:
+
+```terraform
+module "widget" {
+  source = "Azure/avm-res-example-widget/azure"
+
   resource_types = {
-    this = var.resource_types.part
+    example_widgets_parts = {
+      example_widgets_parts_components = {
+        example_widgets_parts_components = "Microsoft.Example/widgets/parts/components@2023-01-01"
+      }
+    }
   }
 
   # ...other arguments...

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR7.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR7.md
@@ -73,7 +73,7 @@ DESCRIPTION
 }
 
 resource "azapi_resource" "this" {
-  type      = var.resource_types.this
+  type      = var.resource_types.example_widgets
   name      = var.name
   parent_id = var.parent_id
   body      = { /* ... */ }

--- a/docs/content/specs-defs/specs/terraform/interfaces.md
+++ b/docs/content/specs-defs/specs/terraform/interfaces.md
@@ -145,7 +145,7 @@ This interface is a **SHOULD** instead of a **MUST** and therefore the AVM core 
 
 {{% notice style="important" %}}
 
-The keys of the `resource_types` object are module-specific. Each module **MUST** declare one `optional(string, "...")` field per `azapi_resource` (or equivalent AzAPI resource) it owns, defaulting each field to the latest tested API version. See [TFFR6]({{% siteparam base %}}/spec/TFFR6).
+Each `resource_types` key **MUST** be the snake_case form of the ARM resource type with the `Microsoft.` prefix dropped (for example `Microsoft.Example/widgets/parts` \u2192 `example_widgets_parts`). Each module **MUST** declare one `optional(string, "...")` field per `azapi_resource` (or equivalent AzAPI resource) it owns, defaulting each field to the latest tested API version. See [TFFR6]({{% siteparam base %}}/spec/TFFR6).
 
 {{% /notice %}}
 
@@ -159,7 +159,8 @@ The keys of the `resource_types` object are module-specific. Each module **MUST*
 
 **Notes:**
 
-- Parent modules **MUST** cascade the relevant subset of `resource_types` to each submodule they instantiate (see [TFRMNFR1]({{% siteparam base %}}/spec/TFRMNFR1)). Submodules **MUST** declare their own `resource_types` variable using the same pattern.
+- `resource_types` keys name the AzAPI resource type and are derived deterministically from the ARM type. They are independent of the Terraform resource label (see [TFRMNFR2]({{% siteparam base %}}/spec/TFRMNFR2)) \u2014 `this` is never a valid `resource_types` key.
+- Submodules **MUST** declare their own `resource_types` variable using the same naming rule for the resources they own. The parent **MUST** declare one nested `optional(object({...}), {})` slot per submodule it instantiates, shaped exactly like that submodule's variable, and **MUST** cascade the slot through unchanged (see [TFRMNFR1]({{% siteparam base %}}/spec/TFRMNFR1)). The parent **MUST NOT** repeat the submodule's defaults \u2014 the submodule remains the source of truth for its own tested API versions.
 - Defaults **MUST** be a stable (non-preview) API version unless the module's primary resource only ships a preview API.
 
 ## AzAPI retry

--- a/docs/static/includes/interfaces/tf/int.resource_types.input.tf
+++ b/docs/static/includes/interfaces/tf/int.resource_types.input.tf
@@ -1,7 +1,19 @@
+# Consumers override only the keys they need; defaults supply the rest.
+# Passing `null` for any attribute (or omitting it) yields the default
+# declared on the owning module's variable.
 resource_types = {
   # Pin the primary widget to a newer preview API version.
-  widget = "Microsoft.Example/widgets@2025-06-01-preview"
+  example_widgets = "Microsoft.Example/widgets@2025-06-01-preview"
 
-  # Use an older API version that is available in a sovereign cloud.
-  widget_setting = "Microsoft.Example/widgets/settings@2023-01-01"
+  # Override an API version inside the `parts` submodule.
+  example_widgets_parts = {
+    example_widgets_parts = "Microsoft.Example/widgets/parts@2023-01-01"
+
+    # Override an API version inside the grandchild `components` submodule
+    # of `parts` — the nested slot mirrors the submodule tree.
+    example_widgets_parts_components = {
+      example_widgets_parts_components = "Microsoft.Example/widgets/parts/components@2023-01-01"
+    }
+  }
 }
+

--- a/docs/static/includes/interfaces/tf/int.resource_types.schema.tf
+++ b/docs/static/includes/interfaces/tf/int.resource_types.schema.tf
@@ -1,33 +1,83 @@
-# The `resource_types` variable is module-specific: the field set below is
-# illustrative. Each module **MUST** declare one `optional(string, "...")`
-# field per `azapi_resource` (or equivalent AzAPI resource) it declares,
-# defaulting each field to the latest tested API version. Submodules
-# **MUST** follow the same pattern for the resources they own. The field
-# names **MUST** describe the resource being managed - never use generic
-# names like `this` or `resource`.
+# `resource_types` keys vs Terraform resource labels
+# -----------------------------------------------------------------------------
+# These are two unrelated concepts:
+#
+#   - Keys in `var.resource_types` name the AzAPI resource TYPE (e.g.
+#     `example_widgets`). They are derived from the ARM resource type by
+#     the naming rule below.
+#   - The Terraform resource LABEL (e.g. `azapi_resource.this`) names the
+#     graph node. The primary resource label MUST be `this` per TFRMNFR2.
+#
+# A primary-resource declaration therefore reads:
+#
+#   resource "azapi_resource" "this" {            # label per TFRMNFR2
+#     type = var.resource_types.example_widgets   # key per the naming rule
+#   }
+#
+# The two MUST NOT be conflated. `this` is never a valid `resource_types` key.
+#
+# Naming rule for `resource_types` keys
+# -----------------------------------------------------------------------------
+# Each key MUST be the snake_case form of the ARM resource type with the
+# `Microsoft.` prefix dropped. The provider namespace is rendered as a single
+# lowercase token (no internal split) and each path segment after the
+# provider is converted from camelCase to snake_case. Segments are joined
+# with `_`:
+#
+#   Microsoft.Example/widgets                  -> example_widgets
+#   Microsoft.Example/widgets/parts            -> example_widgets_parts
+#   Microsoft.Example/widgets/parts/components -> example_widgets_parts_components
+#   Microsoft.Authorization/locks              -> authorization_locks
+#   Microsoft.Authorization/roleAssignments    -> authorization_role_assignments
+#   Microsoft.Insights/diagnosticSettings      -> insights_diagnostic_settings
+#   Microsoft.KeyVault/vaults/secrets          -> keyvault_vaults_secrets
+#   Microsoft.Network/virtualNetworks/subnets  -> network_virtual_networks_subnets
+#
+# Submodules in the variable
+# -----------------------------------------------------------------------------
+# Every submodule the module instantiates gets a nested `optional(object({...}), {})`
+# slot in `resource_types`, keyed by the submodule's primary ARM resource type
+# (same naming rule). The slot's shape MUST match the submodule's own
+# `resource_types` variable exactly. The parent MUST NOT repeat the submodule's
+# defaults: the inner string attributes are declared as `optional(string)`
+# with no default, so the submodule remains the single source of truth for
+# its own tested API versions. Passing `null` (or omitting the key) yields
+# the submodule's default.
+
+# Root module example: manages `Microsoft.Example/widgets`, owns one extension
+# resource (a lock), and instantiates a `parts` submodule that itself
+# instantiates a `component` sibling submodule (per TFRMNFR1).
 variable "resource_types" {
   type = object({
-    widget          = optional(string, "Microsoft.Example/widgets@2024-01-01")
-    widget_setting  = optional(string, "Microsoft.Example/widgets/settings@2024-01-01")
-    lock            = optional(string, "Microsoft.Authorization/locks@2020-05-01")
+    example_widgets     = optional(string, "Microsoft.Example/widgets@2024-01-01")
+    authorization_locks = optional(string, "Microsoft.Authorization/locks@2020-05-01")
+
+    example_widgets_parts = optional(object({
+      example_widgets_parts            = optional(string)
+      example_widgets_parts_components = optional(object({
+        example_widgets_parts_components = optional(string)
+      }), {})
+    }), {})
   })
-  default     = {}
-  nullable    = false
+  default  = {}
+  nullable = false
   description = <<DESCRIPTION
-Override the AzAPI `<provider>/<resource>@<api-version>` strings used by this module. Each key defaults to a tested value; supply only the keys you want to override. Useful when targeting a sovereign cloud with older API versions, or when opting into a newer preview API.
+Override the AzAPI `<provider>/<resource>@<api-version>` strings used by this module and its submodules. Each key defaults to a tested value; supply only the keys you want to override. Useful when targeting a sovereign cloud with older API versions, or when opting into a newer preview API.
 
-The keys below are specific to this example module (which manages widgets). Each module names its keys after the resources it actually owns - for example, a Cosmos DB module would expose keys such as `database_account`, `sql_database`, and `sql_container`.
-
-- `widget`         - The primary widget managed by this module.
-- `widget_setting` - Settings attached to the widget.
-- `lock`           - Management lock applied to the widget and its private endpoints.
+- `example_widgets`     - The primary widget managed by this module.
+- `authorization_locks` - Management lock applied to the widget and its private endpoints.
+- `example_widgets_parts` - Override slot for the `parts` submodule. Defaults live in the submodule; supply only the keys you want to override.
+  - `example_widgets_parts`            - The part resource managed by the `parts` submodule.
+  - `example_widgets_parts_components` - Override slot for the grandchild `components` submodule. Defaults live in that submodule.
+    - `example_widgets_parts_components` - The component resource managed by the `components` submodule.
 DESCRIPTION
 }
 
-# Example resource implementation. The `type` of every `azapi_resource`
-# **MUST** come from `var.resource_types`, never a hard-coded string.
-resource "azapi_resource" "widget" {
-  type      = var.resource_types.widget
+# `type =` of every `azapi_resource` MUST come from `var.resource_types`,
+# never a hard-coded string. The resource label (`this`) and the
+# `resource_types` key (`example_widgets`) are independent concerns.
+resource "azapi_resource" "this" {
+  type      = var.resource_types.example_widgets
   name      = var.name
   parent_id = var.parent_id
   body      = { /* ... */ }
@@ -35,17 +85,14 @@ resource "azapi_resource" "widget" {
   response_export_values = []
 }
 
-# Cascade the relevant subset of `resource_types` to every submodule the
-# parent module instantiates so that a single override at the parent level
-# propagates to every resource the module manages. The submodule names its
-# primary resource `setting` (because that is what it manages), while this
-# parent module exposes the same resource as `widget_setting`.
-module "setting" {
-  source = "./modules/widget-setting"
-
-  resource_types = {
-    setting = var.resource_types.widget_setting
-  }
-
-  # ...other arguments...
+# Cascade the nested slot through to the submodule unchanged. The submodule's
+# `resource_types` variable has exactly the shape of the slot, so no
+# repacking or renaming is required.
+module "part" {
+  source         = "./modules/part"
+  for_each       = var.parts
+  name           = each.value.name
+  parent_id      = azapi_resource.this.id
+  resource_types = var.resource_types.example_widgets_parts
 }
+

--- a/docs/static/includes/interfaces/tf/int.retry.schema.tf
+++ b/docs/static/includes/interfaces/tf/int.retry.schema.tf
@@ -20,7 +20,7 @@ DESCRIPTION
 # so the variable is assigned directly. The same pattern applies to every
 # `azapi_resource` declared by the module, including those in submodules.
 resource "azapi_resource" "this" {
-  type      = var.resource_types.this
+  type      = var.resource_types.example_widgets
   name      = var.name
   parent_id = var.parent_id
   body      = { /* ... */ }

--- a/docs/static/includes/interfaces/tf/int.timeouts.schema.tf
+++ b/docs/static/includes/interfaces/tf/int.timeouts.schema.tf
@@ -21,7 +21,7 @@ DESCRIPTION
 # default. The same pattern applies to every `azapi_resource` declared by
 # the module, including those in submodules.
 resource "azapi_resource" "this" {
-  type      = var.resource_types.this
+  type      = var.resource_types.example_widgets
   name      = var.name
   parent_id = var.parent_id
   body      = { /* ... */ }


### PR DESCRIPTION
# Overview/Summary

Clarifies the AVM Terraform `resource_types`, `retry` and `timeouts` interfaces so submodules and their parents have an unambiguous, mechanical contract.

## This PR fixes/adds/changes/removes

1. Defines a deterministic snake_case naming rule for `resource_types` keys derived directly from the ARM resource type (`Microsoft.Example/widgets/parts` → `example_widgets_parts`). Authors no longer choose key names; consumers and lint checks can derive the expected key for any ARM type.
2. Calls out explicitly that `resource_types` keys (AzAPI types) and Terraform resource labels (graph nodes) are independent concepts. `this` is a Terraform label per TFRMNFR2 and is never a valid `resource_types` key.
3. Switches the submodule cascade for `resource_types` from a flat re-mapping model to a nested object that mirrors the submodule tree. Parents declare one `optional(object({...}), {})` slot per submodule, shaped identically to the submodule's own `resource_types` variable. Slots are cascaded through unchanged (`resource_types = var.resource_types.example_widgets_parts`). Defaults remain owned by the submodule — passing `null` resolves to the submodule's tested default per Terraform's optional-attribute semantics.
4. Adds a root → child → grandchild worked example covering `Microsoft.Example/widgets`, `/widgets/parts` and `/widgets/parts/components`, plus a consumer-side override example that only touches the grandchild API version.
5. Restates that `retry` and `timeouts` cascade unchanged to every submodule.
6. Replaces stale `var.resource_types.this` examples across TFFR7, TFRMNFR1, TFRMNFR2, TFRMFR1, `int.retry.schema.tf` and `int.timeouts.schema.tf` with valid ARM-derived keys.
7. Updates `interfaces.md` notes to reflect the new naming rule, the keys-vs-labels separation, and the nested cascade model.

### Breaking Changes

These are documentation-only changes to AVM Terraform specs (TFFR6, TFFR7, TFRMNFR1, TFRMNFR2, TFRMFR1) and their shared interface snippets. No module source is touched. However, module owners adopting TFFR6 going forward will need to:

1. Rename their `resource_types` keys to the deterministic ARM-derived snake_case form.
2. Restructure parent-module `resource_types` to use nested `optional(object({...}), {})` slots per submodule.

This should be coordinated with the next module release cycle.

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://aka.ms/avm/contribute) and ensured this PR is compliant with the guide
- [x] Checked for [duplicate PRs](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated relevant GitHub Issues / ADO Work Items to this PR — n/a
- [x] Confirmed this PR is initiated from a branch on a fork of this repository (or directly on a branch when working with maintainers) so PR checks execute
- [x] Updated relevant documentation (this PR is itself the documentation update)
