### PR TITLE
docs(terraform): document TFLint v1.0.0

### DIFF
--- a/docs/content/contributing/terraform/advanced.md
+++ b/docs/content/contributing/terraform/advanced.md
@@ -76,7 +76,7 @@ Example:
 
 ```hcl
 # Disable the required resource id output rule — this is a pattern module.
-rule "required_output_rmfr7" {
+rule "avm_output_resource_id_required" {
   enabled = false
 }
 ```

--- a/docs/content/contributing/terraform/tflint-rules.md
+++ b/docs/content/contributing/terraform/tflint-rules.md
@@ -19,52 +19,106 @@ To disable a rule, use the exact HCL shown in the **Disable** column. The config
 
 | Rule | Enforces | Scope | Disable |
 | --- | --- | --- | --- |
-| [azapi_data_response_export_values](#azapi-data-response-export-values) | AzAPI data sources declare `response_export_values`. | All module scopes | `rule "azapi_data_response_export_values" { enabled = false }` |
-| [azapi_replace_triggers_refs](#azapi-replace-triggers-refs) | Managed AzAPI resources validate declared replacement-trigger paths. | All module scopes | `rule "azapi_replace_triggers_refs" { enabled = false }` |
-| [azapi_resource_tag](#azapi-resource-tag) | Supported AzAPI resource types apply the standard `tags` input; unsupported types omit `tags`. | All module scopes | `rule "azapi_resource_tag" { enabled = false }` |
-| [azapi_response_export_values](#azapi-response-export-values) | Managed AzAPI resources declare `response_export_values`. | All module scopes | `rule "azapi_response_export_values" { enabled = false }` |
-| [customer_managed_key](#customer-managed-key) | The customer-managed key interface follows the AVM contract. | All module scopes | `rule "customer_managed_key" { enabled = false }` |
-| [deprecated_lock_interface](#deprecated-lock-interface) | Deprecated lock-interface shapes are not introduced. | All module scopes | `rule "deprecated_lock_interface" { enabled = false }` |
-| [deprecated_private_endpoints_interface](#deprecated-private-endpoints-interface) | Deprecated private-endpoint interface shapes are not introduced. | All module scopes | `rule "deprecated_private_endpoints_interface" { enabled = false }` |
-| [deprecated_role_assignments_interface](#deprecated-role-assignments-interface) | Deprecated role-assignment interface shapes are not introduced. | All module scopes | `rule "deprecated_role_assignments_interface" { enabled = false }` |
-| [diagnostic_settings](#diagnostic-settings) | The diagnostic-settings interface follows the AVM contract. | All module scopes | `rule "diagnostic_settings" { enabled = false }` |
-| [ignore_body_changes](#ignore-body-changes) | Applicable AzAPI resources expose and apply `ignore_body_changes`. | All module scopes | `rule "ignore_body_changes" { enabled = false }` |
-| [location](#location) | The location interface follows the AVM contract. | All module scopes | `rule "location" { enabled = false }` |
-| [lock](#lock) | The lock interface follows the AVM contract. | All module scopes | `rule "lock" { enabled = false }` |
-| [managed_identities](#managed-identities) | The managed-identities interface follows the AVM contract. | All module scopes | `rule "managed_identities" { enabled = false }` |
-| [no_entire_resource_output_tffr2](#no-entire-resource-output-tffr2) | Outputs do not expose an entire provider resource. | Module scopes | `rule "no_entire_resource_output_tffr2" { enabled = false }` |
-| [private_endpoints](#private-endpoints) | The private-endpoints interface follows the AVM contract. | All module scopes | `rule "private_endpoints" { enabled = false }` |
-| [private_endpoints_manage_dns_zone_group](#private-endpoints-manage-dns-zone-group) | Private-endpoint DNS-zone-group management follows the AVM contract. | All module scopes | `rule "private_endpoints_manage_dns_zone_group" { enabled = false }` |
-| [provider_azapi_version_constraint](#provider-azapi-version-constraint) | The AzAPI provider constraint meets AVM requirements. | Module scopes | `rule "provider_azapi_version_constraint" { enabled = false }` |
-| [provider_azurerm_disallowed](#provider-azurerm-disallowed) | AzureRM is not used as a module foundation. | Module scopes | `rule "provider_azurerm_disallowed" { enabled = false }` |
-| [provider_azurerm_version_constraint](#provider-azurerm-version-constraint) | An approved AzureRM exception has the required constraint. | Module scopes | `rule "provider_azurerm_version_constraint" { enabled = false }` |
-| [provider_modtm_version_constraint](#provider-modtm-version-constraint) | The ModTM provider constraint meets AVM requirements. | Module scopes | `rule "provider_modtm_version_constraint" { enabled = false }` |
-| [required_module_source_tffr1](#required-module-source-tffr1) | AVM module references use the required source format. | Module scopes | `rule "required_module_source_tffr1" { enabled = false }` |
-| [required_module_source_tfnfr10](#required-module-source-tfnfr10) | `ignore_changes` uses AVM-compliant references. | All module scopes | `rule "required_module_source_tfnfr10" { enabled = false }` |
-| [required_output_rmfr7](#required-output-rmfr7) | Resource modules expose their required outputs. | Root module | `rule "required_output_rmfr7" { enabled = false }` |
-| [resource_types](#resource-types) | Applicable AzAPI resources use the `resource_types` interface. | All module scopes | `rule "resource_types" { enabled = false }` |
-| [retry](#retry) | Applicable AzAPI resources expose and apply `retry`. | All module scopes | `rule "retry" { enabled = false }` |
-| [role_assignments](#role-assignments) | The role-assignments interface follows the AVM contract. | All module scopes | `rule "role_assignments" { enabled = false }` |
-| [tags](#tags) | The standard tags interface follows the AVM contract. | All module scopes | `rule "tags" { enabled = false }` |
-| [terraform_heredoc_usage](#terraform-heredoc-usage) | JSON and YAML are encoded with `jsonencode` or `yamlencode`, not literal heredocs. | All module scopes | `rule "terraform_heredoc_usage" { enabled = false }` |
-| [terraform_module_provider_declaration](#terraform-module-provider-declaration) | Modules reject provider blocks and declare aliases with `configuration_aliases`. | Module scopes | `rule "terraform_module_provider_declaration" { enabled = false }` |
-| [terraform_sensitive_variable_no_default](#terraform-sensitive-variable-no-default) | Sensitive variables have no non-empty default. | All module scopes | `rule "terraform_sensitive_variable_no_default" { enabled = false }` |
-| [terraform_tf_file](#terraform-tf-file) | Each module has exactly one `terraform` block in `terraform.tf`. | Module scopes | `rule "terraform_tf_file" { enabled = false }` |
-| [timeouts](#timeouts) | Applicable AzAPI resources expose and apply `timeouts`. | All module scopes | `rule "timeouts" { enabled = false }` |
+| [avm_azapi_data_response_export_values_required](#avm_azapi_data_response_export_values_required) | AzAPI data sources declare `response_export_values`. | All module scopes | `rule "avm_azapi_data_response_export_values_required" { enabled = false }` |
+| [avm_azapi_replace_triggers_refs_valid](#avm_azapi_replace_triggers_refs_valid) | Managed AzAPI resources validate declared replacement-trigger paths. | All module scopes | `rule "avm_azapi_replace_triggers_refs_valid" { enabled = false }` |
+| [avm_azapi_resource_tags_required](#avm_azapi_resource_tags_required) | Supported AzAPI resource types apply the standard `tags` input; unsupported types omit `tags`. | All module scopes | `rule "avm_azapi_resource_tags_required" { enabled = false }` |
+| [avm_azapi_response_export_values_required](#avm_azapi_response_export_values_required) | Managed AzAPI resources declare `response_export_values`. | All module scopes | `rule "avm_azapi_response_export_values_required" { enabled = false }` |
+| [avm_interface_customer_managed_key](#avm_interface_customer_managed_key) | The customer-managed key interface follows the AVM contract. | All module scopes | `rule "avm_interface_customer_managed_key" { enabled = false }` |
+| [avm_interface_lock_deprecated](#avm_interface_lock_deprecated) | Deprecated lock-interface shapes are not introduced. | All module scopes | `rule "avm_interface_lock_deprecated" { enabled = false }` |
+| [avm_interface_private_endpoints_deprecated](#avm_interface_private_endpoints_deprecated) | Deprecated private-endpoint interface shapes are not introduced. | All module scopes | `rule "avm_interface_private_endpoints_deprecated" { enabled = false }` |
+| [avm_interface_role_assignments_deprecated](#avm_interface_role_assignments_deprecated) | Deprecated role-assignment interface shapes are not introduced. | All module scopes | `rule "avm_interface_role_assignments_deprecated" { enabled = false }` |
+| [avm_interface_diagnostic_settings](#avm_interface_diagnostic_settings) | The diagnostic-settings interface follows the AVM contract. | All module scopes | `rule "avm_interface_diagnostic_settings" { enabled = false }` |
+| [avm_interface_ignore_body_changes](#avm_interface_ignore_body_changes) | Applicable AzAPI resources expose and apply `ignore_body_changes`. | All module scopes | `rule "avm_interface_ignore_body_changes" { enabled = false }` |
+| [avm_interface_location](#avm_interface_location) | The location interface follows the AVM contract. | All module scopes | `rule "avm_interface_location" { enabled = false }` |
+| [avm_interface_lock](#avm_interface_lock) | The lock interface follows the AVM contract. | All module scopes | `rule "avm_interface_lock" { enabled = false }` |
+| [avm_interface_managed_identities](#avm_interface_managed_identities) | The managed-identities interface follows the AVM contract. | All module scopes | `rule "avm_interface_managed_identities" { enabled = false }` |
+| [avm_output_entire_resource_disallowed](#avm_output_entire_resource_disallowed) | Outputs do not expose an entire provider resource. | Module scopes | `rule "avm_output_entire_resource_disallowed" { enabled = false }` |
+| [avm_interface_private_endpoints](#avm_interface_private_endpoints) | The private-endpoints interface follows the AVM contract. | All module scopes | `rule "avm_interface_private_endpoints" { enabled = false }` |
+| [avm_interface_private_endpoints_manage_dns_zone_group](#avm_interface_private_endpoints_manage_dns_zone_group) | Private-endpoint DNS-zone-group management follows the AVM contract. | All module scopes | `rule "avm_interface_private_endpoints_manage_dns_zone_group" { enabled = false }` |
+| [avm_provider_azapi_version_constraint](#avm_provider_azapi_version_constraint) | The AzAPI provider constraint meets AVM requirements. | Module scopes | `rule "avm_provider_azapi_version_constraint" { enabled = false }` |
+| [avm_provider_azurerm_disallowed](#avm_provider_azurerm_disallowed) | AzureRM is not used as a module foundation. | Module scopes | `rule "avm_provider_azurerm_disallowed" { enabled = false }` |
+| [avm_provider_azurerm_version_constraint](#avm_provider_azurerm_version_constraint) | An approved AzureRM exception has the required constraint. | Module scopes | `rule "avm_provider_azurerm_version_constraint" { enabled = false }` |
+| [avm_provider_modtm_version_constraint](#avm_provider_modtm_version_constraint) | The ModTM provider constraint meets AVM requirements. | Module scopes | `rule "avm_provider_modtm_version_constraint" { enabled = false }` |
+| [avm_terraform_module_source_required](#avm_terraform_module_source_required) | AVM module references use the required source format. | Module scopes | `rule "avm_terraform_module_source_required" { enabled = false }` |
+| [avm_terraform_ignore_changes_unquoted_references](#avm_terraform_ignore_changes_unquoted_references) | `ignore_changes` uses AVM-compliant references. | All module scopes | `rule "avm_terraform_ignore_changes_unquoted_references" { enabled = false }` |
+| [avm_output_resource_id_required](#avm_output_resource_id_required) | Resource modules expose their required outputs. | Root module | `rule "avm_output_resource_id_required" { enabled = false }` |
+| [avm_interface_resource_types](#avm_interface_resource_types) | Applicable AzAPI resources use the `resource_types` interface. | All module scopes | `rule "avm_interface_resource_types" { enabled = false }` |
+| [avm_interface_retry](#avm_interface_retry) | Applicable AzAPI resources expose and apply `retry`. | All module scopes | `rule "avm_interface_retry" { enabled = false }` |
+| [avm_interface_role_assignments](#avm_interface_role_assignments) | The role-assignments interface follows the AVM contract. | All module scopes | `rule "avm_interface_role_assignments" { enabled = false }` |
+| [avm_interface_tags](#avm_interface_tags) | The standard tags interface follows the AVM contract. | All module scopes | `rule "avm_interface_tags" { enabled = false }` |
+| [avm_terraform_literal_heredoc_disallowed](#avm_terraform_literal_heredoc_disallowed) | JSON and YAML are encoded with `jsonencode` or `yamlencode`, not literal heredocs. | All module scopes | `rule "avm_terraform_literal_heredoc_disallowed" { enabled = false }` |
+| [avm_terraform_provider_block_disallowed](#avm_terraform_provider_block_disallowed) | Modules reject provider blocks and declare aliases with `configuration_aliases`. | Module scopes | `rule "avm_terraform_provider_block_disallowed" { enabled = false }` |
+| [avm_terraform_sensitive_variable_default_disallowed](#avm_terraform_sensitive_variable_default_disallowed) | Sensitive variables have no non-empty default. | All module scopes | `rule "avm_terraform_sensitive_variable_default_disallowed" { enabled = false }` |
+| [avm_terraform_configuration_file_required](#avm_terraform_configuration_file_required) | Each module has exactly one `terraform` block in `terraform.tf`. | Module scopes | `rule "avm_terraform_configuration_file_required" { enabled = false }` |
+| [avm_interface_timeouts](#avm_interface_timeouts) | Applicable AzAPI resources expose and apply `timeouts`. | All module scopes | `rule "avm_interface_timeouts" { enabled = false }` |
+
+## Per-rule severity
+
+Version 1.0.0 of the AVM plugin supports an optional `severity` input on every AVM `rule` block. The exact supported values are `error`, `warning`, and `notice`. When `severity` is omitted, the rule keeps its default severity.
+
+```hcl
+rule "avm_interface_resource_types" {
+  enabled  = true
+  severity = "notice"
+}
+```
+
+This setting is specific to rules provided by the AVM plugin and changes the severity emitted by that rule. It is separate from TFLint's global [`--minimum-failure-severity`](https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/config.md#minimum-failure-severity) option, which sets the failure threshold for the TFLint process rather than configuring an individual rule's severity.
+
+## Breaking change in v1.0.0: rule names
+
+[AVM TFLint ruleset v1.0.0](https://github.com/Azure/tflint-ruleset-avm/releases/tag/v1.0.0), released through [ruleset PR #159](https://github.com/Azure/tflint-ruleset-avm/pull/159), renamed all rules to canonical `avm_*` names without compatibility aliases. Update the label of every affected TFLint `rule` block in `.tflint.hcl` and AVM override files:
+
+| Old name | New canonical name |
+| --- | --- |
+| `azapi_data_response_export_values` | `avm_azapi_data_response_export_values_required` |
+| `azapi_replace_triggers_refs` | `avm_azapi_replace_triggers_refs_valid` |
+| `azapi_resource_tag` | `avm_azapi_resource_tags_required` |
+| `azapi_response_export_values` | `avm_azapi_response_export_values_required` |
+| `customer_managed_key` | `avm_interface_customer_managed_key` |
+| `deprecated_lock_interface` | `avm_interface_lock_deprecated` |
+| `deprecated_private_endpoints_interface` | `avm_interface_private_endpoints_deprecated` |
+| `deprecated_role_assignments_interface` | `avm_interface_role_assignments_deprecated` |
+| `diagnostic_settings` | `avm_interface_diagnostic_settings` |
+| `ignore_body_changes` | `avm_interface_ignore_body_changes` |
+| `location` | `avm_interface_location` |
+| `lock` | `avm_interface_lock` |
+| `managed_identities` | `avm_interface_managed_identities` |
+| `no_entire_resource_output_tffr2` | `avm_output_entire_resource_disallowed` |
+| `private_endpoints` | `avm_interface_private_endpoints` |
+| `private_endpoints_manage_dns_zone_group` | `avm_interface_private_endpoints_manage_dns_zone_group` |
+| `provider_azapi_version_constraint` | `avm_provider_azapi_version_constraint` |
+| `provider_azurerm_disallowed` | `avm_provider_azurerm_disallowed` |
+| `provider_azurerm_version_constraint` | `avm_provider_azurerm_version_constraint` |
+| `provider_modtm_version_constraint` | `avm_provider_modtm_version_constraint` |
+| `required_module_source_tffr1` | `avm_terraform_module_source_required` |
+| `required_module_source_tfnfr10` | `avm_terraform_ignore_changes_unquoted_references` |
+| `required_output_rmfr7` | `avm_output_resource_id_required` |
+| `resource_types` | `avm_interface_resource_types` |
+| `retry` | `avm_interface_retry` |
+| `role_assignments` | `avm_interface_role_assignments` |
+| `tags` | `avm_interface_tags` |
+| `terraform_heredoc_usage` | `avm_terraform_literal_heredoc_disallowed` |
+| `terraform_module_provider_declaration` | `avm_terraform_provider_block_disallowed` |
+| `terraform_sensitive_variable_no_default` | `avm_terraform_sensitive_variable_default_disallowed` |
+| `terraform_tf_file` | `avm_terraform_configuration_file_required` |
+| `timeouts` | `avm_interface_timeouts` |
+
+These renames apply only to TFLint rule identifiers. Terraform input variable names such as `ignore_body_changes`, `resource_types`, `retry`, and `timeouts` are unchanged.
 
 ## Rule guidance
 
-### azapi data response export values
+### avm_azapi_data_response_export_values_required
 
 Applies [TFFR4]({{% siteparam base %}}/spec/TFFR4) to AzAPI data sources: declare `response_export_values`, including `[]` when no response fields are needed.
 
-### azapi replace triggers refs
+### avm_azapi_replace_triggers_refs_valid
 
 Applies [TFFR5]({{% siteparam base %}}/spec/TFFR5). Omit `replace_triggers_refs` when no body paths require replacement. When present, it must be a non-empty static list of valid JMESPath expressions that identify body paths requiring replacement. Entries cannot be blank or duplicated, and cannot include `name` or `location`, because AzAPI already replaces the resource when either changes. When the body is statically evaluable, the rule verifies that each declared path resolves against it.
 
 Authors remain responsible for identifying the properties that actually require replacement. Current Bicep-generated schemas do not reliably preserve create-only versus updateable mutability, so this rule validates declared paths but cannot prove that the list is semantically complete.
 
-### azapi resource tag
+### avm_azapi_resource_tags_required
 
 Applies [TFFR9]({{% siteparam base %}}/spec/TFFR9): set `tags = var.tags` exactly on types supported by the embedded AVM-generated capability snapshot, and omit `tags` for unsupported types. The rule skips dynamic or otherwise unevaluable type expressions.
 
@@ -72,119 +126,119 @@ The ruleset embeds its AVM-generated capability snapshot and works standalone. I
 
 A weekly ruleset workflow compares the embedded snapshot with upstream data and opens a ruleset pull request when that data changes. Updated capability data ships with the next ruleset release. All users receive snapshot updates by upgrading the ruleset release.
 
-### azapi response export values
+### avm_azapi_response_export_values_required
 
 Applies [TFFR4]({{% siteparam base %}}/spec/TFFR4): every applicable managed AzAPI resource declares `response_export_values`, including `[]` when no fields are exported.
 
-### customer managed key
+### avm_interface_customer_managed_key
 
 Validates the [customer-managed key interface]({{% siteparam base %}}/specs/tf/interfaces/#customer-managed-keys).
 
-### deprecated lock interface
+### avm_interface_lock_deprecated
 
 Prevents new use of deprecated shapes in the [resource-lock interface]({{% siteparam base %}}/specs/tf/interfaces/#resource-locks).
 
-### deprecated private endpoints interface
+### avm_interface_private_endpoints_deprecated
 
 Prevents new use of deprecated shapes in the [private-endpoints interface]({{% siteparam base %}}/specs/tf/interfaces/#private-endpoints).
 
-### deprecated role assignments interface
+### avm_interface_role_assignments_deprecated
 
 Prevents new use of deprecated shapes in the [role-assignments interface]({{% siteparam base %}}/specs/tf/interfaces/#role-assignments).
 
-### diagnostic settings
+### avm_interface_diagnostic_settings
 
 Validates the [diagnostic-settings interface]({{% siteparam base %}}/specs/tf/interfaces/#diagnostic-settings).
 
-### ignore body changes
+### avm_interface_ignore_body_changes
 
 Validates the [AzAPI `ignore_body_changes` interface]({{% siteparam base %}}/spec/TFFR8), including its per-resource and per-submodule applicability.
 
-### location
+### avm_interface_location
 
 Validates the standard [location interface]({{% siteparam base %}}/specs/tf/interfaces/#location).
 
-### lock
+### avm_interface_lock
 
 Validates the [resource-lock interface]({{% siteparam base %}}/specs/tf/interfaces/#resource-locks).
 
-### managed identities
+### avm_interface_managed_identities
 
 Validates the [managed-identities interface]({{% siteparam base %}}/specs/tf/interfaces/#managed-identities).
 
-### no entire resource output tffr2
+### avm_output_entire_resource_disallowed
 
 Applies [TFFR2]({{% siteparam base %}}/spec/TFFR2): output explicit values instead of an entire provider resource.
 
-### private endpoints
+### avm_interface_private_endpoints
 
 Validates the [private-endpoints interface]({{% siteparam base %}}/specs/tf/interfaces/#private-endpoints).
 
-### private endpoints manage dns zone group
+### avm_interface_private_endpoints_manage_dns_zone_group
 
 Validates the DNS-zone-group behavior of the [private-endpoints interface]({{% siteparam base %}}/specs/tf/interfaces/#private-endpoints).
 
-### provider azapi version constraint
+### avm_provider_azapi_version_constraint
 
 Validates the AzAPI constraint required by [TFFR3]({{% siteparam base %}}/spec/TFFR3).
 
-### provider azurerm disallowed
+### avm_provider_azurerm_disallowed
 
 Applies the AzureRM-foundation prohibition in [TFFR3]({{% siteparam base %}}/spec/TFFR3).
 
-### provider azurerm version constraint
+### avm_provider_azurerm_version_constraint
 
 Validates the AzureRM constraint when the narrow [TFFR3]({{% siteparam base %}}/spec/TFFR3) exception is used.
 
-### provider modtm version constraint
+### avm_provider_modtm_version_constraint
 
 Validates the ModTM provider constraint when that provider is used.
 
-### required module source tffr1
+### avm_terraform_module_source_required
 
 Applies [TFFR1]({{% siteparam base %}}/spec/TFFR1) to AVM module sources.
 
-### required module source tfnfr10
+### avm_terraform_ignore_changes_unquoted_references
 
 Applies [TFNFR10]({{% siteparam base %}}/spec/TFNFR10) to `ignore_changes` references.
 
-### required output rmfr7
+### avm_output_resource_id_required
 
 Applies the required-output contract in [RMFR7]({{% siteparam base %}}/spec/RMFR7).
 
-### resource types
+### avm_interface_resource_types
 
 Validates the [AzAPI `resource_types` interface]({{% siteparam base %}}/spec/TFFR6), including its deterministic resource-type keys and cascading shape.
 
-### retry
+### avm_interface_retry
 
 Validates the [AzAPI `retry` interface]({{% siteparam base %}}/spec/TFFR7).
 
-### role assignments
+### avm_interface_role_assignments
 
 Validates the [role-assignments interface]({{% siteparam base %}}/specs/tf/interfaces/#role-assignments).
 
-### tags
+### avm_interface_tags
 
 Validates the [tags interface]({{% siteparam base %}}/specs/tf/interfaces/#tags).
 
-### terraform heredoc usage
+### avm_terraform_literal_heredoc_disallowed
 
 Applies [TFNFR40]({{% siteparam base %}}/spec/TFNFR40): represent JSON or YAML structured values with `jsonencode` or `yamlencode`.
 
-### terraform module provider declaration
+### avm_terraform_provider_block_disallowed
 
 Applies [TFNFR27]({{% siteparam base %}}/spec/TFNFR27): a published module contains no `provider` blocks; aliases are declared only through `configuration_aliases` and configured by its consumer.
 
-### terraform sensitive variable no default
+### avm_terraform_sensitive_variable_default_disallowed
 
 Applies [TFNFR23]({{% siteparam base %}}/spec/TFNFR23): a sensitive variable may default only to an empty collection.
 
-### terraform tf file
+### avm_terraform_configuration_file_required
 
 Applies [TFNFR39]({{% siteparam base %}}/spec/TFNFR39): a module has exactly one `terraform` block and it is in `terraform.tf`.
 
-### timeouts
+### avm_interface_timeouts
 
 Validates the [AzAPI `timeouts` interface]({{% siteparam base %}}/spec/TFFR7).
 
@@ -209,7 +263,7 @@ The standard Terraform TFLint plugin validates `required_version` and provider r
 Each file contains normal TFLint rule configuration. For example:
 
 ```hcl
-rule "terraform_sensitive_variable_no_default" {
+rule "avm_terraform_sensitive_variable_default_disallowed" {
   enabled = false
 }
 ```

--- a/docs/content/specs-defs/includes/shared/resource/functional/RMFR7.md
+++ b/docs/content/specs-defs/includes/shared/resource/functional/RMFR7.md
@@ -20,7 +20,7 @@ priority: 2080
 
 ## ID: RMFR7 - Category: Outputs - Minimum Required Outputs
 
-This requirement is enforced for resource-module roots by [required_output_rmfr7]({{% siteparam base %}}/contributing/terraform/tflint-rules/#required-output-rmfr7).
+This requirement is enforced for resource-module roots by [avm_output_resource_id_required]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_output_resource_id_required).
 
 Module owners **MUST** output the following outputs as a minimum in their modules:
 

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR1.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR1.md
@@ -21,7 +21,7 @@ priority: 20010
 
 ## ID: TFFR1 - Category: Composition - Cross-Referencing Modules
 
-This requirement is enforced by [required_module_source_tffr1]({{% siteparam base %}}/contributing/terraform/tflint-rules/#required-module-source-tffr1).
+This requirement is enforced by [avm_terraform_module_source_required]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_terraform_module_source_required).
 
 Module owners **MAY** cross-references other modules to build either Resource or Pattern modules. However, they **MUST** be referenced only by a HashiCorp Terraform registry reference to a pinned version e.g.,
 

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR2.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR2.md
@@ -21,7 +21,7 @@ priority: 20020
 
 ## ID: TFFR2 - Category: Outputs - Additional Terraform Outputs
 
-The prohibition on outputting an entire provider resource is enforced by [no_entire_resource_output_tffr2]({{% siteparam base %}}/contributing/terraform/tflint-rules/#no-entire-resource-output-tffr2).
+The prohibition on outputting an entire provider resource is enforced by [avm_output_entire_resource_disallowed]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_output_entire_resource_disallowed).
 
 Authors **SHOULD NOT** output entire resource objects as these may contain sensitive outputs and the schema can change with API or provider versions.
 Instead, authors **SHOULD** output the *computed* attributes of the resource as discreet outputs.

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR3.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR3.md
@@ -21,7 +21,7 @@ priority: 20030
 
 ## ID: TFFR3 - Category: Providers - Permitted Versions
 
-The AVM provider rules are documented in [provider_azapi_version_constraint]({{% siteparam base %}}/contributing/terraform/tflint-rules/#provider-azapi-version-constraint), [provider_azurerm_disallowed]({{% siteparam base %}}/contributing/terraform/tflint-rules/#provider-azurerm-disallowed), and [provider_azurerm_version_constraint]({{% siteparam base %}}/contributing/terraform/tflint-rules/#provider-azurerm-version-constraint).
+The AVM provider rules are documented in [avm_provider_azapi_version_constraint]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_provider_azapi_version_constraint), [avm_provider_azurerm_disallowed]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_provider_azurerm_disallowed), and [avm_provider_azurerm_version_constraint]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_provider_azurerm_version_constraint).
 
 {{% notice style="important" %}}
 
@@ -70,7 +70,7 @@ Where this exception applies, the module **MUST**:
 - Add the following TFLint exclusion:
 
   ```hcl
-  rule "provider_azurerm_disallowed" {
+  rule "avm_provider_azurerm_disallowed" {
     enabled = false
   }
   ```

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR4.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR4.md
@@ -21,7 +21,7 @@ priority: 20040
 
 ## ID: TFFR4 - Category: Composition - AzAPI - response_export_values
 
-This requirement is enforced by [azapi_response_export_values]({{% siteparam base %}}/contributing/terraform/tflint-rules/#azapi-response-export-values) and [azapi_data_response_export_values]({{% siteparam base %}}/contributing/terraform/tflint-rules/#azapi-data-response-export-values).
+This requirement is enforced by [avm_azapi_response_export_values_required]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_azapi_response_export_values_required) and [avm_azapi_data_response_export_values_required]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_azapi_data_response_export_values_required).
 
 Authors **MUST** specify the `response_export_values` argument when using the AzAPI provider:
 

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR5.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR5.md
@@ -21,7 +21,7 @@ priority: 20050
 
 ## ID: TFFR5 - Category: Composition - AzAPI - replace_triggers_refs
 
-This requirement is enforced by [azapi_replace_triggers_refs]({{% siteparam base %}}/contributing/terraform/tflint-rules/#azapi-replace-triggers-refs).
+This requirement is enforced by [avm_azapi_replace_triggers_refs_valid]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_azapi_replace_triggers_refs_valid).
 
 Authors **MUST** omit `replace_triggers_refs` when no body properties require replacement.
 When one or more body properties require replacement, authors **MUST** set `replace_triggers_refs` to a non-empty static list of JMESPath expressions that identify those paths.

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR6.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR6.md
@@ -21,7 +21,7 @@ priority: 20060
 
 ## ID: TFFR6 - Category: Inputs/Outputs - AzAPI - resource_types variable
 
-This requirement is enforced by [resource_types]({{% siteparam base %}}/contributing/terraform/tflint-rules/#resource-types).
+This requirement is enforced by [avm_interface_resource_types]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_interface_resource_types).
 
 ### Applicability
 

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR7.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR7.md
@@ -21,7 +21,7 @@ priority: 20070
 
 ## ID: TFFR7 - Category: Inputs/Outputs - AzAPI - retry and timeouts variables
 
-These requirements are enforced by [retry]({{% siteparam base %}}/contributing/terraform/tflint-rules/#retry) and [timeouts]({{% siteparam base %}}/contributing/terraform/tflint-rules/#timeouts).
+These requirements are enforced by [avm_interface_retry]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_interface_retry) and [avm_interface_timeouts]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_interface_timeouts).
 
 ### Applicability
 

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR8.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR8.md
@@ -21,7 +21,7 @@ priority: 20080
 
 ## ID: TFFR8 - Category: Inputs/Outputs - AzAPI - ignore_body_changes variable
 
-This requirement is enforced by [ignore_body_changes]({{% siteparam base %}}/contributing/terraform/tflint-rules/#ignore-body-changes).
+This requirement is enforced by [avm_interface_ignore_body_changes]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_interface_ignore_body_changes).
 
 ### Applicability
 

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR9.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR9.md
@@ -23,7 +23,7 @@ priority: 20090
 
 ### Applicability
 
-This requirement applies independently to every root module and submodule that directly declares a managed AzAPI resource. The [azapi_resource_tag]({{% siteparam base %}}/contributing/terraform/tflint-rules/#azapi-resource-tag) rule determines whether a resource type supports the `tags` argument from its embedded AVM-generated capability snapshot.
+This requirement applies independently to every root module and submodule that directly declares a managed AzAPI resource. The [avm_azapi_resource_tags_required]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_azapi_resource_tags_required) rule determines whether a resource type supports the `tags` argument from its embedded AVM-generated capability snapshot.
 
 ### Requirement
 
@@ -45,4 +45,4 @@ The validation skips dynamic or otherwise unevaluable `type` expressions to avoi
 
 The `tags` input and propagation behavior remain governed by the [standard tags interface]({{% siteparam base %}}/specs/tf/interfaces/#tags). The embedded AVM-generated capability snapshot, rather than a hand-maintained module allowlist or an AzAPI import, is the authority for deciding whether the argument is supported.
 
-See [azapi_resource_tag]({{% siteparam base %}}/contributing/terraform/tflint-rules/#azapi-resource-tag) for enforcement and the supported override.
+See [avm_azapi_resource_tags_required]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_azapi_resource_tags_required) for enforcement and the supported override.

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR10.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR10.md
@@ -21,7 +21,7 @@ priority: 21100
 
 ## ID: TFNFR10 - Category: Code Style - No Double Quotes in ignore_changes
 
-This requirement is enforced by [required_module_source_tfnfr10]({{% siteparam base %}}/contributing/terraform/tflint-rules/#required-module-source-tfnfr10).
+This requirement is enforced by [avm_terraform_ignore_changes_unquoted_references]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_terraform_ignore_changes_unquoted_references).
 
 The `ignore_changes` attribute **MUST NOT** be enclosed in double quotes.
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR23.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR23.md
@@ -23,7 +23,7 @@ priority: 21230
 
 A default value **MUST NOT** be set for a sensitive input, unless it is an empty collection value.
 
-This is enforced by [terraform_sensitive_variable_no_default]({{% siteparam base %}}/contributing/terraform/tflint-rules/#terraform-sensitive-variable-no-default).
+This is enforced by [avm_terraform_sensitive_variable_default_disallowed]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_terraform_sensitive_variable_default_disallowed).
 
 Good example:
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR25.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR25.md
@@ -47,4 +47,4 @@ terraform {
 }
 ```
 
-The AVM [terraform_tf_file]({{% siteparam base %}}/contributing/terraform/tflint-rules/#terraform-tf-file) rule validates the complementary requirement that the module has exactly one `terraform` block in `terraform.tf`.
+The AVM [avm_terraform_configuration_file_required]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_terraform_configuration_file_required) rule validates the complementary requirement that the module has exactly one `terraform` block in `terraform.tf`.

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR27.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR27.md
@@ -25,7 +25,7 @@ priority: 21270
 
 When a module requires an alternate provider instance, it **MUST** declare that alias through `configuration_aliases` in `terraform.required_providers` and the consumer **MUST** pass the configured alias through the module's `providers` map. A provider block containing only `alias` is not permitted in an AVM module.
 
-This is enforced by [terraform_module_provider_declaration]({{% siteparam base %}}/contributing/terraform/tflint-rules/#terraform-module-provider-declaration).
+This is enforced by [avm_terraform_provider_block_disallowed]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_terraform_provider_block_disallowed).
 
 Good examples:
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR39.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR39.md
@@ -54,7 +54,7 @@ For larger modules the contents of `main.tf`, `variables.tf`, `outputs.tf`, and 
 
 Standardizing file layout means that any reviewer or consumer can find a module's interface (`variables.tf`, `outputs.tf`), provider constraints (`terraform.tf`), and primary logic (`main.tf` / `main.<topic>.tf`) in the same place across every AVM Terraform module, without having to grep. It also makes the cascade rules in [TFFR6]({{% siteparam base %}}/spec/TFFR6), [TFFR7]({{% siteparam base %}}/spec/TFFR7), and [TFRMNFR1]({{% siteparam base %}}/spec/TFRMNFR1) reviewable at a glance.
 
-MAPOTF places top-level blocks in their canonical files. The [terraform_tf_file]({{% siteparam base %}}/contributing/terraform/tflint-rules/#terraform-tf-file) rule validates the single `terraform` block requirement.
+MAPOTF places top-level blocks in their canonical files. The [avm_terraform_configuration_file_required]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_terraform_configuration_file_required) rule validates the single `terraform` block requirement.
 
 ### Notes
 

--- a/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR40.md
+++ b/docs/content/specs-defs/includes/terraform/shared/non-functional/TFNFR40.md
@@ -36,5 +36,4 @@ Terraform interpolation (`${...}`), template directives (`%{...}`), unknown valu
 
 A heredoc **MAY** be used only when the value is not JSON or YAML, or when the receiving system requires opaque source text for a downstream templating engine or syntax that `jsonencode` or `yamlencode` cannot represent without changing its meaning. The heredoc must not use Terraform interpolation to assemble JSON or YAML in that case, and its reason must be clear from the surrounding configuration.
 
-See [terraform_heredoc_usage]({{% siteparam base %}}/contributing/terraform/tflint-rules/#terraform-heredoc-usage) for enforcement and the supported override.
-
+See [avm_terraform_literal_heredoc_disallowed]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_terraform_literal_heredoc_disallowed) for enforcement and the supported override.


### PR DESCRIPTION
# Overview/Summary

Documents the breaking AVM TFLint ruleset v1.0.0 rule-name migration and native per-rule severity configuration on the official AVM site.

Related changes:

- https://github.com/Azure/tflint-ruleset-avm/pull/159
- https://github.com/Azure/azure-verified-modules-tools/pull/93

## This PR fixes/adds/changes/removes

1. Adds plugin-specific `severity` guidance for `error`, `warning`, and `notice`, including the distinction from TFLint's global `--minimum-failure-severity` threshold.
1. Adds the complete 32-rule breaking migration table and updates active AVM rule references to canonical `avm_*` names.
1. Clarifies that Terraform input variable names are unchanged.

### Breaking Changes

1. Documents the v1.0.0 removal of legacy TFLint rule names without compatibility aliases.

## Validation

- Hugo 0.136.5 production build passed (930 pages).
- Repository-pinned `markdownlint-cli` 0.41.0 passed for all 18 changed Markdown files.
- Repository-configured Markdown link checks passed for all 18 changed Markdown files.
- The migration table exactly matches all 32 entries in the released v1.0.0 ruleset, and all 32 generated canonical heading anchors were verified.

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)