### PR TITLE
docs: add TFLint rules to navigation

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -706,11 +706,19 @@ weight = 5
 params = { alwaysopen = false, collapsibleMenu = true }
 
 [[menu.defined]]
+identifier = 'terraform-tflint-rules'
+parent = 'terraform-module-contribution'
+name = 'TFLint Rules'
+pageRef = '/contributing/terraform/tflint-rules'
+weight = 6
+params = { alwaysopen = false, collapsibleMenu = true }
+
+[[menu.defined]]
 identifier = 'terraform-repository-creation-process'
 parent = 'terraform-module-contribution'
 name = 'Repository Setup'
 pageRef = '/contributing/terraform/repository-setup'
-weight = 6
+weight = 7
 params = { alwaysopen = false, collapsibleMenu = true }
 
 [[menu.defined]]


### PR DESCRIPTION
## Summary
- add the AVM TFLint Rules page to the Terraform contribution navigation
- keep the page order aligned with the Terraform contribution guide
- confirm all other unmatched content routes are intentionally hidden or superseded

## Validation
- built the documentation site with Hugo 0.136.5
- verified the generated Terraform sidebar order