### PR TITLE
docs: update retired AVM team references to new team names

### DIFF
--- a/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md
@@ -70,12 +70,12 @@ If the Bicep Child Module Proposal issue was just created, please allow a few da
 1. Check the online [Bicep resource module index source CSV](https://github.com/Azure/Azure-Verified-Modules/blob/main/docs/static/module-indexes/BicepResourceModules.csv).
 1. Search for the child module name in the `ModuleName` field.
 1. Verify if the corresponding value exists in the `TelemetryIdPrefix` field. Note down the value as you will need it in the implementation phase.
-1. If not found, please reach out to the core team, mentioning the `@Azure/avm-core-team-technical-bicep` via the Bicep Child Module Proposal issue.
+1. If not found, please reach out to the core team, mentioning the `@Azure/azure-verified-modules-tooling-contributors` via the Bicep Child Module Proposal issue.
 
 ### Module registered in the MAR-file
 
 Ensure that the child module is registered in the [MAR file](https://github.com/microsoft/mcr/blob/main/teams/bicep/bicep.yml).
-If not, please reach out to the core team, mentioning the `@Azure/avm-core-team-technical-bicep` via the Bicep Child Module Proposal issue.
+If not, please reach out to the core team, mentioning the `@Azure/azure-verified-modules-tooling-contributors` via the Bicep Child Module Proposal issue.
 
 {{% notice style="note" %}}
 

--- a/docs/content/contributing/bicep/bicep-contribution-flow/custom-ci-secrets.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/custom-ci-secrets.md
@@ -20,7 +20,7 @@ Since all modules must pass the tests in the AVM environment, it is important th
 To make this matter not too complicated, we would like to ask you to emphasize this requirement in the description of your PR, for example by adding a text similar to:
 
 ```txt
-- [ ] @avm-core-team-technical-bicep TODO: Add custom secret 'mySecret' to AVM CI
+- [ ] @azure-verified-modules-tooling-contributors TODO: Add custom secret 'mySecret' to AVM CI
 ```
 
 {{% /notice %}}

--- a/docs/content/contributing/bicep/bicep-contribution-flow/owner-contribution-flow.md
+++ b/docs/content/contributing/bicep/bicep-contribution-flow/owner-contribution-flow.md
@@ -56,7 +56,7 @@ If you're the **sole owner of the module**, the **AVM core team must review and 
 
 Under certain circumstances, you may find yourself unable to continue as the module owner. In such cases, it is advisable to designate a new module owner. The following steps outline this transition:
 
-- Leave a comment on the original module proposal, indicating that you'd like to hand the ownership over to somebody else. Mention the person who originally helped triage the issue or the `@Azure/avm-core-team-technical-bicep` team. You must wait for someone from the AVM Core Team to respond first, as the module index must be updated before you can continue handing over the ownership.
+- Leave a comment on the original module proposal, indicating that you'd like to hand the ownership over to somebody else. Mention the person who originally helped triage the issue or the `@Azure/azure-verified-modules-tooling-contributors` team. You must wait for someone from the AVM Core Team to respond first, as the module index must be updated before you can continue handing over the ownership.
 - Add the new owner's GitHub account as a "maintainer" on your modules GitHub team.
 - Remove your GitHub account from your module's GitHub team.
 
@@ -153,5 +153,5 @@ If you're the **sole owner of the module**, the **AVM core team must review and 
 
 {{% /notice %}}
 
-8. After a pull request has been created, it is important to update the [AVM module proposal](https://aka.ms/AVM/ModuleProposals) issue associated with your module, with a link to the pull request you created in BRM and mention the person who helped triage your module or the `@Azure/avm-core-team-technical-bicep` team.
-9. Once your BRM pull request has been approved and merged into main update the [AVM module proposal](https://aka.ms/AVM/ModuleProposals) issue associated with your module, with a **Merged** comment and mention the person who helped triage your module, or the `@Azure/avm-core-team-technical-bicep` team.
+8. After a pull request has been created, it is important to update the [AVM module proposal](https://aka.ms/AVM/ModuleProposals) issue associated with your module, with a link to the pull request you created in BRM and mention the person who helped triage your module or the `@Azure/azure-verified-modules-tooling-contributors` team.
+9. Once your BRM pull request has been approved and merged into main update the [AVM module proposal](https://aka.ms/AVM/ModuleProposals) issue associated with your module, with a **Merged** comment and mention the person who helped triage your module, or the `@Azure/azure-verified-modules-tooling-contributors` team.

--- a/docs/content/help-support/issue-triage/brm-issue-triage.md
+++ b/docs/content/help-support/issue-triage/brm-issue-triage.md
@@ -52,7 +52,7 @@ An issue is considered to be an "AVM module issue" if
 {{% notice style="note" %}}
 Module issues can only be opened for existing AVM modules. Module issues **MUST NOT** be used to file a module proposal.
 
-If the issue was opened as a misplaced module proposal, mention the `@Azure/AVM-core-team-technical-bicep` team in the comment section and ask them to move the issue to the AVM repository.
+If the issue was opened as a misplaced module proposal, mention the `@Azure/azure-verified-modules-tooling-contributors` team in the comment section and ask them to move the issue to the AVM repository.
 {{% /notice %}}
 
 ### Triaging a Module Issue

--- a/docs/content/help-support/issue-triage/issue-triage-automation.md
+++ b/docs/content/help-support/issue-triage/issue-triage-automation.md
@@ -43,7 +43,7 @@ If a bug/feature/request/general question that has the labels of &nbsp;<mark sty
 
 **Action(s):**
 
-- Add a reply, mentioning the `Azure/avm-core-team-technical-bicep` team.
+- Add a reply, mentioning the `Azure/azure-verified-modules-tooling-contributors` team.
 - Add the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>&nbsp; label.
 
 {{% notice style="tip" %}}
@@ -76,7 +76,7 @@ If a bug/feature/request/general question that has the &nbsp;<mark style="backgr
 
 **Action(s):**
 
-- Add a reply, mentioning the `Azure/avm-core-team-technical-bicep` team.
+- Add a reply, mentioning the `Azure/azure-verified-modules-tooling-contributors` team.
 - Add the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#850000;color:white;">Status: Response Overdue 🚩</mark>&nbsp; label.
 
 {{% notice style="tip" %}}
@@ -110,7 +110,7 @@ If after an additional 3 business days there's still no update to the issue that
 
 **Action(s):**
 
-- Add a reply, mentioning the `Azure/avm-core-team-technical-bicep` team.
+- Add a reply, mentioning the `Azure/azure-verified-modules-tooling-contributors` team.
 - Add the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>&nbsp; label.
 
 {{% notice style="tip" %}}
@@ -143,7 +143,7 @@ If after an additional 3 business days there's still no update to the issue that
 
 **Action(s):**
 
-- Add a reply, mentioning the `Azure/avm-core-team-technical-bicep` team.
+- Add a reply, mentioning the `Azure/azure-verified-modules-tooling-contributors` team.
 - Add the &nbsp;<mark style="background-image:none;white-space: nowrap;background-color:#FF0000;color:white;">Needs: Immediate Attention ‼️</mark>&nbsp; label.
 
 {{% notice style="tip" %}}

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md
@@ -121,11 +121,11 @@ Every `CODEOWNERS` entry (line) **MUST** include the following segments separate
 
 - Path of the module, relative to the repo's root, e.g.: `/avm/res/network/virtual-network/`
 - The `-module-owners-`team, with the `@Azure/` prefix, e.g., `@Azure/avm-res-network-virtualnetwork-module-owners-bicep`
-- The GitHub team of the AVM Bicep reviewers, with the `@Azure/` prefix, i.e., `@Azure/avm-module-reviewers-bicep`
+- The GitHub team of the AVM Bicep reviewers, with the `@Azure/` prefix, i.e., `@Azure/azure-verified-modules-module-owners`
 
 Example - `CODEOWNERS` entry for the Bicep resource module of Azure Virtual Network (`avm/res/network/virtual-network`):
 
-- `/avm/res/network/virtual-network/ @Azure/avm-res-network-virtualnetwork-module-owners-bicep @Azure/avm-module-reviewers-bicep`
+- `/avm/res/network/virtual-network/ @Azure/avm-res-network-virtualnetwork-module-owners-bicep @Azure/azure-verified-modules-module-owners`
 
 ### Terraform
 

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR3.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR3.md
@@ -28,6 +28,6 @@ Modules **MUST** pass all tests that ensure compliance to AVM specifications. Th
 
 Please note these are still under development at this time and will be published and available soon for module owners.
 
-Module owners **MUST** request a manual GitHub Pull Request review, prior to their first release of version `0.1.0` of their module, from the related GitHub Team: [`@Azure/azure-verified-modules-tooling-contributors`](https://github.com/orgs/Azure/teams/azure-verified-modules-tooling-contributors), OR [`@Azure/avm-core-team-technical-terraform`](https://github.com/orgs/Azure/teams/avm-core-team-technical-terraform).
+Module owners **MUST** request a manual GitHub Pull Request review, prior to their first release of version `0.1.0` of their module, from the related GitHub Team: [`@Azure/azure-verified-modules-tooling-contributors`](https://github.com/orgs/Azure/teams/azure-verified-modules-tooling-contributors), OR [`@Azure/azure-verified-modules-tooling-contributors`](https://github.com/orgs/Azure/teams/azure-verified-modules-tooling-contributors).
 
 {{% /notice %}}

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR3.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR3.md
@@ -28,6 +28,6 @@ Modules **MUST** pass all tests that ensure compliance to AVM specifications. Th
 
 Please note these are still under development at this time and will be published and available soon for module owners.
 
-Module owners **MUST** request a manual GitHub Pull Request review, prior to their first release of version `0.1.0` of their module, from the related GitHub Team: [`@Azure/avm-core-team-technical-bicep`](https://github.com/orgs/Azure/teams/avm-core-team-technical-bicep), OR [`@Azure/avm-core-team-technical-terraform`](https://github.com/orgs/Azure/teams/avm-core-team-technical-terraform).
+Module owners **MUST** request a manual GitHub Pull Request review, prior to their first release of version `0.1.0` of their module, from the related GitHub Team: [`@Azure/azure-verified-modules-tooling-contributors`](https://github.com/orgs/Azure/teams/azure-verified-modules-tooling-contributors), OR [`@Azure/avm-core-team-technical-terraform`](https://github.com/orgs/Azure/teams/avm-core-team-technical-terraform).
 
 {{% /notice %}}

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR9.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR9.md
@@ -25,7 +25,7 @@ A module owner **MUST** make the following GitHub teams in the Azure GitHub orga
 
 ### Bicep
 
-- [`@Azure/avm-core-team-technical-bicep`](https://github.com/orgs/Azure/teams/avm-core-team-technical-bicep) = AVM Core Team
+- [`@Azure/azure-verified-modules-tooling-contributors`](https://github.com/orgs/Azure/teams/azure-verified-modules-tooling-contributors) = AVM Core Team
 - [`@Azure/bicep-admins`](https://github.com/orgs/Azure/teams/bicep-admins) = Bicep PG team
 
 {{% notice style="note" %}}

--- a/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR9.md
+++ b/docs/content/specs-defs/includes/shared/shared/non-functional/SNFR9.md
@@ -34,7 +34,7 @@ These required GitHub teams are already associated to the [BRM](https://aka.ms/B
 
 ### Terraform
 
-- [`@Azure/avm-core-team-technical-terraform`](https://github.com/orgs/Azure/teams/avm-core-team-technical-terraform) = AVM Core Team
+- [`@Azure/azure-verified-modules-tooling-contributors`](https://github.com/orgs/Azure/teams/azure-verified-modules-tooling-contributors) = AVM Core Team
 - [`@Azure/terraform-avm`](https://github.com/orgs/Azure/teams/terraform-avm) = Terraform PG
 
 {{% notice style="important" %}}


### PR DESCRIPTION
## Summary

Updates stale GitHub team references across AVM documentation to reflect the consolidated team structure.

### Replacement mapping

| Old team | New team |
|---|---|
| `@Azure/avm-core-team-technical-bicep` | `@Azure/azure-verified-modules-tooling-contributors` |
| `@Azure/avm-module-reviewers-bicep` | `@Azure/azure-verified-modules-module-owners` |

### Changed files (7)

1. `docs/content/help-support/issue-triage/issue-triage-automation.md`
1. `docs/content/contributing/bicep/bicep-contribution-flow/owner-contribution-flow.md`
1. `docs/content/contributing/bicep/bicep-contribution-flow/custom-ci-secrets.md`
1. `docs/content/contributing/bicep/bicep-contribution-flow/child-module-publishing.md`
1. `docs/content/specs-defs/includes/shared/shared/non-functional/SNFR3.md`
1. `docs/content/specs-defs/includes/shared/shared/non-functional/SNFR9.md`
1. `docs/content/specs-defs/includes/shared/shared/non-functional/SNFR20.md`

### Related

Follow-up to [Azure/bicep-registry-modules#7319](https://github.com/Azure/bicep-registry-modules/pull/7319).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>