### PR TITLE
fix: adjust timeout value and improve HTML structure in moduleNameStatusOwners shortcode

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -2,6 +2,7 @@ baseURL = 'https://azure.github.io/Azure-Verified-Modules/'
 languageCode = 'en-us'
 title = 'AVM'
 theme = 'hugo-theme-relearn'
+timeout = 240000
 
 images = ['images/avm_logo.png']
 

--- a/docs/layouts/shortcodes/moduleNameStatusOwners.html
+++ b/docs/layouts/shortcodes/moduleNameStatusOwners.html
@@ -148,7 +148,9 @@
       <th>No.</th>
       <th>Module Name</th>
       <th>Display Name</th>
-      {{ if eq $moduleType "resource" }}<th>CAF Abbreviation</th>{{ end }}
+      {{- if eq $moduleType "resource" }}
+      <th>CAF Abbreviation</th>
+      {{- end }}
       <th>Status & Versions</th>
       <th>Owner(s)</th>
     </tr>
@@ -282,7 +284,9 @@
     <td>{{ printf "%02d" $i }}{{ $i = add $i 1 }}</td>
     <td>❌ None listed</td>
     <td>❌ None listed</td>
-    {{ if eq $moduleType "resource" }}<td>❌ None listed</td>{{ end }}
+    {{- if eq $moduleType "resource" }}
+    <td>❌ None listed</td>
+    {{- end }}
     <td>❌ None listed</td>
     <td>❌ None listed</td>
   </tr>
@@ -298,7 +302,9 @@
       <th>Module Name</th>
       <th>Source<br>Code</th>
       <th>Display Name</th>
-      {{ if eq $moduleType "resource" }}<th>CAF Abbreviation</th>{{ end }}
+      {{- if eq $moduleType "resource" }}
+      <th>CAF Abbreviation</th>
+      {{- end }}
       <th>Status & Versions</th>
       <th>Primary Owner</th>
     </tr>
@@ -433,7 +439,9 @@
     <td>❌ None listed</td>
     <td>❌ None listed</td>
     <td>❌ None listed</td>
-    {{ if eq $moduleType "resource" }}<td>❌ None listed</td>{{ end }}
+    {{- if eq $moduleType "resource" }}
+    <td>❌ None listed</td>
+    {{- end }}
     <td>❌ None listed</td>
     <td>❌ None listed</td>
   </tr>


### PR DESCRIPTION
This pull request makes minor improvements to the documentation site configuration and refines the formatting of conditional table columns in the `moduleNameStatusOwners.html` shortcode template.

Configuration update:

* Increased the `timeout` setting in `hugo.toml` to 240000 to allow for longer build times.

Template formatting improvements:

* Updated all instances where the "CAF Abbreviation" column is conditionally rendered in `moduleNameStatusOwners.html` to use Hugo's whitespace control syntax (`{{- ... -}}`). This ensures cleaner HTML output by removing unwanted whitespace around the conditional blocks. [[1]](diffhunk://#diff-5c3b49e6ecc5714badd3bc3c6e949da68d03c3846118a62fa5f3a71767e19200L151-R153) [[2]](diffhunk://#diff-5c3b49e6ecc5714badd3bc3c6e949da68d03c3846118a62fa5f3a71767e19200L285-R289) [[3]](diffhunk://#diff-5c3b49e6ecc5714badd3bc3c6e949da68d03c3846118a62fa5f3a71767e19200L301-R307) [[4]](diffhunk://#diff-5c3b49e6ecc5714badd3bc3c6e949da68d03c3846118a62fa5f3a71767e19200L436-R444)