### PR TITLE
docs(SNFR20): update Terraform access to Entra access package

### DIFF
--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
@@ -130,7 +130,15 @@ Example - `CODEOWNERS` entry for the Bicep resource module of Azure Virtual Netw
 ### Terraform
 
 {{% notice style="note" %}}
-Access management for Terraform repositories now uses a single team, membership of which is managed using an internal entitlement management tool (Core Identity).
+Access management for Terraform repositories is governed centrally through Microsoft Entra. Module owner access is granted via an Entra **access package** — it is no longer managed through a per-module GitHub team or the legacy Core Identity entitlement.
 {{% /notice %}}
 
-All module owners **MUST** request access to the [`avm-module-owners-terraform`](https://github.com/orgs/Azure/teams/avm-module-owners-terraform) GitHub team via the `Azure Verified Module Owners Terraform` entitlement in Core Identity (Microsoft internal tool).
+All module owners **MUST** request access via the **Azure Verified Modules (AVM) Module Contributors** Entra access package:
+
+- [Azure Verified Modules (AVM) Module Contributors — Access Package](https://aka.ms/avm/id/access-package/module-contributor)
+
+Once approved, you are added to the [`azure-verified-modules-module-contributors`](https://aka.ms/avm/id/groups/module-contributors) Entra group, which is the source of truth for who is authorized to own and approve changes on AVM Terraform module repositories. Day-to-day repository access is then granted through this group together with just-in-time (JIT) elevation.
+
+{{% notice style="tip" %}}
+For the full onboarding process, see the Terraform [Prerequisites]({{% siteparam base %}}/contributing/terraform/prerequisites/) and [Repository Setup]({{% siteparam base %}}/contributing/terraform/repository-setup/) pages.
+{{% /notice %}}


### PR DESCRIPTION
## Summary

The **Terraform** section of [SNFR20](https://azure.github.io/Azure-Verified-Modules/spec/SNFR20/#terraform) was out of date. It described the old access model — a single `avm-module-owners-terraform` GitHub team managed via the legacy **Core Identity** entitlement (`Azure Verified Module Owners Terraform`).

Terraform module owner access is now governed centrally through Microsoft Entra via an **access package**, as already documented in the Terraform contribution guides. This PR aligns SNFR20 with that model.

## Changes

- Replaced the Core Identity / single-GitHub-team wording with the current **Azure Verified Modules (AVM) Module Contributors** Entra access package (`https://aka.ms/avm/id/access-package/module-contributor`).
- Clarified that approval adds you to the `azure-verified-modules-module-contributors` Entra group (source of truth), with day-to-day repository access granted via that group + just-in-time (JIT) elevation.
- Added links to the Terraform **Prerequisites** and **Repository Setup** pages for the full onboarding process.
- Explicitly noted the legacy Core Identity entitlement / per-module team is no longer used.

## Scan for other out-of-date instructions

As requested, I scanned the whole repo (all file types) for related stale references:

- `Core Identity`, `entitlement`, `avm-module-owners-terraform`, `Azure Verified Module Owners Terraform` → only present in `SNFR20.md` (now fixed).
- `prerequisites.md` and `repository-setup.md` already use the access-package model — consistent, no changes needed.
- Other Terraform team references (`avm-core-team-technical-terraform`, `terraform-avm` in SNFR3/SNFR9/team-definitions) are core-team/PG **reviewer** teams and remain valid — left untouched.

## File changed

- `docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md`