### PR TITLE
docs(terraform): update 'Using a custom Azure test subscription' for current CI workflow

### DIFF
--- a/docs/content/contributing/terraform/advanced.md
+++ b/docs/content/contributing/terraform/advanced.md
@@ -20,16 +20,60 @@ The [offline sync utility](https://github.com/Azure/Azure-Verified-Modules/tree/
 
 ## Using a custom Azure test subscription
 
-By default, CI end-to-end tests run against a centrally managed Azure subscription. If your module requires a different environment (e.g. due to quota limits or tenant-level deployments), you can override the defaults.
+By default, CI runs against a centrally managed Azure subscription. If your module needs a different environment (quota limits, tenant-level deployments, dedicated tenant), you can override the defaults.
+
+**Understand the environments first.** The managed workflow runs jobs across several GitHub Environments, and the ones that request an Azure token are:
+
+| Environment | Job | Requests Azure token |
+| --- | --- | --- |
+| `pr-check` | `avm pr-check` (incl. `check policy` → `terraform plan`) | Yes |
+| `integration-test` | `avm test integration` | Yes |
+| `examples-test` | `avm test e2e` (one leg per example) | Yes |
+| `no-approval` | subscription selection, unit tests, example discovery | No |
+
+**Steps**
 
 1. Create a user-assigned managed identity in your target Azure environment.
-2. Create GitHub federated credentials for the managed identity, using the module's GitHub organization and repository. Select entity type **environment** and set the name to `test`.
-3. Assign appropriate roles to the managed identity.
-4. Elevate your access via the [Open Source Portal](https://repos.opensource.microsoft.com/orgs/Azure/repos/REPOSITORY-NAME/jit).
-5. Go to the repository **Settings** > **Environments** > `test` and add the following secrets:
-    - `ARM_CLIENT_ID_OVERRIDE` — Client ID of the managed identity.
-    - `ARM_TENANT_ID_OVERRIDE` — Tenant ID.
-    - `ARM_SUBSCRIPTION_ID_OVERRIDE` — Subscription ID.
+
+2. **Create one federated credential per environment.** Azure requires an exact subject match — there are no wildcards, so a single credential cannot cover multiple environments. Use the **Other issuer** (custom) option rather than the "GitHub Actions deploying Azure resources" wizard, because the wizard emits `repo:ORG/REPO:environment:NAME`, which does **not** match what these workflows present.
+
+    - **Issuer:** `https://token.actions.githubusercontent.com`
+    - **Audience:** `api://AzureADTokenExchange`
+    - **Subject** (one credential each, substituting the environment name):
+
+      ```text
+      repository_owner_id:<OWNER_ID>:repository_id:<REPO_ID>:environment:pr-check:job_workflow_ref:Azure/azure-verified-modules-tools/.github/workflows/terraform-module.yml@refs/heads/main
+      repository_owner_id:<OWNER_ID>:repository_id:<REPO_ID>:environment:integration-test:job_workflow_ref:Azure/azure-verified-modules-tools/.github/workflows/terraform-module.yml@refs/heads/main
+      repository_owner_id:<OWNER_ID>:repository_id:<REPO_ID>:environment:examples-test:job_workflow_ref:Azure/azure-verified-modules-tools/.github/workflows/terraform-module.yml@refs/heads/main
+      ```
+
+    {{% notice style="note" %}}
+The subject uses immutable owner/repository **IDs** and a `job_workflow_ref` segment because the module repo calls a *reusable* workflow. The simplest way to get the exact string is to run the workflow once and copy the subject verbatim out of the `AADSTS700213` error message.
+    {{% /notice %}}
+
+    Find your IDs with:
+
+    ```bash
+    gh api repos/<ORG>/<REPO> --jq '{repository_id: .id, repository_owner_id: .owner.id}'
+    ```
+
+3. Assign appropriate Azure roles to the managed identity on the target subscription (and at management-group scope for pattern modules that assign policy or create role assignments).
+
+4. **Add repository secrets** (**Settings** > **Secrets and variables** > **Actions**). Module owners have access to repository secrets by default; environment-scoped configuration is managed by the AVM core team.
+
+    - `ARM_CLIENT_ID` — client ID of the managed identity.
+    - `ARM_TENANT_ID` — tenant ID.
+    - `TEST_SUBSCRIPTION_IDS` — a JSON array of `{ id, name }` objects. The workflow shuffles it and round-robins e2e legs across entries to avoid quota collisions:
+
+      ```json
+      [{"id":"00000000-0000-0000-0000-000000000000","name":"avm-test-01"}]
+      ```
+
+      Must be valid JSON with quoted keys and values. If unset, the workflow falls back to a single `ARM_SUBSCRIPTION_ID` secret or variable.
+
+{{% notice style="tip" %}}
+If one environment authenticates successfully while another fails with `AADSTS700213` using the same identity, that environment may still carry legacy environment-scoped credential overrides from a previous configuration. Module owners cannot view or change these — raise an issue with the AVM core team to have them removed.
+{{% /notice %}}
 
 ---
 

--- a/docs/content/contributing/terraform/advanced.md
+++ b/docs/content/contributing/terraform/advanced.md
@@ -22,7 +22,7 @@ The [offline sync utility](https://github.com/Azure/Azure-Verified-Modules/tree/
 
 By default, CI runs against a centrally managed Azure subscription. If your module needs a different environment (quota limits, tenant-level deployments, dedicated tenant), you can override the defaults.
 
-**Understand the environments first.** The managed workflow runs jobs across several GitHub Environments, and the ones that request an Azure token are:
+**Understand the environments first.** The managed workflow runs jobs across several GitHub Environments:
 
 | Environment | Job | Requests Azure token |
 | --- | --- | --- |
@@ -35,7 +35,7 @@ By default, CI runs against a centrally managed Azure subscription. If your modu
 
 1. Create a user-assigned managed identity in your target Azure environment.
 
-2. **Create one federated credential per environment.** Azure requires an exact subject match — there are no wildcards, so a single credential cannot cover multiple environments. Use the **Other issuer** (custom) option rather than the "GitHub Actions deploying Azure resources" wizard, because the wizard emits `repo:ORG/REPO:environment:NAME`, which does **not** match what these workflows present.
+1. **Create one federated credential per Azure-authenticated environment** (`pr-check`, `integration-test`, and `examples-test`). The managed identity's federated credentials require an exact subject match, so a single credential cannot cover multiple environments. Use the **Other issuer** (custom) option rather than the "GitHub Actions deploying Azure resources" wizard, because the wizard emits `repo:ORG/REPO:environment:NAME`, which does **not** match what these workflows present.
 
     - **Issuer:** `https://token.actions.githubusercontent.com`
     - **Audience:** `api://AzureADTokenExchange`
@@ -48,31 +48,29 @@ By default, CI runs against a centrally managed Azure subscription. If your modu
       ```
 
     {{% notice style="note" %}}
-The subject uses immutable owner/repository **IDs** and a `job_workflow_ref` segment because the module repo calls a *reusable* workflow. The simplest way to get the exact string is to run the workflow once and copy the subject verbatim out of the `AADSTS700213` error message.
+The repository's centrally managed OIDC configuration includes immutable owner/repository **IDs** and a `job_workflow_ref` segment identifying the *reusable* workflow. If authentication fails with `AADSTS700213`, compare the subject in the error message with the federated credential for that environment.
     {{% /notice %}}
 
     Find your IDs with:
 
-    ```bash
-    gh api repos/<ORG>/<REPO> --jq '{repository_id: .id, repository_owner_id: .owner.id}'
+    ```powershell
+    gh api 'repos/<ORG>/<REPO>' --jq '{repository_id: .id, repository_owner_id: .owner.id}'
     ```
 
-3. Assign appropriate Azure roles to the managed identity on the target subscription (and at management-group scope for pattern modules that assign policy or create role assignments).
+1. Assign appropriate Azure roles to the managed identity on the target subscription (and at management-group scope for pattern modules that assign policy or create role assignments).
 
-4. **Add repository secrets** (**Settings** > **Secrets and variables** > **Actions**). Module owners have access to repository secrets by default; environment-scoped configuration is managed by the AVM core team.
+1. **Add repository Actions variables** (**Settings** > **Secrets and variables** > **Actions** > **Variables** > **New repository variable**). These IDs are non-secret configuration. Module owners can manage repository variables; environment-scoped configuration is managed by the AVM core team.
 
-    - `ARM_CLIENT_ID` — client ID of the managed identity.
-    - `ARM_TENANT_ID` — tenant ID.
-    - `TEST_SUBSCRIPTION_IDS` — a JSON array of `{ id, name }` objects. The workflow shuffles it and round-robins e2e legs across entries to avoid quota collisions:
+    - `ARM_CLIENT_ID_OVERRIDE` - client ID of the managed identity.
+    - `ARM_TENANT_ID_OVERRIDE` - tenant ID of the target Azure environment.
+    - `ARM_SUBSCRIPTION_ID_OVERRIDE` - ID of the target Azure subscription.
 
-      ```json
-      [{"id":"00000000-0000-0000-0000-000000000000","name":"avm-test-01"}]
-      ```
+    Set all three values for the same target Azure environment. The workflow maps nonempty overrides to the corresponding `ARM_*` variables in each Azure-authenticated job. `ARM_SUBSCRIPTION_ID_OVERRIDE` takes precedence over the centrally selected subscription, so all example legs use your subscription instead of distributing deployments across the shared pool.
 
-      Must be valid JSON with quoted keys and values. If unset, the workflow falls back to a single `ARM_SUBSCRIPTION_ID` secret or variable.
+    Do not change the repository defaults `ARM_CLIENT_ID`, `ARM_TENANT_ID`, or `TEST_SUBSCRIPTION_IDS`; these are managed by repository synchronization. Leave the shared subscription selection configured, because that job still runs before the overrides are applied. There is no `TEST_SUBSCRIPTION_IDS_OVERRIDE`.
 
 {{% notice style="tip" %}}
-If one environment authenticates successfully while another fails with `AADSTS700213` using the same identity, that environment may still carry legacy environment-scoped credential overrides from a previous configuration. Module owners cannot view or change these — raise an issue with the AVM core team to have them removed.
+`ARM_*_OVERRIDE` remains supported. The workflow merges variables first, then secrets, so a same-named override secret (including an environment secret) masks the variable. If your variables do not take effect, check for conflicting repository override secrets and ask the AVM core team to check for conflicting environment-scoped overrides.
 {{% /notice %}}
 
 ---


### PR DESCRIPTION
## Description

Update **Using a custom Azure test subscription** on the Terraform [Advanced Topics & FAQ](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/advanced/) page for the current [managed CI workflow](https://github.com/Azure/azure-verified-modules-tools/blob/dcb0ba324592b5fcc26aa176634f7a818221f5e9/.github/workflows/terraform-module.yml).

These findings came out of debugging an `AADSTS700213` failure while moving a module repository to a new test subscription.

### Changes

- Document the current environments: `pr-check`, `integration-test`, and `examples-test` request Azure tokens; `no-approval` handles subscription selection, unit tests, and example discovery without requesting one.
- Require a separate managed-identity federated credential for each Azure-authenticated environment, preserving the exact custom subjects, issuer, and audience. Explain why the portal's default GitHub wizard subject does not match the centrally configured OIDC claims.
- Provide a PowerShell `gh api` example for finding the immutable owner and repository IDs.
- Direct module owners to **Settings > Secrets and variables > Actions > Variables > New repository variable** and configure `ARM_CLIENT_ID_OVERRIDE`, `ARM_TENANT_ID_OVERRIDE`, and `ARM_SUBSCRIPTION_ID_OVERRIDE`. These IDs are non-secret configuration, so the guidance recommends repository Actions variables rather than secrets.
- Explain that nonempty overrides map to the corresponding `ARM_*` variables. `ARM_SUBSCRIPTION_ID_OVERRIDE` takes precedence over the pool-selected subscription, including every example leg. The workflow does **not** consume `TEST_SUBSCRIPTION_IDS_OVERRIDE`.
- Leave the centrally configured `ARM_CLIENT_ID`, `ARM_TENANT_ID`, and `TEST_SUBSCRIPTION_IDS` defaults unchanged: repository synchronization manages them, and the subscription-selection job still runs before overrides are applied.
- Clarify that the workflow merges variables first, then secrets. A same-named override secret, including an environment secret, masks the variable. `ARM_*_OVERRIDE` remains supported; environment-scoped configuration is not inherently legacy.
- Remove the outdated Open Source Portal JIT step and direct owners to the AVM core team for conflicting environment-scoped configuration.

### Scope and validation

Documentation only, limited to the custom-subscription section. The adjacent **Custom variables and secrets for end-to-end tests** section is unchanged. No production settings, identities, secrets, variables, or workflows were changed or manually run.

Built locally with the repository's CI-pinned Hugo Extended 0.136.5 and checked the rendered section, unchanged OIDC subjects, PowerShell example syntax, and whitespace.
