### PR TITLE
fix: Remove ITA27 policy documentation, align bicep workflow template to current

### DIFF
--- a/docs/content/help-support/issue-triage/issue-triage-automation.md
+++ b/docs/content/help-support/issue-triage/issue-triage-automation.md
@@ -632,32 +632,6 @@ Add a label for the AVM Core Team to query called &nbsp;<mark style="background-
 
 ---
 
-### ITA27
-
-Add a comment to a PR that modifies these files based on the regex pattern, advising to disable GitHub Actions prior to merging:
-
-- ".github/actions/templates/avm-**"
-- ".github/workflows/avm.template.module.yml"
-- "utilities/pipelines/**"
-- "!utilities/pipelines/platform/**"
-
-
-**Trigger criteria:**
-
-- A comment is added to an PR that modifies these files (above)
-
-**Action(s):**
-
-- A comment is added to an PR that modifies these files as per below
-
-  ```txt
-  [!WARNING]
-  **FAO: AVM Core Team**
-  When merging this PR it will trigger **all** AVM modules to be triggered! Please consider disabling the GitHub actions prior to merging and then re-enable once merged.
-  ```
-
----
-
 ## Where to apply these rules?
 
 The below table details which repositories the above rules are applied to.
@@ -705,4 +679,3 @@ The ITA05 rule is currently disabled in the AVM and BRM repositories.
 | [ITA23](#ita23)             |          ✔️         |                |        ✔️       |
 | [ITA25](#ita25)             |                    |        ✔️        |               |
 | [ITA26](#ita26)             |              ✔️      |                 |              |
-| [ITA27](#ita27)             |                    |         ✔️        |              |

--- a/docs/static/includes/avm.workflow.template.yml
+++ b/docs/static/includes/avm.workflow.template.yml
@@ -27,14 +27,10 @@ on:
     branches:
       - main
     paths:
-      - ".github/actions/templates/avm-**"
-      - ".github/workflows/avm.template.module.yml"
         # >>> UPDATE to for example ".github/workflows/avm.res.key-vault.vault.yml" and remove this comment
       - ".github/workflows/avm.[res|ptn|utl].[provider-namespace].[resource-type].yml"
         # >>> UPDATE to for example "avm/res/key-vault/vault/**" and remove this comment
       - "avm/[res|ptn|utl]/[provider-namespace]/[resource-type]/**"
-      - "utilities/pipelines/**"
-      - "!utilities/pipelines/platform/**"
       - "!*/**/README.md"
 
 env:


### PR DESCRIPTION

# Overview/Summary

Remove CI triggers from workflow template to align with current in BRM
Remove ITA27 policy documentation, made useless by the recent update

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
