### PR TITLE
docs(terraform): define resource tag overrides

### DIFF
--- a/docs/content/contributing/terraform/tflint-rules.md
+++ b/docs/content/contributing/terraform/tflint-rules.md
@@ -21,7 +21,7 @@ To disable a rule, use the exact HCL shown in the **Disable** column. The config
 | --- | --- | --- | --- |
 | [avm_azapi_data_response_export_values_required](#avm_azapi_data_response_export_values_required) | AzAPI data sources declare `response_export_values`. | All module scopes | `rule "avm_azapi_data_response_export_values_required" { enabled = false }` |
 | [avm_azapi_replace_triggers_refs_valid](#avm_azapi_replace_triggers_refs_valid) | Managed AzAPI resources validate declared replacement-trigger paths. | All module scopes | `rule "avm_azapi_replace_triggers_refs_valid" { enabled = false }` |
-| [avm_azapi_resource_tags_required](#avm_azapi_resource_tags_required) | Supported AzAPI resource types apply the standard `tags` input; unsupported types omit `tags`. | All module scopes | `rule "avm_azapi_resource_tags_required" { enabled = false }` |
+| [avm_azapi_resource_tags_required](#avm_azapi_resource_tags_required) | Writable AzAPI resource types expose consumer-settable tags; read-only or unsupported types omit `tags`. | All module scopes | `rule "avm_azapi_resource_tags_required" { enabled = false }` |
 | [avm_azapi_response_export_values_required](#avm_azapi_response_export_values_required) | Managed AzAPI resources declare `response_export_values`. | All module scopes | `rule "avm_azapi_response_export_values_required" { enabled = false }` |
 | [avm_interface_customer_managed_key](#avm_interface_customer_managed_key) | The customer-managed key interface follows the AVM contract. | All module scopes | `rule "avm_interface_customer_managed_key" { enabled = false }` |
 | [avm_interface_lock_deprecated](#avm_interface_lock_deprecated) | Deprecated lock-interface shapes are not introduced. | All module scopes | `rule "avm_interface_lock_deprecated" { enabled = false }` |
@@ -42,6 +42,7 @@ To disable a rule, use the exact HCL shown in the **Disable** column. The config
 | [avm_terraform_module_source_required](#avm_terraform_module_source_required) | AVM module references use the required source format. | Module scopes | `rule "avm_terraform_module_source_required" { enabled = false }` |
 | [avm_terraform_ignore_changes_unquoted_references](#avm_terraform_ignore_changes_unquoted_references) | `ignore_changes` uses AVM-compliant references. | All module scopes | `rule "avm_terraform_ignore_changes_unquoted_references" { enabled = false }` |
 | [avm_output_resource_id_required](#avm_output_resource_id_required) | Resource modules expose their required outputs. | Root module | `rule "avm_output_resource_id_required" { enabled = false }` |
+| [avm_interface_resource_tags](#avm_interface_resource_tags) | An exposed `resource_tags` interface uses the typed recursive replacement contract. | All module scopes | `rule "avm_interface_resource_tags" { enabled = false }` |
 | [avm_interface_resource_types](#avm_interface_resource_types) | Applicable AzAPI resources use the `resource_types` interface. | All module scopes | `rule "avm_interface_resource_types" { enabled = false }` |
 | [avm_interface_retry](#avm_interface_retry) | Applicable AzAPI resources expose and apply `retry`. | All module scopes | `rule "avm_interface_retry" { enabled = false }` |
 | [avm_interface_role_assignments](#avm_interface_role_assignments) | The role-assignments interface follows the AVM contract. | All module scopes | `rule "avm_interface_role_assignments" { enabled = false }` |
@@ -120,7 +121,7 @@ Authors remain responsible for identifying the properties that actually require 
 
 ### avm_azapi_resource_tags_required
 
-Applies [TFFR9]({{% siteparam base %}}/spec/TFFR9): set `tags = var.tags` exactly on types supported by the embedded AVM-generated capability snapshot, and omit `tags` for unsupported types. The rule skips dynamic or otherwise unevaluable type expressions.
+Applies [TFFR9]({{% siteparam base %}}/spec/TFFR9): types with writable tags in the embedded AVM-generated capability snapshot must set `tags` from a consumer-settable expression. A direct `tags = var.tags` assignment remains valid, and modules can use the typed `resource_tags` replacement interface documented by the [standard tags interface]({{% siteparam base %}}/specs/tf/interfaces/#tags). Types with read-only or unsupported tags must omit the argument. The rule does not require one exact tags expression and skips dynamic or otherwise unevaluable type expressions.
 
 The ruleset embeds its AVM-generated capability snapshot and works standalone. It does not consume, import, or query AzAPI, and does not accept an external snapshot path.
 
@@ -206,6 +207,10 @@ Applies [TFNFR10]({{% siteparam base %}}/spec/TFNFR10) to `ignore_changes` refer
 
 Applies the required-output contract in [RMFR7]({{% siteparam base %}}/spec/RMFR7).
 
+### avm_interface_resource_tags
+
+Validates the optional `resource_tags` variable when it is declared. The variable must default to `null` and permit null values. Its type must use one or both non-empty, optional `resources` and `modules` namespaces without inline defaults. Resource labels must be optional `map(string)` leaves, module labels must be optional objects that recursively use the same shape, and the complete type must contain at least one resource leaf. The separate namespaces identify Terraform resource and module block labels without collisions.
+
 ### avm_interface_resource_types
 
 Validates the [AzAPI `resource_types` interface]({{% siteparam base %}}/spec/TFFR6), including its deterministic resource-type keys and cascading shape.
@@ -220,7 +225,7 @@ Validates the [role-assignments interface]({{% siteparam base %}}/specs/tf/inter
 
 ### avm_interface_tags
 
-Validates the [tags interface]({{% siteparam base %}}/specs/tf/interfaces/#tags).
+Validates the [tags interface]({{% siteparam base %}}/specs/tf/interfaces/#tags). The backward-compatible `tags` fallback remains a nullable `map(string)`. When a module exposes `resource_tags`, its deterministic typed `resources` and `modules` namespaces provide complete per-resource replacements without merging.
 
 ### avm_terraform_literal_heredoc_disallowed
 

--- a/docs/content/specs-defs/includes/terraform/shared/functional/TFFR9.md
+++ b/docs/content/specs-defs/includes/terraform/shared/functional/TFFR9.md
@@ -23,11 +23,11 @@ priority: 20090
 
 ### Applicability
 
-This requirement applies independently to every root module and submodule that directly declares a managed AzAPI resource. The [avm_azapi_resource_tags_required]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_azapi_resource_tags_required) rule determines whether a resource type supports the `tags` argument from its embedded AVM-generated capability snapshot.
+This requirement applies independently to every root module and submodule that directly declares a managed AzAPI resource. The [avm_azapi_resource_tags_required]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_azapi_resource_tags_required) rule uses its embedded AVM-generated capability snapshot to classify the resource type's tags property as writable, read-only, or unsupported.
 
 ### Requirement
 
-For every statically supported resource type, the resource **MUST** set the standard AVM tags input exactly as follows:
+For every resource type with a statically writable tags property, the resource **MUST** expose consumer-settable tags through the [standard tags interface]({{% siteparam base %}}/specs/tf/interfaces/#tags) and set the `tags` argument. A direct assignment remains valid for modules that use only the module-wide fallback:
 
 ```terraform
 resource "azapi_resource" "this" {
@@ -37,12 +37,14 @@ resource "azapi_resource" "this" {
 }
 ```
 
-The assignment **MUST NOT** merge, conditionally replace, or otherwise transform `var.tags` at the resource declaration. Apply any approved tag shaping before assigning the standard input.
+When the module exposes the optional `resource_tags` interface, a non-null override for the Terraform resource block label **MUST** replace `var.tags` completely. An omitted or `null` override **MUST** inherit `var.tags`, and an empty map **MUST** remain an intentional empty replacement. The implementation **MUST NOT** merge the fallback and override maps.
 
-For every statically unsupported resource type, the resource **MUST NOT** set a `tags` argument. Do not use a conditional, dynamic value, or an empty map to force tags onto an unsupported type.
+Resource override keys identify Terraform resource block labels, not ARM resource types. Submodule overrides **MUST** use the deterministic typed `resource_tags.modules.<module_label>` shape defined by the standard tags interface. The separate `resources` and `modules` namespaces **MUST** resolve identical resource and module labels without ambiguity.
+
+For every resource type with a statically read-only or unsupported tags property, the resource **MUST NOT** set a `tags` argument. Do not use a conditional, dynamic value, or an empty map to force tags onto these types.
 
 The validation skips dynamic or otherwise unevaluable `type` expressions to avoid false positives. Authors **SHOULD** keep resource types statically resolvable through `var.resource_types` as required by [TFFR6]({{% siteparam base %}}/spec/TFFR6).
 
-The `tags` input and propagation behavior remain governed by the [standard tags interface]({{% siteparam base %}}/specs/tf/interfaces/#tags). The embedded AVM-generated capability snapshot, rather than a hand-maintained module allowlist or an AzAPI import, is the authority for deciding whether the argument is supported.
+The embedded AVM-generated capability snapshot, rather than a hand-maintained module allowlist or an AzAPI import, is the authority for this classification.
 
-See [avm_azapi_resource_tags_required]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_azapi_resource_tags_required) for enforcement and the supported override.
+See [avm_azapi_resource_tags_required]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_azapi_resource_tags_required) for capability enforcement and [avm_interface_resource_tags]({{% siteparam base %}}/contributing/terraform/tflint-rules/#avm_interface_resource_tags) for validation of the optional override interface.

--- a/docs/content/specs-defs/specs/terraform/interfaces.md
+++ b/docs/content/specs-defs/specs/terraform/interfaces.md
@@ -82,12 +82,36 @@ In Terraform, locks become part of the resource graph and suitable `depends_on` 
   {{% include file="/static/includes/interfaces/tf/int.tags.input.tf" %}}
 {{< /highlight >}}
 
-**Details on child, extension and cross-referenced resources:**
+The `tags` variable is the module-wide fallback and common interface. It **MUST** remain a `map(string)` with a default of `null`. A module that does not expose per-resource overrides can continue to assign `tags = var.tags` directly.
 
-- Tags **MUST** be automatically applied to child, extension and cross-referenced resources, if tags are applied to the primary resource.
-  - By default, all tags set for the primary resource will automatically be passed down to child, extension and cross-referenced resources.
-  - This **MUST** be able to be overridden by the module consumer so they can specify alternate tags for child, extension and cross-referenced resources, if they desire via a parameter/variable
-    - If overridden by the module consumer, no merge/union of tags will take place from the primary resource and only the tags specified for the child, extension and cross-referenced resources will be applied
+Modules **MAY** add the typed `resource_tags` variable when consumers need to replace tags for individual resources or resources declared by submodules. The variable **MUST** default to `null` and use this canonical shape:
+
+- `resources` is an optional object whose attribute names match Terraform resource block labels in the current module.
+- `modules` is an optional object whose attribute names match Terraform module block labels. Each value repeats that submodule's typed `resource_tags` shape.
+- The `resources` and `modules` namespaces keep identical resource and module labels unambiguous. For example, `resource_tags.resources.child` and `resource_tags.modules.child` identify different blocks.
+- Each module **MUST** declare a deterministic object type containing only its supported resource and submodule labels. Open-ended maps of objects or `any` types **MUST NOT** replace the typed shape.
+- Every namespace, resource label, and module label **MUST** be optional without an inline default. The object **MUST** contain at least one resource label, either directly or below a module label.
+
+For every tag-capable resource, an omitted or `null` resource override inherits `var.tags`. A supplied map replaces `var.tags` completely for that resource; implementations **MUST NOT** merge the two maps. An empty map therefore deliberately applies no tags. A resource block override applies uniformly to every instance created from that block with `count` or `for_each`. This expression implements the required precedence for a resource labeled `this`:
+
+```terraform
+resource "azapi_resource" "this" {
+  tags = try(var.resource_tags.resources.this, null) != null ? var.resource_tags.resources.this : var.tags
+}
+```
+
+Tags **MUST** propagate by default to tag-capable child, extension, and cross-referenced resources. A parent module passes the fallback and the nested override independently:
+
+```terraform
+module "child" {
+  source = "./modules/child"
+
+  tags          = var.tags
+  resource_tags = try(var.resource_tags.modules.child, null)
+}
+```
+
+The child module applies the same precedence to its own resource labels. Omitting `resource_tags.modules.child`, or setting it to `null`, leaves every child resource on the `tags` fallback unless a more specific non-null override is supplied.
 
 ## Managed Identities
 

--- a/docs/static/includes/interfaces/tf/int.tags.input.tf
+++ b/docs/static/includes/interfaces/tf/int.tags.input.tf
@@ -1,5 +1,22 @@
 tags = {
   key           = "value"
   "another-key" = "another-value"
-  integers      = 123
+  integers      = "123"
+}
+resource_tags = {
+  resources = {
+    this = {
+      key = "root-resource-value"
+    }
+    child = {}
+  }
+  modules = {
+    child = {
+      resources = {
+        this = {
+          key = "child-module-resource-value"
+        }
+      }
+    }
+  }
 }

--- a/docs/static/includes/interfaces/tf/int.tags.schema.tf
+++ b/docs/static/includes/interfaces/tf/int.tags.schema.tf
@@ -1,5 +1,23 @@
 variable "tags" {
-  type     = map(string)
-  default  = null
+  type        = map(string)
+  default     = null
   description = "(Optional) Tags of the resource."
+}
+
+variable "resource_tags" {
+  type = object({
+    resources = optional(object({
+      this  = optional(map(string))
+      child = optional(map(string))
+    }))
+    modules = optional(object({
+      child = optional(object({
+        resources = optional(object({
+          this = optional(map(string))
+        }))
+      }))
+    }))
+  })
+  default     = null
+  description = "(Optional) Per-resource tag overrides."
 }

--- a/utilities/tests/Test-TflintDocumentation.ps1
+++ b/utilities/tests/Test-TflintDocumentation.ps1
@@ -9,38 +9,39 @@ $guidePath = Join-Path $RepositoryRoot 'docs\content\contributing\terraform\tfli
 $guide = Get-Content -Raw $guidePath
 
 $rules = @(
-  'azapi_data_response_export_values',
-  'azapi_replace_triggers_refs',
-  'azapi_resource_tag',
-  'azapi_response_export_values',
-  'customer_managed_key',
-  'deprecated_lock_interface',
-  'deprecated_private_endpoints_interface',
-  'deprecated_role_assignments_interface',
-  'diagnostic_settings',
-  'ignore_body_changes',
-  'location',
-  'lock',
-  'managed_identities',
-  'no_entire_resource_output_tffr2',
-  'private_endpoints',
-  'private_endpoints_manage_dns_zone_group',
-  'provider_azapi_version_constraint',
-  'provider_azurerm_disallowed',
-  'provider_azurerm_version_constraint',
-  'provider_modtm_version_constraint',
-  'required_module_source_tffr1',
-  'required_module_source_tfnfr10',
-  'required_output_rmfr7',
-  'resource_types',
-  'retry',
-  'role_assignments',
-  'tags',
-  'terraform_heredoc_usage',
-  'terraform_module_provider_declaration',
-  'terraform_sensitive_variable_no_default',
-  'terraform_tf_file',
-  'timeouts'
+  'avm_azapi_data_response_export_values_required',
+  'avm_azapi_replace_triggers_refs_valid',
+  'avm_azapi_resource_tags_required',
+  'avm_azapi_response_export_values_required',
+  'avm_interface_customer_managed_key',
+  'avm_interface_lock_deprecated',
+  'avm_interface_private_endpoints_deprecated',
+  'avm_interface_role_assignments_deprecated',
+  'avm_interface_diagnostic_settings',
+  'avm_interface_ignore_body_changes',
+  'avm_interface_location',
+  'avm_interface_lock',
+  'avm_interface_managed_identities',
+  'avm_output_entire_resource_disallowed',
+  'avm_interface_private_endpoints',
+  'avm_interface_private_endpoints_manage_dns_zone_group',
+  'avm_provider_azapi_version_constraint',
+  'avm_provider_azurerm_disallowed',
+  'avm_provider_azurerm_version_constraint',
+  'avm_provider_modtm_version_constraint',
+  'avm_terraform_module_source_required',
+  'avm_terraform_ignore_changes_unquoted_references',
+  'avm_output_resource_id_required',
+  'avm_interface_resource_tags',
+  'avm_interface_resource_types',
+  'avm_interface_retry',
+  'avm_interface_role_assignments',
+  'avm_interface_tags',
+  'avm_terraform_literal_heredoc_disallowed',
+  'avm_terraform_provider_block_disallowed',
+  'avm_terraform_sensitive_variable_default_disallowed',
+  'avm_terraform_configuration_file_required',
+  'avm_interface_timeouts'
 )
 
 foreach ($rule in $rules) {
@@ -62,23 +63,23 @@ foreach ($spec in @('TFFR9', 'TFNFR40', 'TFNFR41')) {
 }
 
 $specRuleLinks = @{
-  'docs\content\specs-defs\includes\shared\resource\functional\RMFR7.md' = '#required-output-rmfr7'
-  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR1.md' = '#required-module-source-tffr1'
-  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR2.md' = '#no-entire-resource-output-tffr2'
-  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR3.md' = '#provider-azapi-version-constraint'
-  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR4.md' = '#azapi-response-export-values'
-  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR5.md' = '#azapi-replace-triggers-refs'
-  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR6.md' = '#resource-types'
-  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR7.md' = '#retry'
-  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR8.md' = '#ignore-body-changes'
-  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR9.md' = '#azapi-resource-tag'
-  'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR10.md' = '#required-module-source-tfnfr10'
-  'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR23.md' = '#terraform-sensitive-variable-no-default'
-  'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR25.md' = '#terraform-tf-file'
+  'docs\content\specs-defs\includes\shared\resource\functional\RMFR7.md' = '#avm_output_resource_id_required'
+  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR1.md' = '#avm_terraform_module_source_required'
+  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR2.md' = '#avm_output_entire_resource_disallowed'
+  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR3.md' = '#avm_provider_azapi_version_constraint'
+  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR4.md' = '#avm_azapi_response_export_values_required'
+  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR5.md' = '#avm_azapi_replace_triggers_refs_valid'
+  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR6.md' = '#avm_interface_resource_types'
+  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR7.md' = '#avm_interface_retry'
+  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR8.md' = '#avm_interface_ignore_body_changes'
+  'docs\content\specs-defs\includes\terraform\shared\functional\TFFR9.md' = '#avm_azapi_resource_tags_required'
+  'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR10.md' = '#avm_terraform_ignore_changes_unquoted_references'
+  'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR23.md' = '#avm_terraform_sensitive_variable_default_disallowed'
+  'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR25.md' = '#avm_terraform_configuration_file_required'
   'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR26.md' = '#mapotf-and-standard-terraform-tflint-coverage'
-  'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR27.md' = '#terraform-module-provider-declaration'
-  'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR39.md' = '#terraform-tf-file'
-  'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR40.md' = '#terraform-heredoc-usage'
+  'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR27.md' = '#avm_terraform_provider_block_disallowed'
+  'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR39.md' = '#avm_terraform_configuration_file_required'
+  'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR40.md' = '#avm_terraform_literal_heredoc_disallowed'
   'docs\content\specs-defs\includes\terraform\shared\non-functional\TFNFR41.md' = '#mapotf-and-standard-terraform-tflint-coverage'
 }
 
@@ -92,8 +93,12 @@ foreach ($relativePath in $specRuleLinks.Keys) {
 $tagSpec = Get-Content -Raw (Join-Path $RepositoryRoot 'docs\content\specs-defs\includes\terraform\shared\functional\TFFR9.md')
 foreach ($requiredText in @(
   'tags = var.tags',
-  'conditionally replace, or otherwise transform',
-  'statically unsupported resource type',
+  'non-null override for the Terraform resource block label',
+  'MUST NOT** merge the fallback and override maps',
+  'resource_tags.modules.<module_label>',
+  'separate `resources` and `modules` namespaces',
+  'statically read-only or unsupported tags property',
+  '#avm_interface_resource_tags',
   'dynamic or otherwise unevaluable',
   'embedded AVM-generated capability snapshot',
   'rather than a hand-maintained module allowlist or an AzAPI import'
@@ -103,8 +108,44 @@ foreach ($requiredText in @(
   }
 }
 
-$tagRuleGuide = $guide -split '### azapi resource tag', 2 | Select-Object -Last 1
+$tagInterface = Get-Content -Raw (Join-Path $RepositoryRoot 'docs\content\specs-defs\specs\terraform\interfaces.md')
 foreach ($requiredText in @(
+  'The `tags` variable is the module-wide fallback and common interface',
+  'A module that does not expose per-resource overrides can continue to assign `tags = var.tags` directly',
+  'Modules **MAY** add the typed `resource_tags` variable',
+  '`resources` and `modules` namespaces',
+  'attribute names match Terraform resource block labels',
+  'attribute names match Terraform module block labels',
+  'A supplied map replaces `var.tags` completely',
+  'An empty map therefore deliberately applies no tags',
+  'resource_tags = try(var.resource_tags.modules.child, null)'
+)) {
+  if ($tagInterface -notmatch [regex]::Escape($requiredText)) {
+    throw "The Terraform tags interface does not define '$requiredText'."
+  }
+}
+
+$tagSchema = Get-Content -Raw (Join-Path $RepositoryRoot 'docs\static\includes\interfaces\tf\int.tags.schema.tf')
+foreach ($requiredText in @(
+  'variable "tags"',
+  'type        = map(string)',
+  'default     = null',
+  'variable "resource_tags"',
+  'resources = optional(object({',
+  'modules = optional(object({'
+)) {
+  if ($tagSchema -notmatch [regex]::Escape($requiredText)) {
+    throw "The Terraform tags schema does not define '$requiredText'."
+  }
+}
+
+$tagRuleGuide = ($guide -split '### avm_azapi_resource_tags_required', 2 | Select-Object -Last 1) -split '### avm_azapi_response_export_values_required', 2 | Select-Object -First 1
+foreach ($requiredText in @(
+  'must set `tags` from a consumer-settable expression',
+  'A direct `tags = var.tags` assignment remains valid',
+  'typed `resource_tags` replacement interface',
+  'read-only or unsupported tags must omit the argument',
+  'does not require one exact tags expression',
   'does not consume, import, or query AzAPI',
   'embeds its AVM-generated capability snapshot and works standalone',
   'does not accept an external snapshot path',
@@ -115,6 +156,21 @@ foreach ($requiredText in @(
 )) {
   if ($tagRuleGuide -notmatch [regex]::Escape($requiredText)) {
     throw "The azapi_resource_tag guide does not document '$requiredText'."
+  }
+}
+
+$resourceTagsRuleGuide = ($guide -split '### avm_interface_resource_tags', 2 | Select-Object -Last 1) -split '### avm_interface_resource_types', 2 | Select-Object -First 1
+foreach ($requiredText in @(
+  'optional `resource_tags` variable when it is declared',
+  'default to `null` and permit null values',
+  'optional `resources` and `modules` namespaces without inline defaults',
+  'optional `map(string)` leaves',
+  'recursively use the same shape',
+  'at least one resource leaf',
+  'Terraform resource and module block labels without collisions'
+)) {
+  if ($resourceTagsRuleGuide -notmatch [regex]::Escape($requiredText)) {
+    throw "The avm_interface_resource_tags guide does not document '$requiredText'."
   }
 }
 


### PR DESCRIPTION
# Overview/Summary

Defines the backward-compatible Terraform tag propagation contract for module-wide fallback tags and optional per-resource replacements.

## This PR fixes/adds/changes/removes

1. Updates TFFR9 so writable AzAPI tag properties require a consumer-settable `tags` expression, while read-only and unsupported properties omit the argument.
1. Defines the optional typed `resource_tags` interface with separate recursive `resources` and `modules` namespaces, null inheritance, complete replacement, and no merging.
1. Documents the matching `avm_interface_resource_tags` rule implemented in https://github.com/Azure/tflint-ruleset-avm/pull/161 and adds documentation assertions.

Related documentation: https://msft.ghe.com/azure-cloud-native/Azure-Verified-Modules-Docs/pull/43

### Breaking Changes

1. None. Existing `tags = var.tags` implementations remain valid, and `resource_tags` is optional.

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)