### PR TITLE
docs(tf): rename legacy AVM core team to azure-verified-modules-engineering-owners in review process and triage notice

### DIFF
--- a/docs/content/contributing/terraform/contribution-flow.md
+++ b/docs/content/contributing/terraform/contribution-flow.md
@@ -299,7 +299,7 @@ PR approvals are **enforced** on all AVM Terraform module repositories. A PR can
 
 ### Finding an approver
 
-1. **First port of call — find a friendly module owner.** Look up another active Terraform module owner from the [`AVM Terraform Module Owners`](https://aka.ms/avm/id/groups/module-contributors) Entra group and request a review from them directly. This is the fastest path to approval.
+1. **First port of call — find a friendly module owner.** Look up another active Terraform module owner from the [`azure-verified-modules-module-contributors`](https://aka.ms/avm/id/groups/module-contributors) Entra group and request a review from them directly. This is the fastest path to approval.
 2. **If no module owner is available**, fall back to the AVM core team:
     - Assign the `@Azure/azure-verified-modules-engineering-owners` GitHub team as a reviewer on the PR.
     - Apply the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>&nbsp; label so the request is picked up during core team triage.

--- a/docs/content/contributing/terraform/prerequisites.md
+++ b/docs/content/contributing/terraform/prerequisites.md
@@ -15,11 +15,11 @@ To contribute, you need a GitHub account. If you are a Microsoft employee, your 
 This step is **only required if you are (or are becoming) a Terraform module owner**. External contributors and one-off contributors do not need this access.
 {{% /notice %}}
 
-Access for Terraform module owners is granted via the **AVM Terraform Module Owners** Entra access package. Request access here:
+Access for Terraform module owners is granted via the **Azure Verified Modules (AVM) Module Contributors** Entra access package. Request access here:
 
-- [AVM Terraform Module Owners — Access Package](https://aka.ms/avm/id/access-package/module-contributor)
+- [Azure Verified Modules (AVM) Module Contributors — Access Package](https://aka.ms/avm/id/access-package/module-contributor)
 
-Once approved, you will be added to the [`AVM Terraform Module Owners`](https://aka.ms/avm/id/groups/module-contributors) Entra group, which is the source of truth for who is authorized to own and approve changes on AVM Terraform module repositories.
+Once approved, you will be added to the [`azure-verified-modules-module-contributors`](https://aka.ms/avm/id/groups/module-contributors) Entra group, which is the source of truth for who is authorized to own and approve changes on AVM Terraform module repositories.
 
 {{% notice style="tip" %}}
 Until your access request is approved, you can continue to contribute by using JIT elevation and by raising PRs that are approved by an existing module owner.

--- a/docs/content/contributing/terraform/repository-setup.md
+++ b/docs/content/contributing/terraform/repository-setup.md
@@ -19,7 +19,7 @@ If you have already completed these steps, skip to step 2.
 
 1. Open the [Open Source Portal](https://repos.opensource.microsoft.com/link) and ensure your GitHub account is linked to your Microsoft account.
 2. Open the [Open Source Portal](https://repos.opensource.microsoft.com/orgs) and ensure you are a member of the `Azure` and `Microsoft` organizations.
-3. Request access via the [AVM Terraform Module Owners access package](https://aka.ms/avm/id/access-package/module-contributor). Approval adds you to the [`AVM Terraform Module Owners`](https://aka.ms/avm/id/groups/module-contributors) Entra group, which is the source of truth for AVM Terraform module owners.
+3. Request access via the [Azure Verified Modules (AVM) Module Contributors access package](https://aka.ms/avm/id/access-package/module-contributor). Approval adds you to the [`azure-verified-modules-module-contributors`](https://aka.ms/avm/id/groups/module-contributors) Entra group.
 
 {{% notice style="info" %}}
 Until your access request is approved, you can contribute by using JIT elevation.
@@ -112,7 +112,7 @@ Click **Complete Setup** and use the following settings:
 | --- | --- |
 | Classify the repository | Production |
 | Assign a Service tree or Opt-out | Azure Verified Modules / AVM |
-| Direct owners | Add yourself and `jaredholgate` or `mawhi`. Add `avm-team-module-owners` as fallback security group. |
+| Direct owners | Add yourself and `jaredholgate`. Add `azure-verified-modules-module-owners` as fallback security group. |
 | Public open source licensed project? | Yes |
 | What type of open source? | Sample code |
 | License | MIT |
@@ -135,7 +135,7 @@ Click **Finish setup + start business review**, then **View repository**, then *
 {{% expand title="➕ If you do NOT see the Complete Setup link" %}}
 
 1. Go to the **Compliance** tab and fill out:
-    - **Direct owners:** Add yourself and `jaredholgate` or `mawhi`. Add `avm-team-module-owners` as fallback.
+    - **Direct owners:** Add yourself and `jaredholgate`. Add `azure-verified-modules-module-owners` as fallback.
     - **Classify the repository:** Production
     - **Service tree:** Azure Verified Modules / AVM
 2. Go back to **Overview** and click **Elevate your access** if available.
@@ -148,11 +148,6 @@ The script will automatically:
 - Create a PR to add module metadata to the `avm-terraform-governance` repository.
 - Create an issue to install the `Azure Verified Modules` GitHub App.
 
-## 4. Update the issue status
-
-1. Add the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#27AB03;color:white;">Status: Repository Created 📄</mark>&nbsp; label.
-2. Remove the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#136A41;color:white;">Status: Ready For Repository Creation 📝</mark>&nbsp; label if present.
-
-## 5. Wait for the GitHub App
+## 4. Wait for the GitHub App
 
 Once installed (usually within 24 hours), the environment sync runs automatically at 15:30 UTC on weekdays to complete the repository setup.

--- a/docs/content/contributing/terraform/review.md
+++ b/docs/content/contributing/terraform/review.md
@@ -12,7 +12,7 @@ The AVM module review is a critical step before an AVM Terraform module gets pub
 
 2. The module owner submits a pull request (PR) titled `AVM-Review-PR` and ensures that all checks are passing on that PR as that is a pre-requisite to request a review.
 
-3. The module owner assigns the `avm-core-team-technical-terraform` GitHub team as reviewer on the PR.
+3. The module owner assigns the `@Azure/azure-verified-modules-engineering-owners` GitHub team as reviewer on the PR.
 
 4. The module owner leaves the following comment as it is on the module proposal in the [AVM - Module Triage](https://github.com/orgs/Azure/projects/529) project by searching for their module proposal by name there.
 

--- a/docs/content/help-support/issue-triage/terraform-issue-triage.md
+++ b/docs/content/help-support/issue-triage/terraform-issue-triage.md
@@ -71,7 +71,7 @@ If the issue was opened as a misplaced module proposal, mention the `@Azure/azur
 PR approvals are **enforced** on all AVM Terraform module repositories. The following rules apply to who must approve:
 
 1. If the **PR is submitted by the module owner** and the **module is owned by a single person**, **another Terraform module owner must review and approve the PR** (the module owner cannot approve their own PR).
-    - **First port of call:** find a friendly module owner from the [`AVM Terraform Module Owners`](https://aka.ms/avm/id/groups/module-contributors) Entra group and request a review.
+    - **First port of call:** find a friendly module owner from the [`azure-verified-modules-module-contributors`](https://aka.ms/avm/id/groups/module-contributors) Entra group and request a review.
     - **If no owner is available**, assign the `@Azure/azure-verified-modules-engineering-owners` GitHub team as a reviewer and apply the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#DB4503;color:white;">Needs: Core Team 🧞</mark>&nbsp; label so the AVM core team picks it up during triage.
 2. If the **PR is submitted by a contributor** (other than the module owner), or the **module is owned by at least 2 people**, **one of the module owners should review and approve the PR**.
 3. Apply relevant labels

--- a/docs/content/help-support/issue-triage/terraform-issue-triage.md
+++ b/docs/content/help-support/issue-triage/terraform-issue-triage.md
@@ -47,7 +47,7 @@ An issue is considered to be an "AVM module issue" if
 {{% notice style="note" %}}
 Module issues can only be opened for existing AVM modules. Module issues **MUST NOT** be used to file a module proposal.
 
-If the issue was opened as a misplaced module proposal, mention the `@Azure/AVM-core-team-technical-terraform` team in the comment section and ask them to move the issue to the AVM repository.
+If the issue was opened as a misplaced module proposal, mention the `@Azure/azure-verified-modules-engineering-owners` team in the comment section and ask them to move the issue to the AVM repository.
 {{% /notice %}}
 
 ### Triaging a Module Issue


### PR DESCRIPTION
Follow-up to #2757.

The AVM Review Process step 3 and the Terraform issue-triage 'misplaced module proposal' notice still referenced the legacy `avm-core-team-technical-terraform` GitHub team. Updated both to the new `@Azure/azure-verified-modules-engineering-owners` team, matching the fallback approver already adopted in the contribution flow and triage docs by #2757.

### Files changed
- `docs/content/contributing/terraform/review.md` (step 3 of the AVM Review Process)
- `docs/content/help-support/issue-triage/terraform-issue-triage.md` (misplaced module proposal notice)

### Out of scope
`docs/content/specs-defs/includes/shared/shared/non-functional/SNFR3.md` and `SNFR9.md` also reference the legacy Terraform team alongside the Bicep team — left untouched here because they're shared specs and a broader rename should be done in a coordinated change.