### PR TITLE
Rename application_security_group_resource_ids to application_securit…

### DIFF
--- a/docs/static/includes/interfaces/tf/int.pe.schema.tf
+++ b/docs/static/includes/interfaces/tf/int.pe.schema.tf
@@ -66,7 +66,7 @@ A map of private endpoints to create on the Key Vault. The map key is deliberate
 - `subresource_name` (Optional) - The name of the sub resource for the private endpoint.
 - `private_dns_zone_group_name` - (Optional) The name of the private DNS zone group. One will be generated if not set.
 - `private_dns_zone_resource_ids` - (Optional) A set of resource IDs of private DNS zones to associate with the private endpoint. If not set, no zone groups will be created and the private endpoint will not be associated with any private DNS zones. DNS records must be managed external to this module.
-- `application_security_group_resource_ids` - (Optional) A map of resource IDs of application security groups to associate with the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+- `application_security_group_associations` - (Optional) A map of resource IDs of application security groups to associate with the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
 - `private_service_connection_name` - (Optional) The name of the private service connection. One will be generated if not set.
 - `network_interface_name` - (Optional) The name of the network interface. One will be generated if not set.
 - `location` - (Optional) The Azure location where the resources will be deployed. Defaults to the location of the resource group.


### PR DESCRIPTION
This pull request makes a minor update to the documentation for the Key Vault private endpoints schema. The main change is a renaming of a parameter for clarity and consistency.

- Documentation update:
  * Renamed the parameter from `application_security_group_resource_ids` to `application_security_group_associations` in the interface documentation to improve clarity.