### PR TITLE
feat(docs): add CAF abbreviation column to Bicep & Terraform resource module indexes

### DIFF
--- a/docs/layouts/partials/caf-abbreviation-map.html
+++ b/docs/layouts/partials/caf-abbreviation-map.html
@@ -7,7 +7,7 @@
     { "ns": <string>, "resource": <string>, "abbr": <string> }
 
     - ns       : lower-cased resource provider namespace (e.g. "microsoft.storage/storageaccounts"),
-                 with any trailing "(kind: ...)" / "(mode: ...)" qualifier removed.
+      with any trailing "(kind: ...)" / "(mode: ...)" qualifier removed.
     - resource : the human-friendly CAF resource name (e.g. "Storage account").
     - abbr     : the CAF recommended abbreviation (e.g. "st").
 

--- a/docs/layouts/partials/caf-abbreviation-map.html
+++ b/docs/layouts/partials/caf-abbreviation-map.html
@@ -1,0 +1,53 @@
+{{/*
+  caf-abbreviation-map.html
+
+  Fetches the Cloud Adoption Framework (CAF) "Abbreviation recommendations for Azure resources"
+  markdown and parses its tables into a slice of dicts, each shaped:
+
+    { "ns": <string>, "resource": <string>, "abbr": <string> }
+
+    - ns       : lower-cased resource provider namespace (e.g. "microsoft.storage/storageaccounts"),
+                 with any trailing "(kind: ...)" / "(mode: ...)" qualifier removed.
+    - resource : the human-friendly CAF resource name (e.g. "Storage account").
+    - abbr     : the CAF recommended abbreviation (e.g. "st").
+
+  Rows whose namespace contains no "/" (table headers / separators) and rows whose abbreviation is a
+  placeholder (e.g. "<*descriptive*>", "<DNS domain name>") are skipped.
+
+  Source of truth (live, so abbreviations stay current with CAF):
+  https://raw.githubusercontent.com/MicrosoftDocs/cloud-adoption-framework/refs/heads/main/docs/ready/azure-best-practices/resource-abbreviations.md
+
+  On any fetch error an empty slice is returned so the site build never breaks. The result is intended
+  to be consumed via partialCached so the remote fetch + parse happens once per build.
+
+  Returns: slice of dicts (see above), in CAF document order.
+*/}}
+{{- $url := "https://raw.githubusercontent.com/MicrosoftDocs/cloud-adoption-framework/refs/heads/main/docs/ready/azure-best-practices/resource-abbreviations.md" -}}
+{{- $rows := slice -}}
+{{- with resources.GetRemote $url -}}
+  {{- with .Err -}}
+    {{- warnf "caf-abbreviation-map.html: unable to fetch CAF resource abbreviations (%q): %s" $url . -}}
+  {{- else -}}
+    {{- $content := .Content -}}
+    {{- range $lineIndex, $line := split $content "\n" -}}
+      {{- $l := trim $line " \r\t" -}}
+      {{- if hasPrefix $l "|" -}}
+        {{- $cells := split (trim $l "|") "|" -}}
+        {{- if ge (len $cells) 3 -}}
+          {{- $resource := trim (index $cells 0) " " -}}
+          {{- $nsRaw := trim (index $cells 1) " " -}}
+          {{- $abbrRaw := trim (index $cells 2) " " -}}
+          {{- $nsClean := trim (replace $nsRaw "`" "") " " -}}
+          {{- $nsBase := trim (replaceRE `\(.*?\)` "" $nsClean) " " -}}
+          {{- $abbr := trim (replace $abbrRaw "`" "") " " -}}
+          {{- if and (in $nsBase "/") (ne $abbr "") (not (in $abbr "<")) (not (in $abbr "*")) -}}
+            {{- $rows = $rows | append (dict "ns" (lower $nsBase) "resource" $resource "abbr" $abbr) -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+  {{- warnf "caf-abbreviation-map.html: no response fetching CAF resource abbreviations (%q)" $url -}}
+{{- end -}}
+{{- return $rows -}}

--- a/docs/layouts/partials/caf-abbreviation.html
+++ b/docs/layouts/partials/caf-abbreviation.html
@@ -6,15 +6,15 @@
   Inputs (dict):
     - rows : slice of { ns, resource, abbr } produced by partials/caf-abbreviation-map.html
     - ns   : lower-cased "<ProviderNamespace>/<ResourceType>" for the module
-             (e.g. "microsoft.storage/storageaccounts")
+      (e.g. "microsoft.storage/storageaccounts")
 
   Output:
     - no CAF match -> "n/a"
     - exactly one  -> <code>abbr</code>
     - more than one -> an unordered list of "<code>abbr</code> (resource name)" entries, in CAF
-                       document order. A single resource provider namespace can map to several CAF
-                       abbreviations (distinguished by kind/mode), so all options are listed and the
-                       reader chooses the one that fits their scenario.
+      document order. A single resource provider namespace can map to several CAF
+      abbreviations (distinguished by kind/mode), so all options are listed and the
+      reader chooses the one that fits their scenario.
 */}}
 {{- $rows := .rows -}}
 {{- $ns := .ns -}}

--- a/docs/layouts/partials/caf-abbreviation.html
+++ b/docs/layouts/partials/caf-abbreviation.html
@@ -1,0 +1,32 @@
+{{/*
+  caf-abbreviation.html
+
+  Renders the "CAF Abbreviation" table cell content for a single resource module.
+
+  Inputs (dict):
+    - rows : slice of { ns, resource, abbr } produced by partials/caf-abbreviation-map.html
+    - ns   : lower-cased "<ProviderNamespace>/<ResourceType>" for the module
+             (e.g. "microsoft.storage/storageaccounts")
+
+  Output:
+    - no CAF match -> "n/a"
+    - exactly one  -> <code>abbr</code>
+    - more than one -> an unordered list of "<code>abbr</code> (resource name)" entries, in CAF
+                       document order. A single resource provider namespace can map to several CAF
+                       abbreviations (distinguished by kind/mode), so all options are listed and the
+                       reader chooses the one that fits their scenario.
+*/}}
+{{- $rows := .rows -}}
+{{- $ns := .ns -}}
+{{- $candidates := where $rows "ns" $ns -}}
+{{- if eq (len $candidates) 0 -}}
+n/a
+{{- else if eq (len $candidates) 1 -}}
+<code>{{ (index $candidates 0).abbr }}</code>
+{{- else -}}
+<ul style="margin: 0; padding-left: 1.1em;">
+{{- range $i, $c := $candidates -}}
+<li><code>{{ $c.abbr }}</code> ({{ $c.resource }})</li>
+{{- end -}}
+</ul>
+{{- end -}}

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -134,6 +134,12 @@
 {{ $maps = sort $maps "ModuleName" }}
 {{ $i = 1 }}
 
+{{/* CAF recommended abbreviations lookup (resource modules only). Built once per build via partialCached. */}}
+{{ $cafRows := slice }}
+{{ if eq $moduleType "resource" }}
+  {{ $cafRows = partialCached "caf-abbreviation-map.html" . "caf-abbreviation-map" }}
+{{ end }}
+
 {{ if eq $language "Bicep" }}
 <table>
   {{ if $useHeaderRow }}
@@ -142,6 +148,7 @@
       <th>No.</th>
       <th>Module Name</th>
       <th>Display Name</th>
+      {{ if eq $moduleType "resource" }}<th>CAF Abbreviation</th>{{ end }}
       <th>Status & Versions</th>
       <th>Owner(s)</th>
     </tr>
@@ -227,6 +234,12 @@
           <b>{{ $item.ModuleDisplayName }} </b>
         {{- end -}}
       </td>
+      {{- if eq $moduleType "resource" -}}
+      <td> {{/* CAF recommended abbreviation(s) */}}
+        {{- $cafNs := lower (printf "%s/%s" $item.ProviderNamespace $item.ResourceType) -}}
+        {{- partial "caf-abbreviation.html" (dict "rows" $cafRows "ns" $cafNs) -}}
+      </td>
+      {{- end -}}
       <td> {{/* availability badge and versions  */}}
         {{- if and (or (eq $item.ModuleStatus "Available") (eq $item.ModuleStatus "Orphaned") (eq $item.ModuleStatus "Deprecated")) (ne $item.PublicRegistryReference "n/a") -}}
           <a href="https://mcr.microsoft.com/v2/bicep/{{ $item.ModuleName }}/tags/list">
@@ -269,6 +282,7 @@
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
     <td>❌ None listed</td>
     <td>❌ None listed</td>
+    {{ if eq $moduleType "resource" }}<td>❌ None listed</td>{{ end }}
     <td>❌ None listed</td>
     <td>❌ None listed</td>
   </tr>
@@ -284,6 +298,7 @@
       <th>Module Name</th>
       <th>Source<br>Code</th>
       <th>Display Name</th>
+      {{ if eq $moduleType "resource" }}<th>CAF Abbreviation</th>{{ end }}
       <th>Status & Versions</th>
       <th>Primary Owner</th>
     </tr>
@@ -367,6 +382,12 @@
           <b>{{ $item.ModuleDisplayName }} </b>
         {{- end -}}
       </td>
+      {{- if eq $moduleType "resource" -}}
+      <td> {{/* CAF recommended abbreviation(s) */}}
+        {{- $cafNs := lower (printf "%s/%s" $item.ProviderNamespace $item.ResourceType) -}}
+        {{- partial "caf-abbreviation.html" (dict "rows" $cafRows "ns" $cafNs) -}}
+      </td>
+      {{- end -}}
       <td> {{/* availability badge and versions  */}}
         {{- if or (eq $item.ModuleStatus "Available") (eq $item.ModuleStatus "Orphaned") (eq $item.ModuleStatus "Deprecated") -}}
           {{/* Replace single hyphens with double hyphens for correct badge rendering for pre-releases - e.g., 0.2.0-pre1 */}}
@@ -412,6 +433,7 @@
     <td>❌ None listed</td>
     <td>❌ None listed</td>
     <td>❌ None listed</td>
+    {{ if eq $moduleType "resource" }}<td>❌ None listed</td>{{ end }}
     <td>❌ None listed</td>
     <td>❌ None listed</td>
   </tr>


### PR DESCRIPTION
## Summary

Adds a new **CAF Abbreviation** column immediately to the right of the **Display Name** column in the Bicep and Terraform **resource** module index tables. The column shows the [Cloud Adoption Framework (CAF) recommended abbreviation(s)](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations) for each module's resource provider namespace.

Example: the Bicep resource module `avm/res/storage/storage-account` maps to `Microsoft.Storage/storageAccounts`, which has the CAF recommended abbreviation `st`.

## What changed

- **New partial `docs/layouts/partials/caf-abbreviation-map.html`** — live-fetches the CAF resource abbreviations markdown at Hugo build time (`resources.GetRemote`) and parses its tables into a slice of `{ ns, resource, abbr }` keyed by resource provider namespace. It strips `(kind: …)`/`(mode: …)` qualifiers, normalises casing, and skips placeholder values. On any fetch error it returns an empty slice so the site build never breaks. Consumed via `partialCached` so the fetch/parse runs once per build.
- **New partial `docs/layouts/partials/caf-abbreviation.html`** — renders the cell content:
  - no match → `n/a`
  - exactly one → a bare `<code>abbr</code>`
  - more than one → an unordered list of `abbr (resource name)` entries (in CAF doc order), letting the reader pick the option that matches their scenario (e.g. `Microsoft.Storage/storageAccounts` → `st` *(Storage account)* and `stvm` *(VM storage account)*).
- **`docs/layouts/shortcodes/moduleNameStatusOwners.html`** — computes each module's namespace from the existing `ProviderNamespace`/`ResourceType` CSV columns and renders the new header/body/"None listed" cells. The new column is gated to `moduleType == "resource"`, so pattern/utility tables are unaffected, and child-module rows do not get a cell.

The CAF source of truth is fetched live, so abbreviations stay current with CAF without manual maintenance.

> [!NOTE]
> The module index **CSV files are intentionally not modified** — the namespace is computed from the columns already present.

## Validation

Validated against the repo's CI-pinned **Hugo `0.136.5` (extended)** using isolated harness sites (offline except the live CAF fetch):

- 203 CAF abbreviation rows parsed from the live document.
- Spot-checks: `Microsoft.Storage/storageAccounts` → `st` + `stvm`; single matches such as `Microsoft.Search/searchServices` → `srch`, `Microsoft.ApiManagement/service` → `apim`, `Microsoft.KeyVault/vaults` → `kv`; `Microsoft.CognitiveServices/accounts` → all 15 options; `Microsoft.DocumentDB/databaseAccounts` → all 5 options; no-match namespaces → `n/a`.
- Full shortcode render confirmed correct column placement and consistent column counts in both the Bicep and Terraform tables, including the "None listed" fallback rows; child-module rows correctly excluded from the new column.

## Notes / follow-ups (not addressed here)

- The Terraform index CSV lists Cosmos DB as `Microsoft.DocumentDB/databaseAccount` (singular), which does not match the plural CAF key and will therefore render `n/a`. Left as-is per the "do not modify the CSVs" constraint — easy follow-up if desired.
- The existing shortcode already relies on the pre-Hugo-v0.141 `resources.GetRemote` `.Err` API, so these partials follow the same pattern to match the pinned CI Hugo version.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>