### PR TITLE
docs(terraform): update module owner access package and enforced PR approval flow

### DIFF
--- a/docs/content/contributing/terraform/contribution-flow.md
+++ b/docs/content/contributing/terraform/contribution-flow.md
@@ -299,7 +299,7 @@ PR approvals are **enforced** on all AVM Terraform module repositories. A PR can
 
 ### Finding an approver
 
-1. **First port of call — find a friendly module owner.** Look up another active Terraform module owner from the [`AVM Terraform Module Owners`](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Overview/groupId/006e73c9-4e67-4e08-903e-527b1547262c) Entra group and request a review from them directly. This is the fastest path to approval.
+1. **First port of call — find a friendly module owner.** Look up another active Terraform module owner from the [`AVM Terraform Module Owners`](https://aka.ms/avm/id/groups/module-contributors) Entra group and request a review from them directly. This is the fastest path to approval.
 2. **If no module owner is available**, fall back to the AVM core team:
     - Assign the `@Azure/azure-verified-modules-engineering-owners` GitHub team as a reviewer on the PR.
     - Apply the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>&nbsp; label so the request is picked up during core team triage.

--- a/docs/content/contributing/terraform/contribution-flow.md
+++ b/docs/content/contributing/terraform/contribution-flow.md
@@ -293,7 +293,16 @@ For your own PRs, the tests trigger automatically — approve the run and wait f
 
 ## 8. Review and merge PR
 
-Every PR must be reviewed and approved before merging.
+{{% notice style="important" %}}
+PR approvals are **enforced** on all AVM Terraform module repositories. A PR cannot be merged until it has been approved by an authorized module owner.
+{{% /notice %}}
+
+### Finding an approver
+
+1. **First port of call — find a friendly module owner.** Look up another active Terraform module owner from the [`AVM Terraform Module Owners`](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Overview/groupId/006e73c9-4e67-4e08-903e-527b1547262c) Entra group and request a review from them directly. This is the fastest path to approval.
+2. **If no module owner is available**, fall back to the AVM core team:
+    - Assign the `@Azure/azure-verified-modules-engineering-owners` GitHub team as a reviewer on the PR.
+    - Apply the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>&nbsp; label so the request is picked up during core team triage.
 
 {{% include file="/static/includes/PR-approval-guidance.md" %}}
 

--- a/docs/content/contributing/terraform/prerequisites.md
+++ b/docs/content/contributing/terraform/prerequisites.md
@@ -17,9 +17,9 @@ This step is **only required if you are (or are becoming) a Terraform module own
 
 Access for Terraform module owners is granted via the **AVM Terraform Module Owners** Entra access package. Request access here:
 
-- [AVM Terraform Module Owners — Access Package](https://myaccess.microsoft.com/@microsoft.onmicrosoft.com#/access-packages/b45b0231-c5ab-43fe-94b1-1efd0547bd67)
+- [AVM Terraform Module Owners — Access Package](https://aka.ms/avm/id/access-package/module-contributor)
 
-Once approved, you will be added to the [`AVM Terraform Module Owners`](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Overview/groupId/006e73c9-4e67-4e08-903e-527b1547262c) Entra group, which is the source of truth for who is authorized to own and approve changes on AVM Terraform module repositories.
+Once approved, you will be added to the [`AVM Terraform Module Owners`](https://aka.ms/avm/id/groups/module-contributors) Entra group, which is the source of truth for who is authorized to own and approve changes on AVM Terraform module repositories.
 
 {{% notice style="tip" %}}
 Until your access request is approved, you can continue to contribute by using JIT elevation and by raising PRs that are approved by an existing module owner.

--- a/docs/content/contributing/terraform/prerequisites.md
+++ b/docs/content/contributing/terraform/prerequisites.md
@@ -9,6 +9,22 @@ weight: 1
 
 To contribute, you need a GitHub account. If you are a Microsoft employee, your account must be [linked](https://repos.opensource.microsoft.com/link) to your corporate identity and you must be a member of the [Azure](https://repos.opensource.microsoft.com/orgs/Azure) organization.
 
+## Module Owner Access (Microsoft FTEs only)
+
+{{% notice style="note" %}}
+This step is **only required if you are (or are becoming) a Terraform module owner**. External contributors and one-off contributors do not need this access.
+{{% /notice %}}
+
+Access for Terraform module owners is granted via the **AVM Terraform Module Owners** Entra access package. Request access here:
+
+- [AVM Terraform Module Owners — Access Package](https://myaccess.microsoft.com/@microsoft.onmicrosoft.com#/access-packages/b45b0231-c5ab-43fe-94b1-1efd0547bd67)
+
+Once approved, you will be added to the [`AVM Terraform Module Owners`](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Overview/groupId/006e73c9-4e67-4e08-903e-527b1547262c) Entra group, which is the source of truth for who is authorized to own and approve changes on AVM Terraform module repositories.
+
+{{% notice style="tip" %}}
+Until your access request is approved, you can continue to contribute by using JIT elevation and by raising PRs that are approved by an existing module owner.
+{{% /notice %}}
+
 ## Required Tooling
 
 {{% notice style="tip" %}}

--- a/docs/content/contributing/terraform/repository-setup.md
+++ b/docs/content/contributing/terraform/repository-setup.md
@@ -19,10 +19,10 @@ If you have already completed these steps, skip to step 2.
 
 1. Open the [Open Source Portal](https://repos.opensource.microsoft.com/link) and ensure your GitHub account is linked to your Microsoft account.
 2. Open the [Open Source Portal](https://repos.opensource.microsoft.com/orgs) and ensure you are a member of the `Azure` and `Microsoft` organizations.
-3. Navigate to [Core Identity](https://coreidentity.microsoft.com/manage/Entitlement/entitlement/azureverifie-ks5z) and request access to the `Azure Verified Module Owners Terraform` entitlement.
+3. Request access via the [AVM Terraform Module Owners access package](https://myaccess.microsoft.com/@microsoft.onmicrosoft.com#/access-packages/b45b0231-c5ab-43fe-94b1-1efd0547bd67). Approval adds you to the [`AVM Terraform Module Owners`](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Overview/groupId/006e73c9-4e67-4e08-903e-527b1547262c) Entra group, which is the source of truth for AVM Terraform module owners.
 
 {{% notice style="info" %}}
-Until your entitlement request is approved, you can contribute by using JIT elevation.
+Until your access request is approved, you can contribute by using JIT elevation.
 {{% /notice %}}
 
 ## 2. Gather repository information

--- a/docs/content/contributing/terraform/repository-setup.md
+++ b/docs/content/contributing/terraform/repository-setup.md
@@ -19,7 +19,7 @@ If you have already completed these steps, skip to step 2.
 
 1. Open the [Open Source Portal](https://repos.opensource.microsoft.com/link) and ensure your GitHub account is linked to your Microsoft account.
 2. Open the [Open Source Portal](https://repos.opensource.microsoft.com/orgs) and ensure you are a member of the `Azure` and `Microsoft` organizations.
-3. Request access via the [AVM Terraform Module Owners access package](https://myaccess.microsoft.com/@microsoft.onmicrosoft.com#/access-packages/b45b0231-c5ab-43fe-94b1-1efd0547bd67). Approval adds you to the [`AVM Terraform Module Owners`](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Overview/groupId/006e73c9-4e67-4e08-903e-527b1547262c) Entra group, which is the source of truth for AVM Terraform module owners.
+3. Request access via the [AVM Terraform Module Owners access package](https://aka.ms/avm/id/access-package/module-contributor). Approval adds you to the [`AVM Terraform Module Owners`](https://aka.ms/avm/id/groups/module-contributors) Entra group, which is the source of truth for AVM Terraform module owners.
 
 {{% notice style="info" %}}
 Until your access request is approved, you can contribute by using JIT elevation.

--- a/docs/content/help-support/issue-triage/terraform-issue-triage.md
+++ b/docs/content/help-support/issue-triage/terraform-issue-triage.md
@@ -68,8 +68,11 @@ If the issue was opened as a misplaced module proposal, mention the `@Azure/AVM-
 
 ### Triaging a Module PR
 
-1. If the **PR is submitted by the module owner** and the **module is owned by a single person**, **the AVM core team or the owner of another Terraform module must review and approve the PR**, (as the module owner can't approve their on PR).
-    - To indicate that the PR needs the core team's attention, apply the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>&nbsp; label.
+PR approvals are **enforced** on all AVM Terraform module repositories. The following rules apply to who must approve:
+
+1. If the **PR is submitted by the module owner** and the **module is owned by a single person**, **another Terraform module owner must review and approve the PR** (the module owner cannot approve their own PR).
+    - **First port of call:** find a friendly module owner from the [`AVM Terraform Module Owners`](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Overview/groupId/006e73c9-4e67-4e08-903e-527b1547262c) Entra group and request a review.
+    - **If no owner is available**, assign the `@Azure/azure-verified-modules-engineering-owners` GitHub team as a reviewer and apply the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>&nbsp; label so the AVM core team picks it up during triage.
 2. If the **PR is submitted by a contributor** (other than the module owner), or the **module is owned by at least 2 people**, **one of the module owners should review and approve the PR**.
 3. Apply relevant labels
     - Categorize the PR using applicable labels, such as:

--- a/docs/content/help-support/issue-triage/terraform-issue-triage.md
+++ b/docs/content/help-support/issue-triage/terraform-issue-triage.md
@@ -71,7 +71,7 @@ If the issue was opened as a misplaced module proposal, mention the `@Azure/AVM-
 PR approvals are **enforced** on all AVM Terraform module repositories. The following rules apply to who must approve:
 
 1. If the **PR is submitted by the module owner** and the **module is owned by a single person**, **another Terraform module owner must review and approve the PR** (the module owner cannot approve their own PR).
-    - **First port of call:** find a friendly module owner from the [`AVM Terraform Module Owners`](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Overview/groupId/006e73c9-4e67-4e08-903e-527b1547262c) Entra group and request a review.
+    - **First port of call:** find a friendly module owner from the [`AVM Terraform Module Owners`](https://aka.ms/avm/id/groups/module-contributors) Entra group and request a review.
     - **If no owner is available**, assign the `@Azure/azure-verified-modules-engineering-owners` GitHub team as a reviewer and apply the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>&nbsp; label so the AVM core team picks it up during triage.
 2. If the **PR is submitted by a contributor** (other than the module owner), or the **module is owned by at least 2 people**, **one of the module owners should review and approve the PR**.
 3. Apply relevant labels


### PR DESCRIPTION
## Summary

Updates the AVM Terraform contributor docs to reflect the new module owner access process and the now-enforced PR approval policy on Terraform module repos.

## Changes

- **`docs/content/contributing/terraform/prerequisites.md`** — Added a `Module Owner Access (Microsoft FTEs only)` section linking to the [AVM Terraform Module Owners access package](https://myaccess.microsoft.com/@microsoft.onmicrosoft.com#/access-packages/b45b0231-c5ab-43fe-94b1-1efd0547bd67) and noting that approval grants membership in the [`AVM Terraform Module Owners`](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Overview/groupId/006e73c9-4e67-4e08-903e-527b1547262c) Entra group.
- **`docs/content/contributing/terraform/repository-setup.md`** — Replaced the legacy `coreidentity.microsoft.com` entitlement step in Step 1.3 with the new access package + Entra group links.
- **`docs/content/contributing/terraform/contribution-flow.md`** — Updated Section 8 (Review and merge PR) to call out that PR approvals are enforced. Added a `Finding an approver` subsection: (1) first port of call is a friendly module owner from the Entra group; (2) fall back to assigning `@Azure/azure-verified-modules-engineering-owners` and adding the `Needs: Core Team` label.
- **`docs/content/help-support/issue-triage/terraform-issue-triage.md`** — Same approver fallback flow added to the Triaging a Module PR section.

## Why

- Module owner access is now requested via an Entra access package, not the old Core Identity entitlement.
- Approvals are enforced on all AVM Terraform module repos, so contributors need clear guidance on who to ask first and how to fall back to the core team.

## Notes

- Did not modify the shared `static/includes/PR-approval-guidance.md` include because it is also embedded in the Bicep contribution flow and shared module-lifecycle page, where the Terraform-specific Entra group/team don't apply.