### PR TITLE
chore: Disable issue/PR chasing scheduled-search automations

### DIFF
--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -17,13 +17,6 @@ configuration:
         then:
           - addLabel:
               label: "Needs: Triage :mag:"
-          - addReply:
-              reply: |
-                > [!IMPORTANT]
-                > **The "Needs: Triage :mag:" label must be removed once the triage process is complete!**
-
-                > [!TIP]
-                > For additional guidance on how to triage this issue/PR, see the [AVM Issue Triage](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/avm-issue-triage/) documentation.
 
       - description: 'ITA09 - When #RR is used in an issue, add the "Needs: Author Feedback :ear:" label'
         if:

--- a/.github/policies/scheduledSearches.yml
+++ b/.github/policies/scheduledSearches.yml
@@ -7,31 +7,31 @@ disabled: false
 configuration:
   resourceManagementConfiguration:
     scheduledSearches:
-      - description: "ITA04 - Label issues and PRs that have been marked as requiring author feedback but have not had any activity for 4 days."
-        frequencies:
-          - hourly:
-              hour: 3
-        filters:
-          - isOpen
-          - hasLabel:
-              label: "Needs: Author Feedback :ear:"
-          - noActivitySince:
-              days: 4
-          - isNotLabeledWith:
-              label: "Status: No Recent Activity :zzz:"
-        actions:
-          - addLabel:
-              label: "Status: No Recent Activity :zzz:"
-          - addReply:
-              reply: |
-                > [!IMPORTANT]
-                > ${issueAuthor}, this issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**.
+      # - description: "ITA04 - Label issues and PRs that have been marked as requiring author feedback but have not had any activity for 4 days."
+      #   frequencies:
+      #     - hourly:
+      #         hour: 3
+      #   filters:
+      #     - isOpen
+      #     - hasLabel:
+      #         label: "Needs: Author Feedback :ear:"
+      #     - noActivitySince:
+      #         days: 4
+      #     - isNotLabeledWith:
+      #         label: "Status: No Recent Activity :zzz:"
+      #   actions:
+      #     - addLabel:
+      #         label: "Status: No Recent Activity :zzz:"
+      #     - addReply:
+      #         reply: |
+      #           > [!IMPORTANT]
+      #           > ${issueAuthor}, this issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**.
 
-                > [!TIP]
-                > To prevent further actions to take effect, one of the following conditions must be met:
-                >   - The author must respond in a comment within 3 days of this comment.
-                >   - The "Status: No Recent Activity :zzz:" label must be removed.
-                >   - If applicable, the "Status: Long Term :hourglass_flowing_sand:" or the "Needs: Module Owner :mega:" label must be added.
+      #           > [!TIP]
+      #           > To prevent further actions to take effect, one of the following conditions must be met:
+      #           >   - The author must respond in a comment within 3 days of this comment.
+      #           >   - The "Status: No Recent Activity :zzz:" label must be removed.
+      #           >   - If applicable, the "Status: Long Term :hourglass_flowing_sand:" or the "Needs: Module Owner :mega:" label must be added.
 
       # - description: 'ITA05A - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
       #   frequencies:
@@ -83,30 +83,30 @@ configuration:
       #           > In case this issue needs to be reopened (e.g., the author responds after the issue was closed), the "Status: No Recent Activity :zzz:" label must be removed.
       #     - closeIssue
 
-      - description: 'ITA24 - Remind module owner(s) to start or continue working on this module if there was no activity on the Module Proposal issue for more than 3 weeks. "Add Needs: Attention :wave:" label.'
-        frequencies:
-          - hourly:
-              hour: 3
-        filters:
-          - isIssue
-          - isOpen
-          - hasLabel:
-              label: "Type: New Module Proposal :bulb:"
-          - hasLabel:
-              label: "Status: Owners Identified :metal:"
-          - noActivitySince:
-              days: 21
-          - isNotLabeledWith:
-              label: "Status: Long Term :hourglass_flowing_sand:"
-          - isNotLabeledWith:
-              label: "Needs: Attention :wave:"
-        actions:
-          - addReply:
-              reply: |
-                > [!IMPORTANT]
-                > ${assignees}, this issue has not had any activity in the last **3 weeks**. Please feel free to reach out to the AVM core team should you have any questions or need any help with the development of this module.
+      # - description: 'ITA24 - Remind module owner(s) to start or continue working on this module if there was no activity on the Module Proposal issue for more than 3 weeks. "Add Needs: Attention :wave:" label.'
+      #   frequencies:
+      #     - hourly:
+      #         hour: 3
+      #   filters:
+      #     - isIssue
+      #     - isOpen
+      #     - hasLabel:
+      #         label: "Type: New Module Proposal :bulb:"
+      #     - hasLabel:
+      #         label: "Status: Owners Identified :metal:"
+      #     - noActivitySince:
+      #         days: 21
+      #     - isNotLabeledWith:
+      #         label: "Status: Long Term :hourglass_flowing_sand:"
+      #     - isNotLabeledWith:
+      #         label: "Needs: Attention :wave:"
+      #   actions:
+      #     - addReply:
+      #         reply: |
+      #           > [!IMPORTANT]
+      #           > ${assignees}, this issue has not had any activity in the last **3 weeks**. Please feel free to reach out to the AVM core team should you have any questions or need any help with the development of this module.
 
-                > [!TIP]
-                > To silence this notification, provide an update every 3 weeks on the Module Proposal issue, or add the "Status: Long Term :hourglass_flowing_sand:" label.
-          - addLabel:
-              label: "Needs: Attention :wave:"
+      #           > [!TIP]
+      #           > To silence this notification, provide an update every 3 weeks on the Module Proposal issue, or add the "Status: Long Term :hourglass_flowing_sand:" label.
+      #     - addLabel:
+      #         label: "Needs: Attention :wave:"

--- a/docs/content/help-support/issue-triage/avm-issue-triage.md
+++ b/docs/content/help-support/issue-triage/avm-issue-triage.md
@@ -109,7 +109,7 @@ You **MUST** still confirm that the requestor is a Microsoft FTE and that they u
     - Make sure the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FBEF2A;">Status: Owners Identified 🤘</mark>&nbsp; label is added to the issue.
       - If applied earlier, remove the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FF0019;color:white;">Needs: Module Owner 📣</mark>&nbsp; label from the issue.
     - Remove the labels of &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FBCA04;">Needs: Triage 🔍</mark>&nbsp; and &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#E4E669;">Status: In Triage 🔍</mark>&nbsp; to indicate you're done with triaging the issue.
-4. Update the AVM Module Indexes, following the [process documented internally](https://dev.azure.com/CSUSolEng/Azure%20Verified%20Modules/_wiki/wikis/AVM%20Internal%20Wiki/684/Module-index-update-process).
+4. Update the AVM Module Indexes, following the [process documented internally](https://eng.ms/docs/azure-verified-modules-avm/how-to/avm/avm-governance/module-index-update-process.html).
 5. Use the following text to approve module development
 
 {{% expand title="➕ Final Confirmation for Proposed Module Owners - Bicep" %}}

--- a/docs/content/help-support/issue-triage/avm-organizer-bot.md
+++ b/docs/content/help-support/issue-triage/avm-organizer-bot.md
@@ -1,12 +1,12 @@
 ---
-title: AVM Organizer Bot
-linktitle: AVM Organizer Bot
-description: AVM Organizer Bot for the Azure Verified Modules (AVM) program's repositories
+title: Azure Verified Modules GitHub App
+linktitle: Azure Verified Modules GitHub App
+description: Azure Verified Modules GitHub App for the Azure Verified Modules (AVM) program's repositories
 ---
 
 ## Overview
 
-The **AVM Organizer Bot** is represented as a [GitHub App](https://github.com/apps/avm-team-linter) currently named **AVM Team Linter** (which will be renamed to **AVM Organizer** in the future). This bot automates various repository management tasks across the Azure Verified Modules program's repositories, including issue triage, pull request labeling, team validation, and documentation updates.
+The **Azure Verified Modules GitHub App** is represented as a [GitHub App](https://github.com/apps/azure-verified-modules). This app automates various repository management tasks across the Azure Verified Modules program's repositories, including issue triage, pull request labeling, team validation, and documentation updates.
 
 The bot operates by authenticating with GitHub using the GitHub App credentials (`TEAM_LINTER_APP_ID` and `TEAM_LINTER_PRIVATE_KEY`) and executing PowerShell scripts through scheduled workflows and/or event-triggered actions.
 
@@ -14,7 +14,7 @@ The bot operates by authenticating with GitHub using the GitHub App credentials 
 
 ## AVM Repository Scripts
 
-The following scripts are leveraged by the **[AVM Organizer Bot](https://github.com/apps/avm-team-linter)** in the [AVM](https://aka.ms/AVM/repo) repository:
+The following scripts are leveraged by the **[Azure Verified Modules GitHub App](https://github.com/apps/azure-verified-modules)** in the [AVM](https://aka.ms/AVM/repo) repository:
 
 ### 1. Invoke-AvmGitHubTeamLinter.ps1
 
@@ -56,7 +56,7 @@ The following scripts are leveraged by the **[AVM Organizer Bot](https://github.
 
 ## BRM Repository Scripts
 
-The following scripts are leveraged by the **[AVM Organizer Bot](https://github.com/apps/avm-team-linter)** in the bicep-registry-modules ([BRM](https://aka.ms/BRM)) repository:
+The following scripts are leveraged by the **[Azure Verified Modules GitHub App](https://github.com/apps/azure-verified-modules)** in the bicep-registry-modules ([BRM](https://aka.ms/BRM)) repository:
 
 ### 1. Set-AvmGitHubIssueOwnerConfig.ps1
 

--- a/docs/content/help-support/issue-triage/issue-triage-automation.md
+++ b/docs/content/help-support/issue-triage/issue-triage-automation.md
@@ -16,6 +16,12 @@ When calculating the number of business days in the issue/triage automation, the
 
 ### ITA01BCP.1 & ITA01BCP.2
 
+{{% notice style="warning" %}}
+
+This rule is currently disabled in the BRM repository.
+
+{{% /notice %}}
+
 If a bug/feature/request/general question that has the labels of &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>&nbsp; and &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FBCA04;">Needs: Triage 🔍</mark>&nbsp; is not responded to after 3 business days, then the issue will be marked with the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>&nbsp; label and the AVM Core team will be mentioned in a comment on the issue to reach out to the module owner.
 
 **Schedule:**
@@ -44,6 +50,12 @@ If a bug/feature/request/general question that has the labels of &nbsp;<mark sty
 
 ### ITA01TF.1 & ITA01TF.2
 
+{{% notice style="warning" %}}
+
+This rule is currently disabled in the Terraform repositories.
+
+{{% /notice %}}
+
 If a bug/feature/request/general question that has the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FBCA04;">Needs: Triage 🔍</mark>&nbsp; label added is not responded to after 3 business days, then the issue will be marked with the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>&nbsp; label and the AVM Core team will be mentioned in a comment on the issue to reach out to the module owner.
 
 **Schedule:**
@@ -70,6 +82,12 @@ If a bug/feature/request/general question that has the &nbsp;<mark style="backgr
 ---
 
 ### ITA02BCP.1 & ITA02BCP.2
+
+{{% notice style="warning" %}}
+
+This rule is currently disabled in the BRM repository.
+
+{{% /notice %}}
 
 If after an additional 3 business days there's still no update to the issue that has the labels of &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>&nbsp; and &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>&nbsp;, the AVM core team will be mentioned on the issue and a further comment stating module owner is unresponsive will be added. The &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>&nbsp; label will also be added.
 
@@ -99,6 +117,12 @@ If after an additional 3 business days there's still no update to the issue that
 
 ### ITA02TF.1 & ITA02TF.2
 
+{{% notice style="warning" %}}
+
+This rule is currently disabled in the Terraform repositories.
+
+{{% /notice %}}
+
 If after an additional 3 business days there's still no update to the issue that has the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>&nbsp; label added, the AVM core team will be mentioned on the issue and a further comment stating module owner is unresponsive will be added. The &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>&nbsp; label will also be added.
 
 **Schedule:**
@@ -126,6 +150,12 @@ If after an additional 3 business days there's still no update to the issue that
 
 ### ITA03BCP
 
+{{% notice style="warning" %}}
+
+This rule is currently disabled in the BRM repository.
+
+{{% /notice %}}
+
 If there's still no response after 5 days (total from start of issue being raised) on an issue that has the labels of &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#F0FFFF;">Type: AVM 🅰️ ✌️ ⓜ️</mark>&nbsp;, &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FBCA04;">Needs: Triage 🔍</mark>&nbsp;, &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FFFF00;">Type: Security Bug 🔒</mark>&nbsp; and &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>&nbsp;, the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>&nbsp; label will be added.
 
 **Schedule:**
@@ -152,6 +182,12 @@ If there's still no response after 5 days (total from start of issue being raise
 
 ### ITA03TF
 
+{{% notice style="warning" %}}
+
+This rule is currently disabled in the Terraform repositories.
+
+{{% /notice %}}
+
 If there's still no response after 5 days (total from start of issue being raised) on an issue that has the labels of &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FBCA04;">Needs: Triage 🔍</mark>&nbsp;, &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FFFF00;">Type: Security Bug 🔒</mark>&nbsp; and &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>&nbsp;, the Terraform PG GitHub Team will be mentioned on the issue to assist. The &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>&nbsp; label will also be added.
 
 **Schedule:**
@@ -172,6 +208,12 @@ If there's still no response after 5 days (total from start of issue being raise
 ---
 
 ### ITA04
+
+{{% notice style="warning" %}}
+
+This rule is currently disabled in all AVM repositories.
+
+{{% /notice %}}
 
 If an issue/PR has been labeled with &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#CB6BA2;color:white;">Needs: Author Feedback 👂</mark>&nbsp; and hasn't had a response in 4 days, label with &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#808080;color:white;">Status: No Recent Activity 💤</mark>&nbsp; and add a comment.
 
@@ -235,6 +277,12 @@ If an issue/PR has been labeled with &nbsp;<mark style="background-image:none;wh
 ---
 
 ### ITA24
+
+{{% notice style="warning" %}}
+
+This rule is currently disabled in the AVM Core repository.
+
+{{% /notice %}}
 
 Remind module owner(s) to start or continue working on this module if there was no activity on the Module Proposal issue for more than 3 weeks. Add &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#E99695;color:white;">Needs: Attention 👋</mark>&nbsp; label.
 
@@ -640,19 +688,19 @@ The below table details which repositories the above rules are applied to.
 
 | ID                          | AVM Core repository | BRM repository | TF repositories |
 |-----------------------------|:-------------------:|:--------------:|:---------------:|
-| [ITA01BCP1-2](#ita01bcp1--ita01bcp2) |                     |       ✔️       |                 |
-| [ITA01TF1-2](#ita01tf1--ita01tf2)   |                     |                |       ✔️        |
-| [ITA02BCP1-2](#ita02bcp1--ita02bcp2) |                     |       ✔️       |                 |
-| [ITA02TF1-2](#ita02tf1--ita02tf2)   |                     |                |       ✔️        |
-| [ITA03BCP](#ita03bcp)       |                     |       ✔️       |                 |
-| [ITA03TF](#ita03tf)         |                     |                |       ✔️        |
-| [ITA04](#ita04)             |         ✔️          |       ✔️       |       ✔️        |
+| [ITA01BCP1-2](#ita01bcp1--ita01bcp2) |                     |       [✔️]       |                 |
+| [ITA01TF1-2](#ita01tf1--ita01tf2)   |                     |                |       [✔️]        |
+| [ITA02BCP1-2](#ita02bcp1--ita02bcp2) |                     |       [✔️]       |                 |
+| [ITA02TF1-2](#ita02tf1--ita02tf2)   |                     |                |       [✔️]        |
+| [ITA03BCP](#ita03bcp)       |                     |       [✔️]       |                 |
+| [ITA03TF](#ita03tf)         |                     |                |       [✔️]        |
+| [ITA04](#ita04)             |         [✔️]          |       [✔️]       |       [✔️]        |
 | [ITA05](#ita05)             |         [✔️]          |       [✔️]       |       ✔️        |
-| [ITA24](#ita24)             |          ✔️         |                |                 |
+| [ITA24](#ita24)             |          [✔️]         |                |                 |
 
 {{% notice style="warning" %}}
 
-The ITA05 rule is currently disabled in the AVM and BRM repositories.
+A check mark in brackets (e.g., [✔️]) indicates that the rule exists in that repository but is currently **disabled**. The following schedule-based rules are currently disabled: ITA01BCP, ITA01TF, ITA02BCP, ITA02TF, ITA03BCP, ITA03TF, and ITA04 (in all the repositories they apply to), ITA05 (in the AVM Core and BRM repositories), and ITA24 (in the AVM Core repository).
 
 {{% /notice %}}
 

--- a/docs/content/help-support/issue-triage/issue-triage-automation.md
+++ b/docs/content/help-support/issue-triage/issue-triage-automation.md
@@ -247,7 +247,7 @@ To prevent further actions to take effect, one of the following conditions must 
 
 {{% notice style="warning" %}}
 
-This rule is currently disabled in the AVM and BRM repositories.
+This rule is currently disabled in the AVM Core and BRM repositories, and is not present in the Terraform repositories.
 
 {{% /notice %}}
 
@@ -695,7 +695,7 @@ The below table details which repositories the above rules are applied to.
 | [ITA03BCP](#ita03bcp)       |                     |       [✔️]       |                 |
 | [ITA03TF](#ita03tf)         |                     |                |       [✔️]        |
 | [ITA04](#ita04)             |         [✔️]          |       [✔️]       |       [✔️]        |
-| [ITA05](#ita05)             |         [✔️]          |       [✔️]       |       ✔️        |
+| [ITA05](#ita05)             |         [✔️]          |       [✔️]       |                 |
 | [ITA24](#ita24)             |          [✔️]         |                |                 |
 
 {{% notice style="warning" %}}

--- a/docs/content/help-support/issue-triage/issue-triage-automation.md
+++ b/docs/content/help-support/issue-triage/issue-triage-automation.md
@@ -6,6 +6,12 @@ description: Issue Triage Automation for the Azure Verified Modules (AVM) progra
 
 This page details the automation that is in place to help with the triage of issues and PRs raised against the AVM modules.
 
+{{% notice style="note" %}}
+
+**Some of these automation rules are currently disabled or reduced.** A number of the comment-based automations — the recurring "chase" scheduled searches, and the per-issue/PR triage comment previously posted by [ITA06](#ita06) — have been disabled, or had their commenting removed, to avoid notification fatigue for everyone involved. In their current form they are too noisy, are largely filtered out and ignored by most, and are not having the desired impact. The AVM team plans to **refine and re-enable** these automations in the near future.
+
+{{% /notice %}}
+
 ## Schedule based automation
 
 This section details all automation rules that are based on a schedule.
@@ -318,6 +324,12 @@ This chapter details all automation rules that are based on an event.
 
 When a new issue or PR of any type is created add the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FBCA04;">Needs: Triage 🔍</mark>&nbsp; label.
 
+{{% notice style="warning" %}}
+
+The comment (reply) previously posted by this rule has been **removed** to reduce notification fatigue; the rule now only applies the label. See the note at the top of this page — the AVM team plans to refine and re-enable these automations in the near future.
+
+{{% /notice %}}
+
 **Trigger criteria:**
 
 - An issue or PR is opened.
@@ -325,7 +337,6 @@ When a new issue or PR of any type is created add the &nbsp;<mark style="backgro
 **Action(s):**
 
 - Add the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FBCA04;">Needs: Triage 🔍</mark>&nbsp; label.
-- Add a reply to explain the action(s).
 
 ---
 


### PR DESCRIPTION
## Summary

As agreed by the AVM team, this disables / reduces the GitHub Policy Service automations that **comment on or chase** module owners / issue authors, to cut notification fatigue. Label-only and other non-harassing automations remain enabled.

This PR also includes a couple of small, pre-existing documentation updates that were already on this branch (see below).

## Changes

### Automation changes

- `.github/policies/scheduledSearches.yml` — commented out the chasing scheduled searches:
  - **ITA04** — stale `Needs: Author Feedback` reminder comment
  - **ITA24** — 3-week module proposal reminder comment
- `.github/policies/eventResponder.yml` — **ITA06** now only applies the `Needs: Triage` label; the comment (reply) it used to post on **every** new issue/PR has been **removed**.
- `docs/content/help-support/issue-triage/issue-triage-automation.md` — added "currently disabled" notices to each disabled rule (ITA01BCP, ITA02BCP, ITA03BCP, ITA01TF, ITA02TF, ITA03TF, ITA04, ITA24), documented the ITA06 comment removal, added a top-level note explaining these automations are temporarily disabled/reduced to avoid notification fatigue and will be **refined and re-enabled** in the near future, bracketed the disabled cells in the schedule-based applicability table, and corrected the **ITA05** applicability (disabled in AVM Core and BRM; **not present** in the Terraform repositories).

The remaining `eventResponder.yml` rules (label add/remove and friendly one-shot acknowledgements) stay in place.

### Other documentation updates already on this branch

- `docs/content/help-support/issue-triage/avm-issue-triage.md` — updated the internal "Module Index update process" link from the old `dev.azure.com` wiki URL to the current `eng.ms` docs URL.
- `docs/content/help-support/issue-triage/avm-organizer-bot.md` — renamed **"AVM Organizer Bot" / "AVM Team Linter"** to **"Azure Verified Modules GitHub App"** and updated the GitHub App link from `apps/avm-team-linter` to `apps/azure-verified-modules`.

## Companion PRs

These apply the same automation changes in the other AVM repositories:

- BRM: Azure/bicep-registry-modules#7204
- TF governance: Azure/avm-terraform-governance#519


## Related issue

Related to https://msft.ghe.com/azure-cloud-native/Azure-Verified-Modules/issues/164

